### PR TITLE
Align block number bubbles with bus icons

### DIFF
--- a/map.html
+++ b/map.html
@@ -746,8 +746,8 @@
                                       html: blockBubble,
                                       className: '',
                                       iconSize: [blockWidth, 30],
-                                      // Push the block number bubble slightly lower so it doesn't cover the bus icon
-                                      iconAnchor: [blockWidth / 2, -16]
+                                      // Position the block number bubble so it touches but doesn't overlap the bus icon
+                                      iconAnchor: [blockWidth / 2, -13]
                                   });
                                   if (nameBubbles[vehicleID] && nameBubbles[vehicleID].blockMarker) {
                                       animateMarkerTo(nameBubbles[vehicleID].blockMarker, newPosition);


### PR DESCRIPTION
## Summary
- Raise block number bubbles so they touch but don't overlap bus icons

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb2953806483338934be12a674f41c