### PR TITLE
Fix replay controls overlap on desktop

### DIFF
--- a/replay.html
+++ b/replay.html
@@ -18,7 +18,7 @@
     }
     html, body { height: 100%; margin: 0; font-family: 'FGDC', sans-serif; overflow: hidden; }
     #map { height: calc(100% - var(--controls-height)); width: 100%; }
-    #controls { position: fixed; bottom: 0; left: 0; width: 100%; background: rgba(255,255,255,0.9); display: flex; flex-wrap: wrap; align-items: center; padding: 5px; box-sizing: border-box; }
+    #controls { position: fixed; bottom: 0; left: 0; width: 100%; background: rgba(255,255,255,0.9); display: flex; flex-wrap: wrap; align-items: center; padding: 5px; box-sizing: border-box; z-index: 1000; }
     #controls > * { margin: 2px; }
     #controls input, #controls button {
       padding: 6px;
@@ -256,7 +256,14 @@
       const height = controls.offsetHeight;
       document.documentElement.style.setProperty('--controls-height', height + 'px');
     }
-    window.addEventListener('load', () => { positionBusTab(); positionRouteTab(); updateControlsHeight(); });
+    window.addEventListener('load', () => {
+      positionBusTab();
+      positionRouteTab();
+      updateControlsHeight();
+      if (document.fonts && document.fonts.ready) {
+        document.fonts.ready.then(updateControlsHeight);
+      }
+    });
     window.addEventListener('resize', () => { positionBusTab(); positionRouteTab(); updateControlsHeight(); });
 
     function updateSpeedButtons() {


### PR DESCRIPTION
## Summary
- ensure bottom control bar renders above Leaflet map
- recalc control height after fonts load to keep map from covering controls

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bf1165f1308333978a8701e3075957