### PR TITLE
Add landing page with navigation tiles

### DIFF
--- a/app.py
+++ b/app.py
@@ -485,6 +485,7 @@ DISPATCHER_HTML = (BASE_DIR / "dispatcher.html").read_text(encoding="utf-8")
 MAP_HTML = (BASE_DIR / "map.html").read_text(encoding="utf-8")
 ADMIN_HTML = (BASE_DIR / "admin.html").read_text(encoding="utf-8")
 SERVICECREW_HTML = (BASE_DIR / "servicecrew.html").read_text(encoding="utf-8")
+LANDING_HTML = (BASE_DIR / "index.html").read_text(encoding="utf-8")
 
 CONFIG_KEYS = [
     "TRANSLOC_BASE","TRANSLOC_KEY","OVERPASS_EP",
@@ -991,6 +992,13 @@ async def stream_route(route_id: int):
 @app.get("/FGDC.ttf", include_in_schema=False)
 async def fgdc_font():
     return FileResponse(BASE_DIR / "FGDC.ttf", media_type="font/ttf")
+
+# ---------------------------
+# LANDING PAGE
+# ---------------------------
+@app.get("/")
+async def landing_page():
+    return HTMLResponse(LANDING_HTML)
 
 # ---------------------------
 # MAP PAGE

--- a/index.html
+++ b/index.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>Headway Guard</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<link rel="preload" href="FGDC.ttf" as="font" type="font/ttf" crossorigin />
+<style>
+  @font-face{font-family:'FGDC';src:url('FGDC.ttf') format('truetype');font-weight:normal;font-style:normal;}
+  :root{ --bg:#0b0e11; --panel:#0f141a; --ink:#e8eef5; --line:#1f2630; }
+  body{margin:0;background:var(--bg);color:var(--ink);font:16px/1.45 'FGDC',sans-serif;display:flex;align-items:center;justify-content:center;height:100vh;}
+  .container{display:flex;gap:20px;}
+  .card{width:160px;height:160px;border-radius:16px;background:var(--panel);border:1px solid var(--line);display:flex;flex-direction:column;align-items:center;justify-content:center;text-decoration:none;color:var(--ink);}
+  .card svg{width:64px;height:64px;margin-bottom:12px;}
+  .admin-link{position:fixed;top:12px;right:16px;color:var(--ink);text-decoration:none;font-size:14px;}
+  @media(max-width:600px){.container{flex-direction:column;}}
+</style>
+</head>
+<body>
+<a href="/admin" class="admin-link">Admin</a>
+<div class="container">
+  <a class="card" href="/driver">
+    <svg viewBox="0 0 64 64" stroke="currentColor" stroke-width="4" fill="none" stroke-linejoin="round">
+      <rect x="8" y="16" width="48" height="28" rx="4" />
+      <line x1="8" y1="30" x2="56" y2="30" />
+      <rect x="16" y="20" width="12" height="8" />
+      <rect x="36" y="20" width="12" height="8" />
+      <circle cx="20" cy="46" r="4" fill="currentColor" stroke="none" />
+      <circle cx="44" cy="46" r="4" fill="currentColor" stroke="none" />
+    </svg>
+    <div>Driver</div>
+  </a>
+  <a class="card" href="/dispatcher">
+    <svg viewBox="0 0 64 64" stroke="currentColor" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M32 12 L22 52 h20 L32 12 z" />
+      <line x1="24" y1="52" x2="40" y2="52" />
+      <path d="M24 28c4-4 8-4 12 0" />
+      <path d="M20 20c8-8 16-8 24 0" />
+    </svg>
+    <div>Dispatch</div>
+  </a>
+  <a class="card" href="/servicecrew">
+    <svg viewBox="0 0 64 64" stroke="currentColor" stroke-width="4" fill="none" stroke-linejoin="round">
+      <rect x="16" y="20" width="20" height="28" rx="2" />
+      <rect x="16" y="12" width="20" height="8" rx="2" />
+      <path d="M36 24h8v20a4 4 0 0 1-4 4h-4" />
+      <path d="M44 44h4a4 4 0 0 0 4-4V24" />
+      <circle cx="24" cy="48" r="4" fill="currentColor" stroke="none" />
+    </svg>
+    <div>Service Crew</div>
+  </a>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add index.html landing page linking to driver, dispatch, and service crew tools
- Load landing page in FastAPI and serve at root route

## Testing
- `pytest`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd0a60b63483339d0729698c069332