### PR TITLE
Serve replay page at /replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Open the [driver](http://localhost:8080/driver) and [dispatcher](http://localhos
 A lightweight logger and replay page are included for reviewing past vehicle
 positions. Run `python log_vehicle_points.py` to continuously poll TransLoc and
 append snapshots to `vehicle_log.jsonl` while pruning entries older than one
-week. Open `replay.html` in a browser to view the logged data with a timeline
-and playback controls (pause, play and fast forward).
+week. Open `/replay` in a running server to view the logged data with a
+timeline and playback controls (pause, play and fast forward).
 
 ## API
 

--- a/app.py
+++ b/app.py
@@ -568,6 +568,7 @@ SERVICECREW_HTML = (BASE_DIR / "servicecrew.html").read_text(encoding="utf-8")
 LANDING_HTML = (BASE_DIR / "index.html").read_text(encoding="utf-8")
 APICALLS_HTML = (BASE_DIR / "apicalls.html").read_text(encoding="utf-8")
 DEBUG_HTML = (BASE_DIR / "debug.html").read_text(encoding="utf-8")
+REPLAY_HTML = (BASE_DIR / "replay.html").read_text(encoding="utf-8")
 
 API_CALL_LOG = deque(maxlen=100)
 API_CALL_SUBS: set[asyncio.Queue] = set()
@@ -1151,6 +1152,10 @@ async def stream_api_calls():
 async def fgdc_font():
     return FileResponse(BASE_DIR / "FGDC.ttf", media_type="font/ttf")
 
+@app.get("/vehicle_log.jsonl", include_in_schema=False)
+async def vehicle_log_file():
+    return FileResponse(BASE_DIR / "vehicle_log.jsonl", media_type="application/json")
+
 # ---------------------------
 # LANDING PAGE
 # ---------------------------
@@ -1262,3 +1267,10 @@ async def dispatcher_page():
 @app.get("/apicalls")
 async def apicalls_page():
     return HTMLResponse(APICALLS_HTML)
+
+# ---------------------------
+# REPLAY PAGE
+# ---------------------------
+@app.get("/replay")
+async def replay_page():
+    return HTMLResponse(REPLAY_HTML)


### PR DESCRIPTION
## Summary
- add FastAPI endpoint to serve replay.html at `/replay`
- expose `vehicle_log.jsonl` for replay page
- document replay page URL in README

## Testing
- `python -m py_compile app.py log_vehicle_points.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bdf34a38e88333865d1310282fb6f8