### PR TITLE
Show date and time in replay slider

### DIFF
--- a/replay.html
+++ b/replay.html
@@ -61,8 +61,12 @@
     function showFrame(i) {
       if (!logData[i]) return;
       const entry = logData[i];
-      document.getElementById('timeline').value = i;
-      document.getElementById('timeLabel').textContent = new Date(entry.ts).toLocaleTimeString();
+      const timeline = document.getElementById('timeline');
+      const date = new Date(entry.ts);
+      const formatted = date.toLocaleString();
+      timeline.value = i;
+      timeline.title = formatted; // show date/time when hovering the slider
+      document.getElementById('timeLabel').textContent = formatted;
       clearMarkers();
       entry.vehicles.forEach(vehicle => {
         const routeID = vehicle.RouteID || 0;


### PR DESCRIPTION
## Summary
- Display full date and time for each replay frame
- Add slider tooltip showing the current frame's timestamp

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bdf4ce46e88333a244bfc733409b34