### PR TITLE
Fix timezone display for driver and dispatcher pages

### DIFF
--- a/dispatcher.html
+++ b/dispatcher.html
@@ -63,7 +63,7 @@ const pill = st => { const m = {green:["OK","ok"],yellow:["Slow Down","warn"],re
 async function j(u){ const r = await fetch(u,{cache:"no-store"}); if(!r.ok) throw new Error(r.status); return r.json(); }
 function setBanner(txt,kind){ const b=$('#banner'); if(!txt){ b.style.display='none'; b.textContent=''; return; } b.className='banner '+(kind||'info'); b.textContent=txt; b.style.display='block'; }
 
-const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+const tz = 'America/New_York';
 
 function contrastColor(hex){
   if(!hex) return '#e8eef5';

--- a/driver.html
+++ b/driver.html
@@ -106,7 +106,7 @@ let lowClearances = [];
 let clearanceCircles = [];
 let bridgeWarningActive = false;
 let alertCtx=null, alertInterval=null;
-const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+const tz = 'America/New_York';
 function startAlert(){
   if(alertInterval) return;
   alertCtx = new (window.AudioContext||window.webkitAudioContext)();


### PR DESCRIPTION
## Summary
- ensure driver and dispatcher pages render timestamps in Charlottesville time

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb8c97a2f483339b690e842285673a