### PR TITLE
Normalize bus ID types for extra bus rendering

### DIFF
--- a/dispatcher.html
+++ b/dispatcher.html
@@ -102,7 +102,7 @@ let allBuses=[
 async function loadConfig(){
   try{
     const cfg = await j('/v1/config');
-    if(cfg.ALL_BUSES) allBuses = cfg.ALL_BUSES;
+    if(cfg.ALL_BUSES) allBuses = cfg.ALL_BUSES.map(b=>String(b));
   }catch(e){}
 }
 
@@ -110,7 +110,7 @@ let activeES=null, activeIV=null, activeTL=null, currentRid=null, sessionId=0, u
 
 function updateExtraBuses(){
   const extra=$('#extra-buses');
-  const unassigned=allBuses.filter(b=>!allBlockByBus.has(b));
+  const unassigned=allBuses.map(b=>String(b)).filter(b=>!allBlockByBus.has(b));
   extra.innerHTML=unassigned.length
     ? unassigned.map(b=>`<li class="mono">${b}</li>`).join('')
     : '<li class="hint">None</li>';


### PR DESCRIPTION
## Summary
- Ensure ALL_BUSES config values are converted to strings when loaded
- Cast bus IDs to strings before filtering unassigned buses to avoid `startsWith` crashes

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbb0dd1a648333b4ec81d003c5ad89