### PR TITLE
Use nested outline arrows for playback controls

### DIFF
--- a/replay.html
+++ b/replay.html
@@ -30,7 +30,6 @@
       background-color: #ccc;
     }
     #timeline { flex: 1; margin: 0 10px; }
-    .play-icons { letter-spacing: -4px; }
     #busSelector {
       width: 300px;
       position: fixed;
@@ -164,9 +163,25 @@
     <input id="endTime" placeholder="End time">
     <button id="loadRangeBtn">Load</button>
     <button id="pauseBtn">&#10074;&#10074;</button>
-    <button id="playBtn">&#9654;</button>
-    <button id="ff2Btn"><span class="play-icons">&#9654;&#9654;</span></button>
-    <button id="ff4Btn"><span class="play-icons">&#9654;&#9654;&#9654;&#9654;</span></button>
+    <button id="playBtn">
+      <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <polyline points="2,2 22,12 2,22" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+    </button>
+    <button id="ff2Btn">
+      <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <polyline points="2,2 22,12 2,22" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+        <polyline points="6,4 18,12 6,20" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+    </button>
+    <button id="ff4Btn">
+      <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <polyline points="2,2 22,12 2,22" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+        <polyline points="6,4 18,12 6,20" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+        <polyline points="10,6 14,12 10,18" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+        <polyline points="12,8 14,12 12,16" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+    </button>
     <input type="range" id="timeline" min="0" value="0">
     <span id="timeLabel"></span>
     <span id="lastUpdateLabel"></span>


### PR DESCRIPTION
## Summary
- Replace character-based play icons with SVG outlines
- Render 2x and 4x buttons as nested arrows for compact display

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf057c06b4833393bc8642ddb9ccae