### PR TITLE
Highlight non-24 and overheight extra buses

### DIFF
--- a/dispatcher.html
+++ b/dispatcher.html
@@ -116,10 +116,8 @@ function updateExtraBuses(){
   const unassigned=allBuses.filter(b=>!allBlockByBus.has(b));
   extra.innerHTML=unassigned.length
     ? unassigned.map(b=>{
-        let bg='#10151c';
-        if(OVERHEIGHT_BUSES.includes(b)){
-          bg='#E57200';
-        }else if(b.startsWith('24')){
+        let bg='#EEE8AA';
+        if(b.startsWith('24') && !OVERHEIGHT_BUSES.includes(b)){
           bg='#232D4B';
         }
         const color=contrastColor(bg);


### PR DESCRIPTION
## Summary
- Color-code extra buses: default to pale goldenrod (#EEE8AA) unless bus starts with `24` and isn't overheight, in which case keep route blue

## Testing
- `npm test` *(fails: command not found)*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbb28e08dc8333a2cf888df6fdf144