### PR TITLE
Accumulate miles since last reset across days

### DIFF
--- a/servicecrew.html
+++ b/servicecrew.html
@@ -53,7 +53,7 @@ async function fetchData(){
     const tr=document.createElement('tr');
     const blocks=info.blocks.length?info.blocks.join(', '):'—';
     const milesDisplay=(info.display_miles||0).toFixed(2);
-    const miles=isToday?milesDisplay:`${milesDisplay} (total ${(info.actual_miles||0).toFixed(2)})`;
+    const miles=isToday?milesDisplay:`${milesDisplay} (day ${(info.actual_miles||0).toFixed(2)})`;
     tr.innerHTML=`<td>${b}</td><td>${blocks}</td><td>${miles}</td>`;
     if(isToday){
       total+=info.display_miles||0;


### PR DESCRIPTION
## Summary
- track per-bus mileage across days
- show cumulative miles since last reset in service crew UI

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc7ef15f688333acf993c27c43fa47