### PR TITLE
Handle TransLoc timestamps as Eastern time

### DIFF
--- a/apicalls.html
+++ b/apicalls.html
@@ -14,20 +14,10 @@ li{padding:4px 0;border-bottom:1px solid #2a3442;word-break:break-all;}
 <div class="credit">proof of concept created by pat cox • phc6j@virginia.edu</div>
 <script>
 const log=document.getElementById('log');
-function toEasternDate(ts){
-  const d=new Date(ts);
-  const y=d.getUTCFullYear();
-  const m1=new Date(Date.UTC(y,2,1));
-  const mSun=(7-m1.getUTCDay())%7;
-  const dstStart=Date.UTC(y,2,8+mSun,7,0,0);
-  const n1=new Date(Date.UTC(y,10,1));
-  const nSun=(7-n1.getUTCDay())%7;
-  const dstEnd=Date.UTC(y,10,1+nSun,6,0,0);
-  const off=(ts>=dstStart && ts<dstEnd)?-4:-5;
-  return new Date(ts+off*3600*1000);
-}
 function formatTime(ts){
-  return toEasternDate(ts).toLocaleTimeString('en-US',{hour:'numeric',minute:'2-digit',second:'2-digit',hour12:true});
+  return new Date(ts).toLocaleTimeString('en-US',{
+    timeZone:'America/New_York',
+    hour:'numeric',minute:'2-digit',second:'2-digit',hour12:true});
 }
 function add(item){
   const li=document.createElement('li');

--- a/app.py
+++ b/app.py
@@ -169,12 +169,13 @@ def cumulative_distance(poly: List[Tuple[float,float]]) -> Tuple[List[float], fl
     return cum, cum[-1] if cum else 0.0
 
 def parse_msajax(s: Optional[str]) -> Optional[int]:
-    # e.g. "/Date(1693622400000-0400)/" -> 1693622400000
-    if not s: return None
+    """Extract milliseconds from TransLoc's ``/Date(ms-offset)/`` format."""
+    if not s:
+        return None
     try:
-        i = s.find("("); j = s.find(")")
-        return int(s[i+1:j].split("-")[0])
-    except (ValueError, IndexError) as e:
+        m = re.search(r"/Date\((\d+)(?:[-+]\d{4})?\)/", s)
+        return int(m.group(1)) if m else None
+    except ValueError as e:
         print(f"[parse_msajax] invalid timestamp {s!r}: {e}")
         return None
 

--- a/replay.html
+++ b/replay.html
@@ -576,7 +576,7 @@
     }
 
     function parseMsAjax(s) {
-      const m = /Date\((\d+)/.exec(s || '');
+      const m = /Date\((\d+)(?:[-+]\d{4})?\)/.exec(s || '');
       return m ? Number(m[1]) : null;
     }
 
@@ -585,8 +585,7 @@
       currentFrameIndex = i;
       const entry = playbackData[i];
       const timeline = document.getElementById('timeline');
-      const date = new Date(entry.ts);
-      const formatted = date.toLocaleString();
+      const formatted = new Date(entry.ts).toLocaleString('en-US', {timeZone: 'America/New_York'});
       timeline.value = i;
       timeline.title = formatted; // show date/time when hovering the slider
       document.getElementById('timeLabel').textContent = `Showing: ${formatted}`;
@@ -597,7 +596,7 @@
         if (ms && ms > lastUpdateMs) lastUpdateMs = ms;
       }
       if (lastUpdateMs) {
-        const lastFormatted = new Date(lastUpdateMs).toLocaleString();
+        const lastFormatted = new Date(lastUpdateMs).toLocaleString('en-US', {timeZone: 'America/New_York'});
         document.getElementById('lastUpdateLabel').textContent = `Last Position Update: ${lastFormatted}`;
       } else {
         document.getElementById('lastUpdateLabel').textContent = '';


### PR DESCRIPTION
## Summary
- Robustly parse `/Date(ms-offset)/` timestamps and discard extraneous timezone suffixes.
- Display replay and API-call times in explicit America/New_York timezone.

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68be826e184883339002de5b700cf9eb