### PR TITLE
Fix header wrapping to keep status chips visible on mobile

### DIFF
--- a/dispatcher.html
+++ b/dispatcher.html
@@ -6,7 +6,8 @@
 @font-face{font-family:'FGDC';src:url('FGDC.ttf') format('truetype')}
 :root{--route-color:#2a3442}
 body{font:17px 'FGDC',system-ui;margin:0;background:#0b0e11;color:#e8eef5}
-header{display:flex;gap:10px;align-items:center;padding:12px 14px;border-bottom:1px solid #1f2630}
+header{display:flex;gap:10px;align-items:center;padding:12px 14px;border-bottom:1px solid #1f2630;flex-wrap:wrap}
+header h1{flex-basis:100%}
 select{background:#10151c;color:#e8eef5;border:1px solid #2a3442;border-radius:10px;padding:8px 10px}
 .chip{display:inline-block;border:1px solid #2a3442;border-radius:999px;padding:2px 8px;margin-left:8px;color:#cfe1ff}
 table{width:100%;border-collapse:collapse;margin-top:8px}


### PR DESCRIPTION
## Summary
- Allow dispatcher header to wrap so Target and Updated chips stay on screen on small displays

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc701005388333a99e34c9ae43093c