### PR TITLE
feat: show speed limits on debug page

### DIFF
--- a/app.py
+++ b/app.py
@@ -1061,6 +1061,8 @@ async def route_debug(route_id: int):
                 "updated_at": vv.updated_at,
             }
             if raw:
+                seg_idx = find_seg_index_at_s(route.cum, raw.s_pos)
+                cap = route.seg_caps_mps[seg_idx] if route.seg_caps_mps else DEFAULT_CAP_MPS
                 d.update({
                     "lat": raw.lat,
                     "lon": raw.lon,
@@ -1070,6 +1072,7 @@ async def route_debug(route_id: int):
                     "dir_sign": raw.dir_sign,
                     "heading": raw.heading,
                     "age_s": raw.age_s,
+                    "speed_limit_mph": cap / MPH_TO_MPS,
                 })
             out.append(d)
         return out

--- a/debug.html
+++ b/debug.html
@@ -23,6 +23,7 @@
 <script>
 async function loadDebug(){
   const container=document.getElementById('info');
+  const scrollTop=container.scrollTop;
   try{
     const res=await fetch('/v1/routes');
     const data=await res.json();
@@ -40,10 +41,11 @@ async function loadDebug(){
           const p=document.createElement('p');p.textContent='No vehicles.';sect.appendChild(p);
         }else{
           const tbl=document.createElement('table');
-          tbl.innerHTML='<tr><th>Bus</th><th>Status</th><th>Headway</th><th>Target</th><th>Gap</th><th>Leader</th><th>s (m)</th><th>Lat</th><th>Lon</th><th>mph</th></tr>';
+          tbl.innerHTML='<tr><th>Bus</th><th>Status</th><th>Headway</th><th>Target</th><th>Gap</th><th>Leader</th><th>s (m)</th><th>Lat</th><th>Lon</th><th>mph</th><th>Limit</th></tr>';
           for(const v of vehs){
             const mph=(v.ground_mps||0)*2.23694;
-            tbl.innerHTML+=`<tr><td>${v.name}</td><td>${v.status}</td><td>${v.headway_sec??'—'}</td><td>${v.target_headway_sec??'—'}</td><td>${v.gap_label||'—'}</td><td>${v.leader_name||'—'}</td><td>${v.s_pos?.toFixed(1)}</td><td>${v.lat?.toFixed(5)}</td><td>${v.lon?.toFixed(5)}</td><td>${mph.toFixed(1)}</td></tr>`;
+            const lim=v.speed_limit_mph;
+            tbl.innerHTML+=`<tr><td>${v.name}</td><td>${v.status}</td><td>${v.headway_sec??'—'}</td><td>${v.target_headway_sec??'—'}</td><td>${v.gap_label||'—'}</td><td>${v.leader_name||'—'}</td><td>${v.s_pos?.toFixed(1)}</td><td>${v.lat?.toFixed(5)}</td><td>${v.lon?.toFixed(5)}</td><td>${mph.toFixed(1)}</td><td>${lim!=null?lim.toFixed(1):'—'}</td></tr>`;
           }
           sect.appendChild(tbl);
         }
@@ -55,6 +57,7 @@ async function loadDebug(){
   }catch(e){
     container.textContent='Error loading routes';
   }
+  container.scrollTop=scrollTop;
 }
 loadDebug();
 setInterval(loadDebug,5000);


### PR DESCRIPTION
## Summary
- show speed limit for each vehicle in debug view
- retain scroll position when debug data refreshes

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68bde59c9b5c8333ab9af6d88f3882f1