### PR TITLE
Adjust block number bubble positioning

### DIFF
--- a/map.html
+++ b/map.html
@@ -746,7 +746,8 @@
                                       html: blockBubble,
                                       className: '',
                                       iconSize: [blockWidth, 30],
-                                      iconAnchor: [blockWidth / 2, -6]
+                                      // Push the block number bubble slightly lower so it doesn't cover the bus icon
+                                      iconAnchor: [blockWidth / 2, -16]
                                   });
                                   if (nameBubbles[vehicleID] && nameBubbles[vehicleID].blockMarker) {
                                       animateMarkerTo(nameBubbles[vehicleID].blockMarker, newPosition);


### PR DESCRIPTION
## Summary
- Nudge block number marker anchor downward to avoid covering the bus icon

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb26cc99dc83338bed2814bbcb35ae