### PR TITLE
Fix future timestamps in vehicle updates

### DIFF
--- a/dispatcher.html
+++ b/dispatcher.html
@@ -115,7 +115,7 @@ async function loadConfig(){
 let activeES=null, activeIV=null, activeTL=null, currentRid=null, sessionId=0, userLocked=false, busOrder=[], lastRows=[], lastTLRows=[], blockByBus=new Map(), allBlockByBus=new Map(), lastUpdateTs=Date.now();
 
 function updateLastUpdated(){
-  const secondsAgo = Math.max((Date.now() - lastUpdateTs) / 1000, 0);
+  const secondsAgo = (Date.now() - lastUpdateTs) / 1000;
   const updatedAgo = fmt(secondsAgo);
   $('#upd').textContent = "Updated " + updatedAgo + " ago";
 }

--- a/driver.html
+++ b/driver.html
@@ -292,7 +292,7 @@ async function tick(){
     box.textContent=inst;
   }
     const ts = (data.updated_at || Date.now()/1000) * 1000;
-    const updatedAgo = fmt(Math.max((Date.now() - ts) / 1000, 0));
+    const updatedAgo = fmt((Date.now() - ts) / 1000);
     $('#details').innerHTML=`Headway: ${data.headway||'—'} • Target: ${data.target||'—'}<br>Gap: ${data.gap||'—'} • Countdown: ${data.countdown||'—'}<br><span class="muted">Leader: ${data.leader||'—'} • Updated ${updatedAgo} ago</span>`;
   } catch(e){
     const box=$('#instruction');


### PR DESCRIPTION
## Summary
- Derive vehicle age from raw timestamp or `Seconds` field and ensure `updated_at` reflects current time minus age
- Remove client-side clamping of negative update intervals in driver and dispatcher pages

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdd2e017048333b50a07046073cc96