### PR TITLE
Clamp negative update timestamps

### DIFF
--- a/dispatcher.html
+++ b/dispatcher.html
@@ -115,7 +115,8 @@ async function loadConfig(){
 let activeES=null, activeIV=null, activeTL=null, currentRid=null, sessionId=0, userLocked=false, busOrder=[], lastRows=[], lastTLRows=[], blockByBus=new Map(), allBlockByBus=new Map(), lastUpdateTs=Date.now();
 
 function updateLastUpdated(){
-  const updatedAgo = fmt((Date.now() - lastUpdateTs) / 1000);
+  const secondsAgo = Math.max((Date.now() - lastUpdateTs) / 1000, 0);
+  const updatedAgo = fmt(secondsAgo);
   $('#upd').textContent = "Updated " + updatedAgo + " ago";
 }
 

--- a/driver.html
+++ b/driver.html
@@ -292,7 +292,7 @@ async function tick(){
     box.textContent=inst;
   }
     const ts = (data.updated_at || Date.now()/1000) * 1000;
-    const updatedAgo = fmt((Date.now() - ts) / 1000);
+    const updatedAgo = fmt(Math.max((Date.now() - ts) / 1000, 0));
     $('#details').innerHTML=`Headway: ${data.headway||'—'} • Target: ${data.target||'—'}<br>Gap: ${data.gap||'—'} • Countdown: ${data.countdown||'—'}<br><span class="muted">Leader: ${data.leader||'—'} • Updated ${updatedAgo} ago</span>`;
   } catch(e){
     const box=$('#instruction');


### PR DESCRIPTION
## Summary
- avoid negative "Updated" display in dispatcher by clamping timestamp differences to zero
- ensure driver view displays non-negative elapsed time when using updated_at values

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdd16aa82c8333850c04f5c80351b0