### PR TITLE
Add Replay button to landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,13 @@
     </svg>
     <div>Live Map</div>
   </a>
+  <a class="card" href="/replay">
+    <svg viewBox="0 0 64 64" stroke="currentColor" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M32 12a20 20 0 1 1-20 20" />
+      <polyline points="12 24 12 12 24 12" />
+    </svg>
+    <div>Replay</div>
+  </a>
 </div>
 <div class="credit">proof of concept created by pat cox • phc6j@virginia.edu</div>
 </body>


### PR DESCRIPTION
## Summary
- add Replay button with circular arrow icon to landing page

## Testing
- `python -m py_compile app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be74362f44833381fdb05ab699231e