### PR TITLE
Persist bus mileage on Fly.io volume

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -42,3 +42,7 @@ kill_timeout = "5s"
 [metrics]
   port = 8080
   path = "/metrics"  # (not implemented; harmless)
+
+[[mounts]]
+  source = "mileage_data"
+  destination = "/data"


### PR DESCRIPTION
## Summary
- mount `mileage_data` Fly.io volume at `/data`
- load saved mileage data on startup and persist updates to JSON

## Testing
- `python -m py_compile app.py`
- `fly volumes create mileage_data --size 1 -r iad` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc82d2e3c08333992d5a9a962990af