### PR TITLE
Ensure times render in Eastern timezone

### DIFF
--- a/apicalls.html
+++ b/apicalls.html
@@ -14,9 +14,24 @@ li{padding:4px 0;border-bottom:1px solid #2a3442;word-break:break-all;}
 <div class="credit">proof of concept created by pat cox • phc6j@virginia.edu</div>
 <script>
 const log=document.getElementById('log');
+function toEasternDate(ts){
+  const d=new Date(ts);
+  const y=d.getUTCFullYear();
+  const m1=new Date(Date.UTC(y,2,1));
+  const mSun=(7-m1.getUTCDay())%7;
+  const dstStart=Date.UTC(y,2,8+mSun,7,0,0);
+  const n1=new Date(Date.UTC(y,10,1));
+  const nSun=(7-n1.getUTCDay())%7;
+  const dstEnd=Date.UTC(y,10,1+nSun,6,0,0);
+  const off=(ts>=dstStart && ts<dstEnd)?-4:-5;
+  return new Date(ts+off*3600*1000);
+}
+function formatTime(ts){
+  return toEasternDate(ts).toLocaleTimeString('en-US',{hour:'numeric',minute:'2-digit',second:'2-digit',hour12:true});
+}
 function add(item){
   const li=document.createElement('li');
-  const t=new Date(item.ts).toLocaleTimeString();
+  const t=formatTime(item.ts);
   li.textContent=`[${t}] ${item.method} ${item.status} ${item.url}`;
   log.prepend(li);
   while(log.children.length>50) log.removeChild(log.lastChild);

--- a/dispatcher.html
+++ b/dispatcher.html
@@ -81,16 +81,20 @@ const pill = st => { const m = {green:["OK","ok"],yellow:["Slow Down","warn"],re
 async function j(u){ const r = await fetch(u,{cache:"no-store"}); if(!r.ok) throw new Error(r.status); return r.json(); }
 function setBanner(txt,kind){ const b=$('#banner'); if(!txt){ b.style.display='none'; b.textContent=''; return; } b.className='banner '+(kind||'info'); b.textContent=txt; b.style.display='block'; }
 
-const tz = 'America/New_York';
-const timeOptions = {
-  hour: 'numeric',
-  minute: '2-digit',
-  second: '2-digit',
-  hour12: true,
-  timeZone: tz
-};
+function toEasternDate(ts){
+  const d=new Date(ts);
+  const y=d.getUTCFullYear();
+  const m1=new Date(Date.UTC(y,2,1));
+  const mSun=(7-m1.getUTCDay())%7;
+  const dstStart=Date.UTC(y,2,8+mSun,7,0,0);
+  const n1=new Date(Date.UTC(y,10,1));
+  const nSun=(7-n1.getUTCDay())%7;
+  const dstEnd=Date.UTC(y,10,1+nSun,6,0,0);
+  const off=(ts>=dstStart && ts<dstEnd)?-4:-5;
+  return new Date(ts+off*3600*1000);
+}
 function formatTime(ts){
-  return new Date(ts).toLocaleTimeString('en-US', timeOptions);
+  return toEasternDate(ts).toLocaleTimeString('en-US',{hour:'numeric',minute:'2-digit',second:'2-digit',hour12:true});
 }
 
 function contrastColor(hex){

--- a/driver.html
+++ b/driver.html
@@ -110,16 +110,20 @@ let lowClearances = [];
 let clearanceCircles = [];
 let bridgeWarningActive = false;
 let alertCtx=null, alertInterval=null;
-const tz = 'America/New_York';
-const timeOptions = {
-  hour: 'numeric',
-  minute: '2-digit',
-  second: '2-digit',
-  hour12: true,
-  timeZone: tz
-};
+function toEasternDate(ts){
+  const d=new Date(ts);
+  const y=d.getUTCFullYear();
+  const m1=new Date(Date.UTC(y,2,1));
+  const mSun=(7-m1.getUTCDay())%7;
+  const dstStart=Date.UTC(y,2,8+mSun,7,0,0);
+  const n1=new Date(Date.UTC(y,10,1));
+  const nSun=(7-n1.getUTCDay())%7;
+  const dstEnd=Date.UTC(y,10,1+nSun,6,0,0);
+  const off=(ts>=dstStart && ts<dstEnd)?-4:-5;
+  return new Date(ts+off*3600*1000);
+}
 function formatTime(ts){
-  return new Date(ts).toLocaleTimeString('en-US', timeOptions);
+  return toEasternDate(ts).toLocaleTimeString('en-US', {hour:'numeric', minute:'2-digit', second:'2-digit', hour12:true});
 }
 
 async function loadConfig(){
@@ -312,9 +316,10 @@ async function tick(){
   }
 }
 function updateClock(){
-  const t=new Date().toLocaleTimeString('en-US', {hour:'2-digit', minute:'2-digit', second:'2-digit', hour12:false, timeZone: tz});
+  const t=toEasternDate(Date.now()).toLocaleTimeString('en-US',{hour:'2-digit',minute:'2-digit',second:'2-digit',hour12:false});
   $('#clock').textContent=t;
 }
+updateClock();
 setInterval(updateClock,1000);
 function initMap(){
   map = L.map('map').setView([38.03799212281404, -78.50981502838886], 14);


### PR DESCRIPTION
## Summary
- Convert timestamps to America/New_York manually to avoid missing time zone data
- Show dispatcher and driver "updated" times in Eastern time
- Adjust driver clock and API call monitor to render in Eastern

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdc3351d688333a779205116baddd6