### PR TITLE
Preserve overheight bus color in extra bus list

### DIFF
--- a/dispatcher.html
+++ b/dispatcher.html
@@ -117,7 +117,9 @@ function updateExtraBuses(){
   extra.innerHTML=unassigned.length
     ? unassigned.map(b=>{
         let bg='#EEE8AA';
-        if(b.startsWith('24') && !OVERHEIGHT_BUSES.includes(b)){
+        if(OVERHEIGHT_BUSES.includes(b)){
+          bg='#E57200';
+        }else if(b.startsWith('24')){
           bg='#232D4B';
         }
         const color=contrastColor(bg);


### PR DESCRIPTION
## Summary
- Ensure dispatcher extra bus list keeps dedicated colors for overheight buses instead of overriding with the new default color

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbb48c6a14833398285001e7b50f40