### PR TITLE
Show per-bus mileage since reset

### DIFF
--- a/servicecrew.html
+++ b/servicecrew.html
@@ -28,7 +28,7 @@
 <div id="layout">
   <div id="table-wrapper">
     <table id="bustable">
-      <thead><tr><th>Bus</th><th>Blocks</th><th>Miles</th><th id="resetHead">Reset</th></tr></thead>
+      <thead><tr><th>Bus</th><th>Blocks</th><th>Miles since Reset</th><th id="resetHead">Reset</th></tr></thead>
       <tbody></tbody>
     </table>
   </div>
@@ -52,7 +52,8 @@ async function fetchData(){
     const info=data.buses[b];
     const tr=document.createElement('tr');
     const blocks=info.blocks.length?info.blocks.join(', '):'—';
-    const miles=isToday?(info.display_miles||0).toFixed(2):`${(info.actual_miles||0).toFixed(2)} (reset at ${(info.reset_miles||0).toFixed(2)})`;
+    const milesDisplay=(info.display_miles||0).toFixed(2);
+    const miles=isToday?milesDisplay:`${milesDisplay} (total ${(info.actual_miles||0).toFixed(2)})`;
     tr.innerHTML=`<td>${b}</td><td>${blocks}</td><td>${miles}</td>`;
     if(isToday){
       total+=info.display_miles||0;


### PR DESCRIPTION
## Summary
- Display each bus's miles since last reset instead of only combined total
- Label mileage column "Miles since Reset" for clarity

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68bc7c253dcc8333bfe93f6b1ef60524