### PR TITLE
Add authentication and user management

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,21 @@ uvicorn app:app --reload --port 8080
 
 Open the [driver](http://localhost:8080/driver) and [dispatcher](http://localhost:8080/dispatcher) pages in a browser.
 
+## Authentication
+The admin interface, configuration API and TransLoc key are protected behind a username/password login.
+
+1. **Create the first user** (no authentication required while the database is empty):
+
+   ```bash
+   curl -X POST http://localhost:8080/v1/users \
+        -H "Content-Type: application/json" \
+        -d '{"username":"admin","password":"secret","is_admin": true}'
+   ```
+
+2. Visit [http://localhost:8080/login](http://localhost:8080/login) and sign in.
+3. The [admin page](http://localhost:8080/admin) allows configuration and links to the `/users` page for managing additional accounts.
+4. Configuration updates and user creation events are logged to `audit.log` with the acting user and timestamp.
+
 ## API
 
 Key endpoints exposed by the service:

--- a/admin.html
+++ b/admin.html
@@ -10,6 +10,7 @@ input,textarea{width:100%;padding:6px;border-radius:4px;border:1px solid #2a3442
 button{margin-top:12px;padding:10px 14px;border-radius:6px;border:1px solid #2a3442;background:#15202b;color:#e8eef5;cursor:pointer;}
 </style>
 <h1>Headway Guard Admin</h1>
+<p><a href="/users">Manage Users</a> | <a href="#" id="logout">Logout</a></p>
 <form id="cfg"></form>
 <button id="save">Save</button>
 <script>
@@ -49,5 +50,9 @@ async function save(){
   alert('Saved!');
 }
 document.getElementById('save').onclick=save;
+document.getElementById('logout').onclick=async()=>{
+  await fetch('/logout',{method:'POST'});
+  location.href='/login';
+};
 load();
 </script>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Headway Guard Login</title>
+<style>
+@font-face{font-family:'FGDC';src:url('FGDC.ttf') format('truetype')}
+body{font:16px 'FGDC',system-ui;background:#0b0e11;color:#e8eef5;margin:0;padding:20px;}
+label{display:block;margin:8px 0;}
+input{width:100%;padding:6px;border-radius:4px;border:1px solid #2a3442;background:#10151c;color:#e8eef5;}
+button{margin-top:12px;padding:10px 14px;border-radius:6px;border:1px solid #2a3442;background:#15202b;color:#e8eef5;cursor:pointer;}
+</style>
+<h1>Login</h1>
+<form id="login">
+<label>Username<input name="username"></label>
+<label>Password<input type="password" name="password"></label>
+</form>
+<button id="go">Login</button>
+<script>
+document.getElementById('go').onclick = async () => {
+  const form = document.getElementById('login');
+  const resp = await fetch('/login', {
+    method:'POST',
+    headers:{'Content-Type':'application/json'},
+    body: JSON.stringify({username: form.username.value, password: form.password.value})
+  });
+  if(resp.ok){
+    location.href='/admin';
+  }else{
+    alert('Login failed');
+  }
+};
+</script>

--- a/users.html
+++ b/users.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Headway Guard Users</title>
+<style>
+@font-face{font-family:'FGDC';src:url('FGDC.ttf') format('truetype')}
+body{font:16px 'FGDC',system-ui;background:#0b0e11;color:#e8eef5;margin:0;padding:20px;}
+label{display:block;margin:8px 0;}
+input{width:100%;padding:6px;border-radius:4px;border:1px solid #2a3442;background:#10151c;color:#e8eef5;}
+button{margin-top:12px;padding:10px 14px;border-radius:6px;border:1px solid #2a3442;background:#15202b;color:#e8eef5;cursor:pointer;}
+</style>
+<h1>Users</h1>
+<div id="list"></div>
+<h2>Create User</h2>
+<form id="new">
+<label>Username<input name="username"></label>
+<label>Password<input type="password" name="password"></label>
+<label><input type="checkbox" name="admin"> Admin</label>
+</form>
+<button id="create">Create</button>
+<script>
+async function load(){
+  const data = await fetch('/v1/users').then(r=>r.json());
+  const list = document.getElementById('list');
+  list.innerHTML='';
+  for(const u of data){
+    const div=document.createElement('div');
+    div.textContent = u.username + (u.is_admin ? ' (admin)' : '');
+    list.appendChild(div);
+  }
+}
+document.getElementById('create').onclick = async () => {
+  const form = document.getElementById('new');
+  await fetch('/v1/users', {
+    method:'POST',
+    headers:{'Content-Type':'application/json'},
+    body: JSON.stringify({username: form.username.value, password: form.password.value, is_admin: form.admin.checked})
+  });
+  form.reset();
+  load();
+};
+load();
+</script>


### PR DESCRIPTION
## Summary
- protect admin and config endpoints with login
- add simple user database and audit logging
- introduce login and user management pages

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bba888755c833386637dfddb68691c