### PR TITLE
Fix replay speed control labels

### DIFF
--- a/replay.html
+++ b/replay.html
@@ -29,6 +29,11 @@
     #controls button.selected {
       background-color: #ccc;
     }
+    #controls button.speed-btn {
+      font-family: sans-serif;
+      font-size: 16px;
+      font-weight: bold;
+    }
     #timeline { flex: 1; margin: 0 10px; }
     #busSelector {
       width: 300px;
@@ -163,25 +168,9 @@
     <input id="endTime" placeholder="End time">
     <button id="loadRangeBtn">Load</button>
     <button id="pauseBtn">&#10074;&#10074;</button>
-    <button id="playBtn">
-      <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-        <polyline points="2,2 22,12 2,22" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-      </svg>
-    </button>
-    <button id="ff2Btn">
-      <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-        <polyline points="2,2 22,12 2,22" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-        <polyline points="6,4 18,12 6,20" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-      </svg>
-    </button>
-    <button id="ff4Btn">
-      <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-        <polyline points="2,2 22,12 2,22" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-        <polyline points="6,4 18,12 6,20" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-        <polyline points="10,6 14,12 10,18" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-        <polyline points="12,8 14,12 12,16" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-      </svg>
-    </button>
+    <button id="playBtn" class="speed-btn">1x</button>
+    <button id="ff2Btn" class="speed-btn">2x</button>
+    <button id="ff4Btn" class="speed-btn">4x</button>
     <input type="range" id="timeline" min="0" value="0">
     <span id="timeLabel"></span>
     <span id="lastUpdateLabel"></span>


### PR DESCRIPTION
## Summary
- Replace broken playback SVG icons with clear text labels: 1x, 2x, 4x
- Add CSS to use standard fonts for speed buttons, ensuring digits render correctly

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bf075dc248833389eecefa2cc43616