### PR TITLE
Add Live Map card on landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,14 @@
     </svg>
     <div>Service Crew</div>
   </a>
+  <a class="card" href="/map">
+    <svg viewBox="0 0 64 64" stroke="currentColor" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round">
+      <polyline points="8 20 24 12 40 20 56 12 56 44 40 52 24 44 8 52 8 20" />
+      <line x1="24" y1="12" x2="24" y2="44" />
+      <line x1="40" y1="20" x2="40" y2="52" />
+    </svg>
+    <div>Live Map</div>
+  </a>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add "Live Map" card linking to `/map` on landing page with simple map SVG.

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd0be03ae483338659b9318a4de2a5