### PR TITLE
Add live external API call monitor

### DIFF
--- a/apicalls.html
+++ b/apicalls.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>External API Calls - Headway Guard</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+@font-face{font-family:'FGDC';src:url('FGDC.ttf') format('truetype')}
+body{font:16px 'FGDC',system-ui;background:#0b0e11;color:#e8eef5;margin:0;padding:20px;}
+ul{list-style:none;padding:0;margin:0;}
+li{padding:4px 0;border-bottom:1px solid #2a3442;word-break:break-all;}
+.credit{position:fixed;bottom:8px;right:8px;font-size:12px;color:#9fb0c9}
+</style>
+<h1>External API Calls</h1>
+<ul id="log"></ul>
+<div class="credit">proof of concept created by pat cox • phc6j@virginia.edu</div>
+<script>
+const log=document.getElementById('log');
+function add(item){
+  const li=document.createElement('li');
+  const t=new Date(item.ts).toLocaleTimeString();
+  li.textContent=`[${t}] ${item.method} ${item.status} ${item.url}`;
+  log.prepend(li);
+  while(log.children.length>50) log.removeChild(log.lastChild);
+}
+const es=new EventSource('/v1/stream/api_calls');
+es.onmessage=ev=>{ try{ add(JSON.parse(ev.data)); }catch(_){}};
+</script>


### PR DESCRIPTION
## Summary
- track external API requests and stream them to clients
- instrument TransLoc and Overpass requests to record method, url, and status
- add `/apicalls` page showing live API call log via SSE

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdbdeb780c8333a0078eaa619b89e3