### PR TITLE
Use timezone-aware formatting for Eastern time

### DIFF
--- a/dispatcher.html
+++ b/dispatcher.html
@@ -81,20 +81,14 @@ const pill = st => { const m = {green:["OK","ok"],yellow:["Slow Down","warn"],re
 async function j(u){ const r = await fetch(u,{cache:"no-store"}); if(!r.ok) throw new Error(r.status); return r.json(); }
 function setBanner(txt,kind){ const b=$('#banner'); if(!txt){ b.style.display='none'; b.textContent=''; return; } b.className='banner '+(kind||'info'); b.textContent=txt; b.style.display='block'; }
 
-function toEasternDate(ts){
-  const d=new Date(ts);
-  const y=d.getUTCFullYear();
-  const m1=new Date(Date.UTC(y,2,1));
-  const mSun=(7-m1.getUTCDay())%7;
-  const dstStart=Date.UTC(y,2,8+mSun,7,0,0);
-  const n1=new Date(Date.UTC(y,10,1));
-  const nSun=(7-n1.getUTCDay())%7;
-  const dstEnd=Date.UTC(y,10,1+nSun,6,0,0);
-  const off=(ts>=dstStart && ts<dstEnd)?-4:-5;
-  return new Date(ts+off*3600*1000);
-}
 function formatTime(ts){
-  return toEasternDate(ts).toLocaleTimeString('en-US',{hour:'numeric',minute:'2-digit',second:'2-digit',hour12:true});
+  return new Date(ts).toLocaleTimeString('en-US', {
+    timeZone:'America/New_York',
+    hour:'numeric',
+    minute:'2-digit',
+    second:'2-digit',
+    hour12:true
+  });
 }
 
 function contrastColor(hex){

--- a/driver.html
+++ b/driver.html
@@ -110,20 +110,14 @@ let lowClearances = [];
 let clearanceCircles = [];
 let bridgeWarningActive = false;
 let alertCtx=null, alertInterval=null;
-function toEasternDate(ts){
-  const d=new Date(ts);
-  const y=d.getUTCFullYear();
-  const m1=new Date(Date.UTC(y,2,1));
-  const mSun=(7-m1.getUTCDay())%7;
-  const dstStart=Date.UTC(y,2,8+mSun,7,0,0);
-  const n1=new Date(Date.UTC(y,10,1));
-  const nSun=(7-n1.getUTCDay())%7;
-  const dstEnd=Date.UTC(y,10,1+nSun,6,0,0);
-  const off=(ts>=dstStart && ts<dstEnd)?-4:-5;
-  return new Date(ts+off*3600*1000);
-}
 function formatTime(ts){
-  return toEasternDate(ts).toLocaleTimeString('en-US', {hour:'numeric', minute:'2-digit', second:'2-digit', hour12:true});
+  return new Date(ts).toLocaleTimeString('en-US', {
+    timeZone:'America/New_York',
+    hour:'numeric',
+    minute:'2-digit',
+    second:'2-digit',
+    hour12:true
+  });
 }
 
 async function loadConfig(){
@@ -316,7 +310,13 @@ async function tick(){
   }
 }
 function updateClock(){
-  const t=toEasternDate(Date.now()).toLocaleTimeString('en-US',{hour:'2-digit',minute:'2-digit',second:'2-digit',hour12:false});
+  const t = new Date().toLocaleTimeString('en-US', {
+    timeZone:'America/New_York',
+    hour:'2-digit',
+    minute:'2-digit',
+    second:'2-digit',
+    hour12:false
+  });
   $('#clock').textContent=t;
 }
 updateClock();


### PR DESCRIPTION
## Summary
- Fix driver and dispatcher pages to use `toLocaleTimeString` with `America/New_York` timezone
- Remove manual DST offsets that caused incorrect clocks and timestamps

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdc75abf9c8333bc6440846d1f4198