### PR TITLE
Set replay end time to latest loaded log entry

### DIFF
--- a/replay.html
+++ b/replay.html
@@ -344,6 +344,9 @@
           const datePicker = document.getElementById('datePicker')._flatpickr;
           const first = playbackData[0] && new Date(playbackData[0].ts);
           if (first) { datePicker.setDate(first, true); }
+          const last = playbackData[playbackData.length - 1] && new Date(playbackData[playbackData.length - 1].ts);
+          const endPicker = document.getElementById('endTime')._flatpickr;
+          if (last && endPicker) { endPicker.setDate(last, true); }
           showFrame(0);
         })
         .catch(err => {


### PR DESCRIPTION
## Summary
- Default the end time selector to the newest timestamp in the replay log when the page loads

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68be68f460988333a43fc40b5c50dd60