### PR TITLE
Prevent route selector from overlapping replay timeline

### DIFF
--- a/replay.html
+++ b/replay.html
@@ -29,11 +29,11 @@
       position: fixed;
       top: 10px;
       right: 10px;
+      bottom: 110px;
       z-index: 1100;
       background: rgba(255, 255, 255, 0.9);
       padding: 10px;
       border-radius: 5px;
-      max-height: 90vh;
       overflow-y: auto;
       transition: transform 0.3s ease;
       font-size: 21px;
@@ -78,7 +78,7 @@
       user-select: none;
     }
     @media (max-width: 600px) {
-      #routeSelector { width: 80%; right: 10%; font-size: 18px; }
+      #routeSelector { width: 80%; right: 10%; font-size: 18px; bottom: 110px; }
       #routeSelector.hidden { transform: translateX(calc(100% + 20px)); }
       #routeSelector button { font-size: 20px; }
       #routeSelector label { font-size: 18px; }


### PR DESCRIPTION
## Summary
- Constrain the replay route selector between the top and timeline controls so it no longer overlaps
- Apply the same bottom constraint on small screens

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68be65c821b88333af4743fbf66a7581