### PR TITLE
Add leader-loss logging endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Key endpoints exposed by the service:
 - `/v1/routes/{route_id}/status` – headway status for a route.
 - `/v1/routes/{route_id}/vehicles/{vehicle_name}/instruction` – driver instruction for a vehicle.
 - `/v1/stream/routes/{route_id}` – Server-Sent Events stream.
+- `/v1/leader_events` – recent leader-loss events for debugging.
 
 ## Configuration
 Runtime settings can be tuned with environment variables such as `TRANSLOC_BASE`, `TRANSLOC_KEY` and `OVERPASS_EP`.


### PR DESCRIPTION
## Summary
- Log leader-loss events with ring composition and positions so missing leaders can be investigated later
- Expose a `/v1/leader_events` endpoint to retrieve recent leader-loss events

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bde75daa5c83338ed88ae030d56c1e