### PR TITLE
Add admin configuration page

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Headway Guard Admin</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+@font-face{font-family:'FGDC';src:url('FGDC.ttf') format('truetype')}
+body{font:16px 'FGDC',system-ui;background:#0b0e11;color:#e8eef5;margin:0;padding:20px;}
+label{display:block;margin:8px 0;}
+input,textarea{width:100%;padding:6px;border-radius:4px;border:1px solid #2a3442;background:#10151c;color:#e8eef5;}
+button{margin-top:12px;padding:10px 14px;border-radius:6px;border:1px solid #2a3442;background:#15202b;color:#e8eef5;cursor:pointer;}
+</style>
+<h1>Headway Guard Admin</h1>
+<form id="cfg"></form>
+<button id="save">Save</button>
+<script>
+async function load(){
+  const cfg = await fetch('/v1/config',{cache:'no-store'}).then(r=>r.json());
+  const form=document.getElementById('cfg');
+  for(const [k,v] of Object.entries(cfg)){
+    const label=document.createElement('label');
+    label.textContent=k;
+    let inp;
+    if(Array.isArray(v)){
+      inp=document.createElement('textarea');
+      inp.rows=2;
+      inp.value=v.join(',');
+    }else{
+      inp=document.createElement('input');
+      inp.value=v;
+    }
+    inp.name=k;
+    label.appendChild(inp);
+    form.appendChild(label);
+  }
+}
+async function save(){
+  const form=document.getElementById('cfg');
+  const data={};
+  for(const el of form.elements){
+    if(!el.name) continue;
+    if(el.tagName==='TEXTAREA'){
+      data[el.name]=el.value.split(',').map(s=>s.trim()).filter(Boolean);
+    }else{
+      const num=parseFloat(el.value);
+      data[el.name]=isNaN(num)?el.value:num;
+    }
+  }
+  await fetch('/v1/config',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});
+  alert('Saved!');
+}
+document.getElementById('save').onclick=save;
+load();
+</script>

--- a/app.py
+++ b/app.py
@@ -25,7 +25,7 @@ Environment
 """
 
 from __future__ import annotations
-from typing import List, Dict, Optional, Tuple
+from typing import List, Dict, Optional, Tuple, Any
 from dataclasses import dataclass, field
 import asyncio, time, math, os, json, re
 from datetime import datetime
@@ -75,6 +75,23 @@ BRIDGE_LON = -78.4995922309842
 LOW_CLEARANCE_SEARCH_M = 25 * 1609.34  # 25 miles in meters
 LOW_CLEARANCE_LIMIT_FT = 11 + 11/12    # 11'11"
 BRIDGE_IGNORE_RADIUS_M = 100.0
+
+# Driver/Dispatcher configuration
+OVERHEIGHT_BUSES = [
+    "25131","25231","25331","25431","17132","14132","12432","18532"
+]
+LOW_CLEARANCE_RADIUS = 122
+BRIDGE_RADIUS = 117
+ALL_BUSES = [
+    "12132","12232","12332","12432","12532","12632",
+    "14132","14232","14332","14432","14532",
+    "17132","17232","17332","17432","17532","17632","17732",
+    "18132","18232","18332","18432","18532","18632","18732","18832",
+    "19132","19232","19332","19432","19532",
+    "20131","20231","20331","20431",
+    "24012","24112","24212","24312","24412",
+    "25131","25231","25331","25431",
+]
 
 # ---------------------------
 # Geometry helpers
@@ -441,6 +458,17 @@ BASE_DIR = Path(__file__).resolve().parent
 DRIVER_HTML = (BASE_DIR / "driver.html").read_text(encoding="utf-8")
 DISPATCHER_HTML = (BASE_DIR / "dispatcher.html").read_text(encoding="utf-8")
 MAP_HTML = (BASE_DIR / "map.html").read_text(encoding="utf-8")
+ADMIN_HTML = (BASE_DIR / "admin.html").read_text(encoding="utf-8")
+
+CONFIG_KEYS = [
+    "TRANSLOC_BASE","TRANSLOC_KEY","OVERPASS_EP",
+    "VEH_REFRESH_S","ROUTE_REFRESH_S","STALE_FIX_S","ROUTE_GRACE_S",
+    "URBAN_FACTOR","GREEN_FRAC","RED_FRAC","ONTARGET_TOL_SEC","W_LIMIT",
+    "EMA_ALPHA","MIN_SPEED_FLOOR","MAX_SPEED_CEIL","LEADER_EPS_M",
+    "DEFAULT_CAP_MPS","BRIDGE_LAT","BRIDGE_LON","LOW_CLEARANCE_SEARCH_M",
+    "LOW_CLEARANCE_LIMIT_FT","BRIDGE_IGNORE_RADIUS_M","OVERHEIGHT_BUSES",
+    "LOW_CLEARANCE_RADIUS","BRIDGE_RADIUS","ALL_BUSES"
+]
 
 class State:
     def __init__(self):
@@ -850,6 +878,36 @@ async def fgdc_font():
 @app.get("/map")
 async def map_page():
     return HTMLResponse(MAP_HTML)
+
+# ---------------------------
+# ADMIN PAGE
+# ---------------------------
+@app.get("/admin")
+async def admin_page():
+    return HTMLResponse(ADMIN_HTML)
+
+# ---------------------------
+# CONFIG
+# ---------------------------
+@app.get("/v1/config")
+async def get_config():
+    return {k: globals().get(k) for k in CONFIG_KEYS}
+
+@app.post("/v1/config")
+async def set_config(payload: Dict[str, Any]):
+    for k, v in payload.items():
+        if k in CONFIG_KEYS:
+            cur = globals().get(k)
+            if isinstance(cur, list):
+                if not isinstance(v, list):
+                    v = [x.strip() for x in str(v).split(',') if x.strip()]
+                globals()[k] = v
+            else:
+                try:
+                    globals()[k] = type(cur)(v)
+                except Exception:
+                    globals()[k] = v
+    return {k: globals().get(k) for k in CONFIG_KEYS}
 
 # ---------------------------
 # DRIVER PAGE

--- a/dispatcher.html
+++ b/dispatcher.html
@@ -85,7 +85,7 @@ function contrastColor(hex){
   return l>0.5?'#000':'#fff';
 }
 
-const allBuses=[
+let allBuses=[
   "12132","12232","12332","12432","12532","12632",
   "14132","14232","14332","14432","14532",
   "17132","17232","17332","17432","17532","17632","17732",
@@ -95,6 +95,14 @@ const allBuses=[
   "24012","24112","24212","24312","24412",
   "25131","25231","25331","25431",
 ];
+
+async function loadConfig(){
+  try{
+    const cfg = await j('/v1/config');
+    if(cfg.ALL_BUSES) allBuses = cfg.ALL_BUSES;
+  }catch(e){}
+}
+
 let activeES=null, activeIV=null, activeTL=null, currentRid=null, sessionId=0, userLocked=false, busOrder=[], lastRows=[], lastTLRows=[], blockByBus=new Map(), allBlockByBus=new Map();
 
 function updateExtraBuses(){
@@ -410,6 +418,6 @@ async function pollHealth(){
   setTimeout(pollHealth, 15000);
 }
 
-document.addEventListener('DOMContentLoaded', ()=>{ loadRoutes(); pollHealth(); loadBlocks(); setInterval(loadBlocks,30000); });
+document.addEventListener('DOMContentLoaded', async ()=>{ await loadConfig(); loadRoutes(); pollHealth(); loadBlocks(); setInterval(loadBlocks,30000); });
 document.getElementById('route').addEventListener('change', e=> { userLocked=true; start(e.target.value); });
 </script>

--- a/driver.html
+++ b/driver.html
@@ -97,11 +97,11 @@ const $ = s=>document.querySelector(s);
 const fmt = s=>{ if(s==null||!isFinite(s)) return "—"; s=Math.round(s); const m=Math.floor(s/60), r=s%60; return `${String(m).padStart(2,'0')}:${String(r).padStart(2,'0')}`; };
 async function j(u){ const r=await fetch(u,{cache:"no-store"}); if(!r.ok) throw new Error(r.status+" "+r.statusText); return r.json(); }
 let timer=null, busTimer=null, currentBus="", currentRoute=0, currentRouteLabel="", map=null, routeLayer=null, markers={}, nameMarkers={}, routeColor='#E57200';
-const OVERHEIGHT_BUSES = ['25131','25231','25331','25431','17132','14132','12432','18532'];
-const LOW_CLEARANCE_RADIUS = 122; // meters (~400 ft)
-const BRIDGE_RADIUS = 117; // meters
-const BRIDGE_LAT = 38.03404931117353;
-const BRIDGE_LON = -78.4995922309842;
+let OVERHEIGHT_BUSES = ['25131','25231','25331','25431','17132','14132','12432','18532'];
+let LOW_CLEARANCE_RADIUS = 122; // meters (~400 ft)
+let BRIDGE_RADIUS = 117; // meters
+let BRIDGE_LAT = 38.03404931117353;
+let BRIDGE_LON = -78.4995922309842;
 let lowClearances = [];
 let clearanceCircles = [];
 let bridgeWarningActive = false;
@@ -114,6 +114,18 @@ const timeFormatter = new Intl.DateTimeFormat([], {
   hour12: true,
   timeZone: tz
 });
+
+async function loadConfig(){
+  try{
+    const cfg = await j('/v1/config');
+    if(cfg.OVERHEIGHT_BUSES) OVERHEIGHT_BUSES = cfg.OVERHEIGHT_BUSES;
+    if(cfg.LOW_CLEARANCE_RADIUS!=null) LOW_CLEARANCE_RADIUS = cfg.LOW_CLEARANCE_RADIUS;
+    if(cfg.BRIDGE_RADIUS!=null) BRIDGE_RADIUS = cfg.BRIDGE_RADIUS;
+    if(cfg.BRIDGE_LAT!=null) BRIDGE_LAT = cfg.BRIDGE_LAT;
+    if(cfg.BRIDGE_LON!=null) BRIDGE_LON = cfg.BRIDGE_LON;
+  }catch(e){}
+}
+
 function startAlert(){
   if(alertInterval) return;
   alertCtx = new (window.AudioContext||window.webkitAudioContext)();
@@ -370,7 +382,7 @@ $('#theme').onclick = ()=>{
   const light=document.body.classList.toggle('light');
   $('#theme').textContent=light?'Dark Mode':'Light Mode';
 };
-document.addEventListener('DOMContentLoaded', async ()=>{ try{ await loadBuses(); await loadRoutes(); await loadLowClearances(); }catch(e){ $('#instruction').className='red'; $('#instruction').textContent='Error loading lists'; } });
+document.addEventListener('DOMContentLoaded', async ()=>{ try{ await loadConfig(); await loadBuses(); await loadRoutes(); await loadLowClearances(); }catch(e){ $('#instruction').className='red'; $('#instruction').textContent='Error loading lists'; } });
 async function pollHealth(){
   try{ const h=await j('/v1/health'); const w=$('#warn'); if(!h.ok && h.last_error){ w.style.display='block'; w.textContent='Feed error: '+h.last_error; } else { w.style.display='none'; w.textContent=''; } }
   catch(e){ const w=$('#warn'); w.style.display='block'; w.textContent='Health check failed'; }


### PR DESCRIPTION
## Summary
- expose server and client configuration through new `/admin` page
- centralize editable settings via `/v1/config` API
- driver and dispatcher pages now pull runtime config values from the server

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bba3af4a988333ba9635f8fd9cbefd