### PR TITLE
Fix block assignments table layout

### DIFF
--- a/dispatcher.html
+++ b/dispatcher.html
@@ -228,7 +228,8 @@ async function loadBlocks(){
       }
     }
     blockByBus=new Map(Array.from(tmp.entries()).map(([bus,val])=>[bus,val.block]));
-    const rows=9, cols=4;
+    const cols=4;
+    const rows=Math.ceil(entries.length/cols);
     let html='';
     for(let r=0;r<rows;r++){
       html+='<tr>';


### PR DESCRIPTION
## Summary
- Ensure block assignments table always renders four columns
- Stack entries column by column for balanced layout

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb969aa8308333824a99040d66c19f