### PR TITLE
Ensure replay page fetches vehicle log from correct path

### DIFF
--- a/replay.html
+++ b/replay.html
@@ -42,7 +42,8 @@
     }
 
     function loadLog() {
-      fetch('vehicle_log.jsonl')
+      // Use absolute path so this works regardless of the current URL
+      fetch('/vehicle_log.jsonl')
         .then(r => (r.ok ? r.text() : ''))
         .then(text => {
           if (!text.trim()) return;


### PR DESCRIPTION
## Summary
- Fix replay page to fetch vehicle_log.jsonl using an absolute path so it loads correctly in deployed environments

## Testing
- `python -m py_compile app.py log_vehicle_points.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdfa1e49a88333a576fa17cc5c827e