### PR TITLE
centralize TransLoc calls

### DIFF
--- a/dispatcher.html
+++ b/dispatcher.html
@@ -77,20 +77,12 @@ let activeES=null, activeIV=null, activeTL=null, currentRid=null, sessionId=0, u
 
 async function loadBlocks(){
   try{
-    const d=new Date();
-    const ds=`${d.getMonth()+1}/${d.getDate()}/${d.getFullYear()}`;
-    const sched=await j('https://uva.transloc.com/Services/JSONPRelay.svc/GetScheduleVehicleCalendarByDateAndRoute?dateString='+encodeURIComponent(ds));
-    const ids=(sched||[]).map(s=>s.ScheduleVehicleCalendarID).join(',');
+    const res=await j('/v1/dispatch/blocks');
+    const groups=res.block_groups||[];
+    const colorByRoute=new Map(Object.entries(res.color_by_route||{}));
+    const routeByBus=new Map(Object.entries(res.route_by_bus||{}));
     const tbody=$('#blocks');
-    if(!ids){ tbody.innerHTML='<tr><td class="hint" colspan="4">No blocks.</td></tr>'; return; }
-    const data=await j('https://uva.transloc.com/Services/JSONPRelay.svc/GetDispatchBlockGroupData?scheduleVehicleCalendarIdsString='+ids);
-    const groups=data.BlockGroups||[];
-
-    const routes=await j('https://uva.transloc.com/Services/JSONPRelay.svc/GetRoutes');
-    const colorByRoute=new Map((routes||[]).map(r=>[String(r.RouteID||r.RouteId), r.MapLineColor||r.Color||r.RouteColor]));
-
-    const mvps=await j('https://uva.transloc.com/Services/JSONPRelay.svc/GetMapVehiclePoints');
-    const routeByBus=new Map((mvps||[]).map(v=>[String(v.Name), v.RouteID||v.RouteId]));
+    if(!groups.length){ tbody.innerHTML='<tr><td class="hint" colspan="4">No blocks.</td></tr>'; return; }
 
     const entryMap=new Map();
     const busMap=new Map();
@@ -336,9 +328,8 @@ async function start(rid){
   currentRid=rid;
   const sid=++sessionId;
   try{
-    const routes=await j('https://uva.transloc.com/Services/JSONPRelay.svc/GetRoutes?APIKey=8882812681');
-    const route=(routes||[]).find(r=>String(r.RouteID)===rid);
-    const col=route&&route.MapLineColor? (route.MapLineColor.startsWith('#')?route.MapLineColor:'#'+route.MapLineColor):null;
+    const route=await j('/v1/routes/'+rid);
+    const col=route && route.color ? route.color : null;
     if(col) document.documentElement.style.setProperty('--route-color', col);
   }catch(_){ document.documentElement.style.setProperty('--route-color','#2a3442'); }
 
@@ -359,7 +350,7 @@ async function start(rid){
     async function tick(){
       if(rid!==currentRid || sid!==sessionId) return;
       try{
-        const data=await j('https://uva.transloc.com/Services/JSONPRelay.svc/GetAntiBunching');
+        const data=await j('/v1/transloc/anti_bunching');
         const route=(data||[]).find(r=>String(r.RouteID)===rid);
         renderTL(route?.VehicleAntiBunching||[]);
       }catch(_){ }

--- a/driver.html
+++ b/driver.html
@@ -289,13 +289,11 @@ function initMap(){
 }
 async function loadRoutePath(){
   try{
-    const res=await fetch('https://uva.transloc.com/Services/JSONPRelay.svc/GetRoutesForMapWithScheduleWithEncodedLine?APIKey=8882812681');
-    const data=await res.json();
-    const r=data.find(x=>x.RouteID==currentRoute);
-    if(r && r.EncodedPolyline){
-      routeColor = r.MapLineColor ? (r.MapLineColor.startsWith('#') ? r.MapLineColor : `#${r.MapLineColor}`) : '#E57200';
+    const data=await j(`/v1/routes/${currentRoute}/shape`);
+    if(data && data.polyline){
+      routeColor = data.color ? (data.color.startsWith('#') ? data.color : `#${data.color}`) : '#E57200';
       setRoutePillColor(routeColor);
-      const pts=polyline.decode(r.EncodedPolyline);
+      const pts=polyline.decode(data.polyline);
       routeLayer=L.polyline(pts,{color:routeColor,weight:5}).addTo(map);
       map.fitBounds(routeLayer.getBounds());
     }
@@ -304,18 +302,16 @@ async function loadRoutePath(){
 async function updateBuses(){
   if(!map) return;
   try{
-    const res=await fetch('https://uva.transloc.com/Services/JSONPRelay.svc/GetMapVehiclePoints?APIKey=8882812681');
-    const data=await res.json();
+    const data=await j(`/v1/routes/${currentRoute}/vehicles_raw`);
     const active=new Set();
     let nearBridge=false, nearOther=false;
-    data.forEach(v=>{
-      if(v.RouteID==currentRoute){
-        const id=v.VehicleID;
-        const pos=[v.Latitude,v.Longitude];
-        const isMoving = v.GroundSpeed > 0;
-        const heading = v.Heading || 0;
-        const busName = v.Name;
-        active.add(id);
+    (data.vehicles||[]).forEach(v=>{
+      const id=v.id;
+      const pos=[v.lat,v.lon];
+      const isMoving = v.ground_mps > 0;
+      const heading = v.heading || 0;
+      const busName = v.name;
+      active.add(id);
         if(busName===currentBus){
           for(const c of lowClearances){
             const dist=L.latLng(pos).distanceTo([c.lat,c.lon]);
@@ -335,7 +331,6 @@ async function updateBuses(){
         const nameIcon = L.divIcon({html:nameBubble, className:'', iconSize:[bubbleWidth,30], iconAnchor:[bubbleWidth/2,40]});
         if(nameMarkers[id]){ animateMarkerTo(nameMarkers[id], pos); nameMarkers[id].setIcon(nameIcon); }
         else { nameMarkers[id]=L.marker(pos,{icon:nameIcon,interactive:false}).addTo(map); }
-      }
     });
     const overheight=OVERHEIGHT_BUSES.includes(String(currentBus));
     if(overheight && (nearBridge || nearOther)){ updateBridgeWarning(true, nearBridge); }


### PR DESCRIPTION
## Summary
- Move TransLoc polling to API endpoints and expose shapes, vehicles, blocks and anti-bunching data
- Update driver and dispatcher pages to consume new app endpoints instead of TransLoc

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb83ad54948333bacc4f24a0a28f3d