### PR TITLE
Show block numbers in dispatcher antibunching tables

### DIFF
--- a/dispatcher.html
+++ b/dispatcher.html
@@ -33,16 +33,16 @@ h2{font-size:16px;margin:16px 0 0}
     <h2>Headway Guard AntiBunching</h2>
     <table>
       <thead><tr>
-        <th>Vehicle</th><th>Order</th><th>Headway</th><th>Gap vs Target</th><th>Leader</th><th>Countdown</th>
+        <th>Vehicle</th><th>Block</th><th>Order</th><th>Headway</th><th>Gap vs Target</th><th>Leader</th><th>Countdown</th>
       </tr></thead>
-      <tbody id="rows"><tr><td class="hint" colspan="6">Loading…</td></tr></tbody>
+      <tbody id="rows"><tr><td class="hint" colspan="7">Loading…</td></tr></tbody>
     </table>
     <h2>TransLoc AntiBunching</h2>
     <table>
       <thead><tr>
-        <th>Vehicle</th><th>Order</th><th>Headway</th><th>Gap vs Target</th><th>Leader</th><th>Countdown</th>
+        <th>Vehicle</th><th>Block</th><th>Order</th><th>Headway</th><th>Gap vs Target</th><th>Leader</th><th>Countdown</th>
       </tr></thead>
-      <tbody id="rows-tl"><tr><td class="hint" colspan="6">Loading…</td></tr></tbody>
+      <tbody id="rows-tl"><tr><td class="hint" colspan="7">Loading…</td></tr></tbody>
     </table>
   </main>
   <aside style="flex:1;padding:0 12px 16px;border-left:1px solid #1f2630">
@@ -58,7 +58,7 @@ const pill = st => { const m = {green:["OK","ok"],yellow:["Slow Down","warn"],re
 async function j(u){ const r = await fetch(u,{cache:"no-store"}); if(!r.ok) throw new Error(r.status); return r.json(); }
 function setBanner(txt,kind){ const b=$('#banner'); if(!txt){ b.style.display='none'; b.textContent=''; return; } b.className='banner '+(kind||'info'); b.textContent=txt; b.style.display='block'; }
 
-let activeES=null, activeIV=null, activeTL=null, currentRid=null, sessionId=0, userLocked=false, busOrder=[], lastTLRows=[];
+let activeES=null, activeIV=null, activeTL=null, currentRid=null, sessionId=0, userLocked=false, busOrder=[], lastRows=[], lastTLRows=[], blockByBus=new Map();
 
 async function loadBlocks(){
   try{
@@ -138,6 +138,7 @@ async function loadBlocks(){
       }
       return 0;
     });
+    blockByBus=new Map(entries.filter(e=>e.bus && e.bus!=='—').map(e=>[e.bus,e.block]));
     const rows=9, cols=4;
     let html='';
     for(let r=0;r<rows;r++){
@@ -150,6 +151,8 @@ async function loadBlocks(){
     }
     if(!entries.length) html='<tr><td class="hint" colspan="4">No blocks.</td></tr>';
     tbody.innerHTML=html;
+    if(lastRows.length) render(lastRows);
+    if(lastTLRows.length) renderTL(lastTLRows);
   }catch(e){ $('#blocks').innerHTML='<tr><td class="hint" colspan="4">Error</td></tr>'; }
 }
 
@@ -188,13 +191,14 @@ function computeBusOrder(rows){
 }
 
 function render(rows){
+  lastRows=rows.slice();
   const t=rows.find(x=>x.target_headway_sec!=null)?.target_headway_sec; $('#target').textContent="Target "+(t!=null?fmt(t):"—");
   const ts=rows[0]?.updated_at ? new Date(rows[0].updated_at * 1000) : new Date();
   const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
   $('#upd').textContent = "Updated " + ts.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit', second:'2-digit', timeZone: tz});
   const onlyBus = rows.length===1 && rows.every(x=>x.headway_sec==null || x.headway_sec===undefined);
 
-  if(!rows.length){ $('#rows').innerHTML='<tr><td class="hint" colspan="6">No vehicles.</td></tr>'; return; }
+  if(!rows.length){ $('#rows').innerHTML='<tr><td class="hint" colspan="7">No vehicles.</td></tr>'; return; }
 
   busOrder = computeBusOrder(rows);
   const orderMap=new Map(busOrder.map((n,i)=>[n,i]));
@@ -207,6 +211,7 @@ function render(rows){
 
   $('#rows').innerHTML=rows.map(v=>'<tr>'
     +'<td class="mono">'+(v.name||"—")+'</td>'
+    +'<td class="mono">'+(blockByBus.get(v.name)||"—")+'</td>'
     +'<td>'+ (onlyBus ? '<span class="pill ok"><span class="dot"></span><span>Only Bus</span></span>' : pill(v.status)) +'</td>'
     +'<td class="mono">'+(v.headway_sec!=null?fmt(v.headway_sec):"—")+'</td>'
     +'<td class="mono">'+(v.gap_label||"—")+'</td>'
@@ -219,7 +224,7 @@ function render(rows){
 
 function renderTL(rows){
   lastTLRows = rows.slice();
-  if(!rows.length){ $('#rows-tl').innerHTML='<tr><td class="hint" colspan="6">No vehicles.</td></tr>'; return; }
+  if(!rows.length){ $('#rows-tl').innerHTML='<tr><td class="hint" colspan="7">No vehicles.</td></tr>'; return; }
   const orderMap=new Map(busOrder.map((n,i)=>[n,i]));
   rows = rows.slice().sort((a,b)=>{
     const ia=orderMap.has(a.VehicleName)?orderMap.get(a.VehicleName):Infinity;
@@ -231,6 +236,7 @@ function renderTL(rows){
     const sev=String(v.Severity||'').toLowerCase();
     return '<tr>'
       +'<td class="mono">'+(v.VehicleName||"—")+'</td>'
+      +'<td class="mono">'+(blockByBus.get(v.VehicleName)||"—")+'</td>'
       +'<td>'+pill(sev)+'</td>'
       +'<td class="mono">—</td>'
       +'<td class="mono">—</td>'


### PR DESCRIPTION
## Summary
- add Block column to Headway Guard and TransLoc antibunching tables
- map buses to dispatch blocks and render block assignment in each row

## Testing
- `python -m py_compile app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb590020f083338f90436ac95f4613