### PR TITLE
Handle missing vehicle log

### DIFF
--- a/app.py
+++ b/app.py
@@ -1154,7 +1154,10 @@ async def fgdc_font():
 
 @app.get("/vehicle_log.jsonl", include_in_schema=False)
 async def vehicle_log_file():
-    return FileResponse(BASE_DIR / "vehicle_log.jsonl", media_type="application/json")
+    path = BASE_DIR / "vehicle_log.jsonl"
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Log file not found")
+    return FileResponse(path, media_type="application/json")
 
 # ---------------------------
 # LANDING PAGE

--- a/replay.html
+++ b/replay.html
@@ -43,14 +43,16 @@
 
     function loadLog() {
       fetch('vehicle_log.jsonl')
-        .then(r => r.text())
+        .then(r => (r.ok ? r.text() : ''))
         .then(text => {
+          if (!text.trim()) return;
           logData = text.trim().split('\n').map(line => JSON.parse(line));
           if (logData.length === 0) return;
           const timeline = document.getElementById('timeline');
           timeline.max = logData.length - 1;
           showFrame(0);
-        });
+        })
+        .catch(err => console.error('Failed to load vehicle log', err));
     }
 
     function clearMarkers() {


### PR DESCRIPTION
## Summary
- return 404 instead of 500 when `vehicle_log.jsonl` is absent
- make replay page gracefully handle missing vehicle log

## Testing
- `python -m py_compile app.py`
- `uvicorn app:app --port 8000 &` then `curl -i http://127.0.0.1:8000/vehicle_log.jsonl`


------
https://chatgpt.com/codex/tasks/task_e_68bdf6c07bb0833391adb2f8b2029546