### PR TITLE
Add labels to replay page date and time selectors

### DIFF
--- a/replay.html
+++ b/replay.html
@@ -94,8 +94,11 @@
   <div id="routeSelector"></div>
   <div id="routeSelectorTab" onclick="togglePanel()">&#9664;</div>
   <div id="controls">
+    <label for="datePicker">Date</label>
     <input id="datePicker" placeholder="Date">
+    <label for="startTime">From</label>
     <input id="startTime" placeholder="Start time">
+    <label for="endTime">To</label>
     <input id="endTime" placeholder="End time">
     <button id="loadRangeBtn">Load</button>
     <button id="pauseBtn">&#10074;&#10074;</button>


### PR DESCRIPTION
## Summary
- add accessible labels for date, start, and end time pickers on replay page

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be6d07fc3483338b7e7af8c7eb5be4