### PR TITLE
Default replay selectors collapsed and adjust tab arrows

### DIFF
--- a/replay.html
+++ b/replay.html
@@ -144,10 +144,10 @@
 </head>
 <body>
   <div id="map"></div>
-  <div id="busSelector"></div>
-  <div id="busSelectorTab" onclick="toggleBusPanel()">&#9654;</div>
-  <div id="routeSelector"></div>
-  <div id="routeSelectorTab" onclick="togglePanel()">&#9664;</div>
+  <div id="busSelector" class="hidden"></div>
+  <div id="busSelectorTab" onclick="toggleBusPanel()">&#9664;</div>
+  <div id="routeSelector" class="hidden"></div>
+  <div id="routeSelectorTab" onclick="togglePanel()">&#9654;</div>
   <div id="controls">
     <label for="datePicker">Date</label>
     <input id="datePicker" placeholder="Date">


### PR DESCRIPTION
## Summary
- Start route and bus selectors hidden on replay page to avoid mobile conflicts
- Swap tab arrow directions so tabs point outward when closed and inward when open

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be715873388333b7de91eeac98b071