### PR TITLE
Show selected routes without active buses

### DIFF
--- a/map.html
+++ b/map.html
@@ -566,7 +566,7 @@
                           } else {
                               allRoutes[route.RouteID] = route;
                           }
-                          if (route.EncodedPolyline && route.IsRunning && (adminMode || route.IsVisibleOnMap) && isRouteSelected(route.RouteID)) {
+                          if (route.EncodedPolyline && (adminMode || route.IsVisibleOnMap) && isRouteSelected(route.RouteID)) {
                               const decodedPolyline = polyline.decode(route.EncodedPolyline);
                               let routeColor = getRouteColor(route.RouteID);
                               const routeLayer = L.polyline(decodedPolyline, {


### PR DESCRIPTION
## Summary
- Allow route polylines to render when manually selected even if no buses are currently running on that route

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68be7c2a109c8333a1890f539e685487