### PR TITLE
Improve driver interface theming and route display

### DIFF
--- a/driver.html
+++ b/driver.html
@@ -1,15 +1,17 @@
 <!doctype html>
 <html>
+<head>
 <meta charset="utf-8" />
 <title>Driver Anti-Bunching</title>
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
+<link rel="preload" href="FGDC.ttf" as="font" type="font/ttf" crossorigin />
 <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
 <script src="https://unpkg.com/@mapbox/polyline@1.1.1"></script>
 <style>
-  @font-face{font-family:'FGDC';src:url('FGDC.ttf') format('truetype');}
-  :root{ --bg:#0b0e11; --panel:#0f141a; --ink:#e8eef5; --muted:#9fb0c9; --line:#1f2630; --chip:#2a3442; --ok:#24c28a; --warn:#ffbf47; --bad:#ff6b6b; }
-  body.light{ --bg:#f0f4f8; --panel:#ffffff; --ink:#000000; --muted:#555555; --line:#cccccc; --chip:#dddddd; }
+  @font-face{font-family:'FGDC';src:url('FGDC.ttf') format('truetype');font-weight:normal;font-style:normal;}
+  :root{ --bg:#0b0e11; --panel:#0f141a; --ink:#e8eef5; --muted:#9fb0c9; --line:#1f2630; --chip:#2a3442; --btn:#15202b; --btn-danger:#2b1515; --btn-danger-border:#523737; --ok:#24c28a; --warn:#ffbf47; --bad:#ff6b6b; }
+  body.light{ --bg:#f0f4f8; --panel:#ffffff; --ink:#000000; --muted:#555555; --line:#cccccc; --chip:#dddddd; --btn:#e0e0e0; --btn-danger:#ffdddd; --btn-danger-border:#ffbbbb; }
   html,body{height:100%}
   body{margin:0;background:var(--bg);color:var(--ink);font:16px/1.45 'FGDC',sans-serif;}
   button,select{font-family:inherit;}
@@ -20,9 +22,9 @@
   select{width:100%;background:#10151c;color:var(--ink);border:1px solid var(--chip);border-radius:10px;padding:10px}
   .row{display:flex;gap:10px}
   .row>div{flex:1}
-  .btn{width:100%;margin-top:12px;background:#15202b;border:1px solid var(--chip);color:var(--ink);border-radius:10px;padding:10px;cursor:pointer;font-weight:600}
+  .btn{width:100%;margin-top:12px;background:var(--btn);border:1px solid var(--chip);color:var(--ink);border-radius:10px;padding:10px;cursor:pointer;font-weight:600}
   .btn:hover{filter:brightness(1.1)}
-  .btn.danger{background:#2b1515;border-color:#523737}
+  .btn.danger{background:var(--btn-danger);border-color:var(--btn-danger-border)}
   .btn.danger:hover{filter:brightness(1.05)}
   .out{margin-top:14px;border-top:1px solid var(--line);padding-top:12px}
   .mono{font-family:'FGDC',ui-monospace,Menlo,Consolas,monospace}
@@ -31,6 +33,7 @@
   #dashboard{display:flex;height:100%;width:100%;}
   #left,#right{flex:1;display:flex;flex-direction:column;}
   #topbar{background:var(--panel);padding:16px;border-bottom:1px solid var(--line);text-align:center;font-size:24px;}
+  .route-pill{display:inline-block;padding:2px 8px;border-radius:999px;}
   #info{padding:12px;flex:1;display:flex;flex-direction:column;align-items:center;text-align:center;}
   #info .out{margin-top:0;border-top:none;padding-top:0;flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;width:100%;}
   #instruction{width:100%;height:120px;border-radius:12px;display:flex;align-items:center;justify-content:center;font-size:48px;font-weight:700;margin-bottom:12px;background:var(--panel);border:1px solid var(--line);}
@@ -40,6 +43,7 @@
   #clock{flex:0 0 33%;display:flex;align-items:center;justify-content:center;font-size:20vh;border-bottom:1px solid var(--line);background:var(--panel);}
   #map{flex:1;}
 </style>
+</head>
 <body class="centered">
 <div id="setup" class="card">
   <h1>Driver Anti-Bunching</h1>
@@ -82,7 +86,7 @@
 const $ = s=>document.querySelector(s);
 const fmt = s=>{ if(s==null||!isFinite(s)) return "—"; s=Math.round(s); const m=Math.floor(s/60), r=s%60; return `${String(m).padStart(2,'0')}:${String(r).padStart(2,'0')}`; };
 async function j(u){ const r=await fetch(u,{cache:"no-store"}); if(!r.ok) throw new Error(r.status+" "+r.statusText); return r.json(); }
-let timer=null, busTimer=null, currentBus="", currentRoute=0, map=null, routeLayer=null, markers={}, nameMarkers={}, routeColor='#E57200';
+let timer=null, busTimer=null, currentBus="", currentRoute=0, currentRouteLabel="", map=null, routeLayer=null, markers={}, nameMarkers={}, routeColor='#E57200';
 // Load pickers once
 async function loadBuses(){
   let list=[];
@@ -100,7 +104,9 @@ function showSession(busName, routeId, routeLabel){
   $('#setup').style.display='none';
   document.body.classList.remove('centered');
   $('#dashboard').style.display='flex';
-  $('#topbar').textContent = `Unit ${busName} • ${routeLabel}`;
+  currentRouteLabel = routeLabel;
+  $('#topbar').innerHTML = `Unit ${busName} • <span id="route-pill" class="route-pill">${routeLabel}</span>`;
+  setRoutePillColor(routeColor);
   $('#instruction').className='';
   $('#instruction').textContent='Connecting…';
   $('#details').textContent='';
@@ -119,8 +125,18 @@ function showSetup(){
   $('#setup').style.display='block';
   if(map){ map.remove(); map=null; routeLayer=null; markers={}; nameMarkers={}; }
   routeColor='#E57200';
+  currentRouteLabel='';
   if(timer) { clearInterval(timer); timer=null; }
   if(busTimer){ clearInterval(busTimer); busTimer=null; }
+}
+
+function setRoutePillColor(color){
+  const pill = $('#route-pill');
+  if(pill){
+    const contrast = getContrastColor(color);
+    pill.style.background = color;
+    pill.style.color = contrast;
+  }
 }
 async function tick(){
   try{
@@ -157,6 +173,7 @@ async function loadRoutePath(){
     const r=data.find(x=>x.RouteID==currentRoute);
     if(r && r.EncodedPolyline){
       routeColor = r.MapLineColor ? (r.MapLineColor.startsWith('#') ? r.MapLineColor : `#${r.MapLineColor}`) : '#E57200';
+      setRoutePillColor(routeColor);
       const pts=polyline.decode(r.EncodedPolyline);
       routeLayer=L.polyline(pts,{color:routeColor,weight:5}).addTo(map);
       map.fitBounds(routeLayer.getBounds());


### PR DESCRIPTION
## Summary
- Fix light mode button colors with theme-aware CSS variables
- Preload and use FGDC font for consistent typography
- Display route name in a color-coded pill matching the route color

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7ac91d4ac8333a45e990ad5642946