### PR TITLE
Hide opposite selector tab when other panel is open on replay map

### DIFF
--- a/replay.html
+++ b/replay.html
@@ -397,16 +397,18 @@
       if (willOpen) {
         panel.classList.remove('hidden');
         tab.innerHTML = '&#9654;';
-        if (routePanel && !routePanel.classList.contains('hidden')) {
-          routePanel.classList.add('hidden');
-          if (routeTab) routeTab.innerHTML = '&#9654;';
-          positionRouteTab();
+        if (routePanel) routePanel.classList.add('hidden');
+        if (routeTab) {
+          routeTab.innerHTML = '&#9654;';
+          routeTab.style.display = 'none';
         }
       } else {
         panel.classList.add('hidden');
         tab.innerHTML = '&#9664;';
+        if (routeTab) routeTab.style.display = 'block';
       }
       positionBusTab();
+      positionRouteTab();
     }
 
     function updateRouteSelector(activeRoutes) {
@@ -499,16 +501,18 @@
       if (willOpen) {
         panel.classList.remove('hidden');
         tab.innerHTML = '&#9664;';
-        if (busPanel && !busPanel.classList.contains('hidden')) {
-          busPanel.classList.add('hidden');
-          if (busTab) busTab.innerHTML = '&#9664;';
-          positionBusTab();
+        if (busPanel) busPanel.classList.add('hidden');
+        if (busTab) {
+          busTab.innerHTML = '&#9664;';
+          busTab.style.display = 'none';
         }
       } else {
         panel.classList.add('hidden');
         tab.innerHTML = '&#9654;';
+        if (busTab) busTab.style.display = 'block';
       }
       positionRouteTab();
+      positionBusTab();
     }
 
     function loadLog(retryDelay = 2000) {


### PR DESCRIPTION
## Summary
- Hide route selector tab whenever bus selector panel is open
- Hide bus selector tab whenever route selector panel is open
- Reposition tabs after toggling for consistent layout

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68be7cf38e5c8333a90022eaa513cd4f