### PR TITLE
Sort routes by active status in dropdowns

### DIFF
--- a/dispatcher.html
+++ b/dispatcher.html
@@ -234,13 +234,17 @@ async function loadBlocks(){
 }
 
 async function loadRoutes(){
-  const d = await j("/v1/routes"); const list=(d.routes||[]);
-  const sel=$('#route');
-  const prev=currentRid;
-  sel.innerHTML=list.map(r=>'<option value="'+r.id+'">'+(r.name||("Route "+r.id))+'</option>').join("");
-  if(prev){ sel.value=String(prev); }
-  if(!sel.value && list.length){ sel.value=String(list[0].id); }
-  if(!currentRid && sel.value) await start(sel.value);
+  const d = await j("/v1/routes");
+  const list = d.routes || [];
+  const active = list.filter(r => r.active_vehicles > 0).sort((a, b) => String(a.name || "").localeCompare(String(b.name || "")));
+  const inactive = list.filter(r => !r.active_vehicles).sort((a, b) => String(a.name || "").localeCompare(String(b.name || "")));
+  const sel = $('#route');
+  const prev = currentRid;
+  const combined = active.concat(inactive);
+  sel.innerHTML = combined.map(r => '<option value="' + r.id + '">' + (r.name || ("Route " + r.id)) + '</option>').join("");
+  if (prev) { sel.value = String(prev); }
+  if (!sel.value && combined.length) { sel.value = String(combined[0].id); }
+  if (!currentRid && sel.value) await start(sel.value);
 }
 
 function computeBusOrder(rows){

--- a/driver.html
+++ b/driver.html
@@ -171,8 +171,10 @@ async function loadBuses(){
 }
 async function loadRoutes(){
   let list=[]; const d=await j('/v1/routes_all'); list=(d.routes||[]);
-  list.sort((a,b)=>String(a.name||"").localeCompare(String(b.name||"")));
-  $('#route').innerHTML=list.map(r=>`<option value="${r.id}">${r.name}${r.active?'':' (inactive)'}</option>`).join('');
+  const active = list.filter(r=>r.active).sort((a,b)=>String(a.name||"").localeCompare(String(b.name||"")));
+  const inactive = list.filter(r=>!r.active).sort((a,b)=>String(a.name||"").localeCompare(String(b.name||"")));
+  const combined = active.concat(inactive);
+  $('#route').innerHTML=combined.map(r=>`<option value="${r.id}">${r.name}${r.active?'':' (inactive)'}</option>`).join('');
 }
 async function loadLowClearances(){
   try{


### PR DESCRIPTION
## Summary
- Order dispatcher and driver route dropdowns with active routes first, then inactive routes, both alphabetized

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb8a85fdf483339373f29fc18296dc