### PR TITLE
Handle timezone offsets in MS AJAX timestamps

### DIFF
--- a/app.py
+++ b/app.py
@@ -169,11 +169,24 @@ def cumulative_distance(poly: List[Tuple[float,float]]) -> Tuple[List[float], fl
     return cum, cum[-1] if cum else 0.0
 
 def parse_msajax(s: Optional[str]) -> Optional[int]:
-    # e.g. "/Date(1693622400000-0400)/" -> 1693622400000
-    if not s: return None
+    """Parse a Microsoft AJAX timestamp into epoch milliseconds.
+
+    Handles optional timezone offsets such as "/Date(1693622400000-0400)/".
+    """
+    if not s:
+        return None
     try:
-        i = s.find("("); j = s.find(")")
-        return int(s[i+1:j].split("-")[0])
+        m = re.search(r"Date\((\d+)([-+]\d{4})?", s)
+        if not m:
+            return None
+        ms = int(m.group(1))
+        off = m.group(2)
+        if off:
+            sign = 1 if off[0] == '+' else -1
+            hrs = int(off[1:3])
+            mins = int(off[3:5])
+            ms += sign * (hrs * 60 + mins) * 60 * 1000
+        return ms
     except (ValueError, IndexError) as e:
         print(f"[parse_msajax] invalid timestamp {s!r}: {e}")
         return None

--- a/replay.html
+++ b/replay.html
@@ -576,8 +576,17 @@
     }
 
     function parseMsAjax(s) {
-      const m = /Date\((\d+)/.exec(s || '');
-      return m ? Number(m[1]) : null;
+      const m = /Date\((\d+)([-+]\d{4})?/.exec(s || '');
+      if (!m) return null;
+      let ms = Number(m[1]);
+      if (m[2]) {
+        const sign = m[2][0] === '-' ? -1 : 1;
+        const hrs = Number(m[2].slice(1,3));
+        const mins = Number(m[2].slice(3,5));
+        const offset = sign * (hrs * 60 + mins);
+        ms += offset * 60 * 1000;
+      }
+      return ms;
     }
 
     function showFrame(i) {


### PR DESCRIPTION
## Summary
- Correct parsing of Microsoft AJAX timestamps in both backend and replay page
- Adjust timestamps by embedded timezone offset to display accurate "Last Position Update" times

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68be80554d4083339668caaf1022190c