### PR TITLE
Add vehicle logging and replay page

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ uvicorn app:app --reload --port 8080
 
 Open the [driver](http://localhost:8080/driver) and [dispatcher](http://localhost:8080/dispatcher) pages in a browser.
 
+### Replay
+
+A lightweight logger and replay page are included for reviewing past vehicle
+positions. Run `python log_vehicle_points.py` to continuously poll TransLoc and
+append snapshots to `vehicle_log.jsonl` while pruning entries older than one
+week. Visit [`/replay`](http://localhost:8080/replay) to view the logged data
+with a timeline and playback controls (pause, play and fast forward).
+
 ## API
 
 Key endpoints exposed by the service:

--- a/app.py
+++ b/app.py
@@ -568,6 +568,7 @@ SERVICECREW_HTML = (BASE_DIR / "servicecrew.html").read_text(encoding="utf-8")
 LANDING_HTML = (BASE_DIR / "index.html").read_text(encoding="utf-8")
 APICALLS_HTML = (BASE_DIR / "apicalls.html").read_text(encoding="utf-8")
 DEBUG_HTML = (BASE_DIR / "debug.html").read_text(encoding="utf-8")
+REPLAY_HTML = (BASE_DIR / "replay.html").read_text(encoding="utf-8")
 
 API_CALL_LOG = deque(maxlen=100)
 API_CALL_SUBS: set[asyncio.Queue] = set()
@@ -1151,6 +1152,13 @@ async def stream_api_calls():
 async def fgdc_font():
     return FileResponse(BASE_DIR / "FGDC.ttf", media_type="font/ttf")
 
+@app.get("/vehicle_log.jsonl", include_in_schema=False)
+async def vehicle_log_file():
+    path = BASE_DIR / "vehicle_log.jsonl"
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="log not found")
+    return FileResponse(path, media_type="application/json")
+
 # ---------------------------
 # LANDING PAGE
 # ---------------------------
@@ -1164,6 +1172,13 @@ async def landing_page():
 @app.get("/map")
 async def map_page():
     return HTMLResponse(MAP_HTML)
+
+# ---------------------------
+# REPLAY PAGE
+# ---------------------------
+@app.get("/replay")
+async def replay_page():
+    return HTMLResponse(REPLAY_HTML)
 
 # ---------------------------
 # DEBUG PAGE

--- a/index.html
+++ b/index.html
@@ -60,6 +60,13 @@
     </svg>
     <div>Live Map</div>
   </a>
+  <a class="card" href="/replay">
+    <svg viewBox="0 0 64 64" stroke="currentColor" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round">
+      <rect x="8" y="20" width="48" height="24" rx="4" />
+      <polygon points="28,32 28,24 40,32 28,40" fill="currentColor" stroke="none" />
+    </svg>
+    <div>Replay</div>
+  </a>
 </div>
 <div class="credit">proof of concept created by pat cox • phc6j@virginia.edu</div>
 </body>

--- a/log_vehicle_points.py
+++ b/log_vehicle_points.py
@@ -1,0 +1,45 @@
+import time, json
+from pathlib import Path
+import httpx
+
+API_URL = "https://uva.transloc.com/Services/JSONPRelay.svc/GetMapVehiclePoints?APIKey=8882812681&returnVehiclesNotAssignedToRoute=true"
+LOG_FILE = Path("vehicle_log.jsonl")
+INTERVAL_SEC = 4
+ONE_WEEK_MS = 7 * 24 * 3600 * 1000
+
+
+def prune_old_entries():
+    cutoff = int(time.time() * 1000) - ONE_WEEK_MS
+    if not LOG_FILE.exists():
+        return
+    lines: list[str] = []
+    with LOG_FILE.open() as f:
+        for line in f:
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if entry.get("ts", 0) >= cutoff:
+                lines.append(line)
+    with LOG_FILE.open("w") as f:
+        f.writelines(lines)
+
+def main():
+    with httpx.Client(timeout=20) as client:
+        while True:
+            ts = int(time.time()*1000)
+            r = client.get(API_URL)
+            r.raise_for_status()
+            data = r.json()
+            vehicles = data if isinstance(data, list) else data.get("d", [])
+            entry = {"ts": ts, "vehicles": vehicles}
+            with LOG_FILE.open("a") as f:
+                f.write(json.dumps(entry) + "\n")
+            prune_old_entries()
+            time.sleep(INTERVAL_SEC)
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        pass

--- a/replay.html
+++ b/replay.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Replay Map - Headway Guard</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
+  <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+  <style>
+    html, body { height: 100%; margin: 0; }
+    #map { height: calc(100% - 60px); width: 100%; }
+    #controls { position: fixed; bottom: 0; left: 0; width: 100%; height: 60px; background: rgba(255,255,255,0.9); display: flex; align-items: center; padding: 5px; box-sizing: border-box; }
+    #timeline { flex: 1; margin: 0 10px; }
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+  <div id="controls">
+    <button id="playBtn">Play</button>
+    <button id="pauseBtn">Pause</button>
+    <button id="ff2Btn">FF x2</button>
+    <button id="ff4Btn">FF x4</button>
+    <input type="range" id="timeline" min="0" value="0">
+    <span id="timeLabel"></span>
+  </div>
+  <script>
+    let map = L.map('map', { zoomControl: false }).setView([38.03799212281404, -78.50981502838886], 15);
+    L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+    }).addTo(map);
+
+    let logData = [];
+    let markers = {};
+    let timer = null;
+    let playbackSpeed = 1;
+    let routeColors = {};
+
+    function fetchRouteColors() {
+      const routesApiUrl = "https://uva.transloc.com/Services/JSONPRelay.svc/GetRoutes?APIKey=8882812681";
+      return fetch(routesApiUrl)
+        .then(r => r.json())
+        .then(data => { if (Array.isArray(data)) data.forEach(route => { routeColors[route.RouteID] = route.MapLineColor; }); });
+    }
+
+    function loadLog() {
+      fetch('vehicle_log.jsonl')
+        .then(r => r.text())
+        .then(text => {
+          logData = text.trim().split('\n').map(line => JSON.parse(line));
+          if (logData.length === 0) return;
+          const timeline = document.getElementById('timeline');
+          timeline.max = logData.length - 1;
+          showFrame(0);
+        });
+    }
+
+    function clearMarkers() {
+      for (let id in markers) { map.removeLayer(markers[id]); }
+      markers = {};
+    }
+
+    function showFrame(i) {
+      if (!logData[i]) return;
+      const entry = logData[i];
+      document.getElementById('timeline').value = i;
+      document.getElementById('timeLabel').textContent = new Date(entry.ts).toLocaleTimeString();
+      clearMarkers();
+      entry.vehicles.forEach(vehicle => {
+        const routeID = vehicle.RouteID || 0;
+        const pos = [vehicle.Latitude, vehicle.Longitude];
+        const isMoving = vehicle.GroundSpeed > 0;
+        const heading = vehicle.Heading;
+        const routeColor = routeColors[routeID] || '#000000';
+        const svgIcon = `
+          <svg width="40" height="80" viewBox="0 0 40 80" xmlns="http://www.w3.org/2000/svg">
+            <g>
+              <circle cx="20" cy="20" r="15" fill="${routeColor}" stroke="white" stroke-width="3" />
+              ${isMoving ? `
+                <line x1="20" y1="10" x2="20" y2="22" stroke="white" stroke-width="4" stroke-linecap="round" style="transform: rotate(${heading + 180}deg); transform-origin: 20px 20px" />
+                <polygon points="15,22 25,22 20,30" fill="white" style="transform: rotate(${heading + 180}deg); transform-origin: 20px 20px" />
+              ` : `
+                <rect x="14" y="14" width="12" height="12" fill="white" />
+              `}
+            </g>
+          </svg>`;
+        const busIcon = L.divIcon({ html: svgIcon, className: '', iconSize: [40,40], iconAnchor: [20,20] });
+        const marker = L.marker(pos, { icon: busIcon }).addTo(map);
+        markers[vehicle.VehicleID] = marker;
+      });
+    }
+
+    function advance() {
+      const timeline = document.getElementById('timeline');
+      let next = parseInt(timeline.value) + 1;
+      if (next >= logData.length) { pause(); return; }
+      showFrame(next);
+    }
+
+    function play() {
+      pause();
+      timer = setInterval(advance, 1000 / playbackSpeed);
+    }
+
+    function pause() {
+      if (timer) clearInterval(timer);
+      timer = null;
+    }
+
+    document.getElementById('playBtn').onclick = () => { playbackSpeed = 1; play(); };
+    document.getElementById('pauseBtn').onclick = pause;
+    document.getElementById('ff2Btn').onclick = () => { playbackSpeed = 2; play(); };
+    document.getElementById('ff4Btn').onclick = () => { playbackSpeed = 4; play(); };
+    document.getElementById('timeline').addEventListener('input', e => { pause(); showFrame(parseInt(e.target.value)); });
+
+    fetchRouteColors().then(loadLog);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `log_vehicle_points.py` to record vehicle snapshots for replay
- introduce `replay.html` with timeline and playback controls for logged data
- document replay workflow in README
- prune log entries older than one week to limit storage use
- serve replay page and log file at `/replay` and `/vehicle_log.jsonl`

## Testing
- `python -m py_compile app.py log_vehicle_points.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdee2a7f7483339bb6d433cbd42853