### PR TITLE
Add viewport meta and mobile route selector styles

### DIFF
--- a/map.html
+++ b/map.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Bus Locations on OpenStreetMap</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
     <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
     <script src="https://unpkg.com/@mapbox/polyline@1.1.1"></script>
@@ -135,6 +136,13 @@
         line-height: 60px;
         font-size: 20px;
         user-select: none;
+      }
+      @media (max-width: 600px) {
+        #routeSelector { width: 80%; right: 10%; font-size: 18px; }
+        #routeSelector.hidden { transform: translateX(calc(100% + 20px)); }
+        #routeSelector button { font-size: 20px; }
+        #routeSelector label { font-size: 18px; }
+        #routeSelectorTab { width: 40px; height: 80px; font-size: 28px; }
       }
     </style>
     <script>


### PR DESCRIPTION
## Summary
- Add viewport meta tag for proper scaling on mobile devices
- Add mobile-specific CSS to improve route selector usability on small screens

## Testing
- `python -m py_compile app.py && echo 'py_compile succeeded'`


------
https://chatgpt.com/codex/tasks/task_e_68bb476229a483339af6e4fcaeadcde0