### PR TITLE
Show all assigned training blocks

### DIFF
--- a/dispatcher.html
+++ b/dispatcher.html
@@ -108,7 +108,8 @@ async function loadBlocks(){
             col=colorByRoute.get(String(rid))||null;
             if(col && !col.startsWith('#')) col='#'+col;
           }
-          const key=g.BlockGroupId;
+          let key=g.BlockGroupId;
+          if(!String(key).includes('[')) key = b.BlockId || key;
           const segs=[];
           segs.push({start:b.BlockStartTime,end:b.BlockEndTime});
           for(const t of (b.Trips||[])){


### PR DESCRIPTION
## Summary
- Distinguish blocks without brackets by their block ID to avoid merging training assignments

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb905b80ec833381689b3bc3c988af