### PR TITLE
Support kioskMode parameter and enable in service crew view

### DIFF
--- a/map.html
+++ b/map.html
@@ -156,6 +156,12 @@
       let kioskMode = false; // adminMode must = true for kisokMode to work
       let showSpeed = false; // default to showing block numbers
       let showBlockNumbers = true;
+
+      const params = new URLSearchParams(window.location.search);
+      const kioskParam = params.get('kioskMode');
+      if (kioskParam !== null) {
+        kioskMode = kioskParam.toLowerCase() === 'true';
+      }
       
       const outOfServiceRouteColor = '#000000';
       

--- a/servicecrew.html
+++ b/servicecrew.html
@@ -36,7 +36,7 @@
       <tbody></tbody>
     </table>
   </div>
-  <iframe id="mapframe" src="/map"></iframe>
+  <iframe id="mapframe" src="/map?kioskMode=true"></iframe>
 </div>
 <div class="credit">proof of concept created by pat cox • phc6j@virginia.edu</div>
 <script>


### PR DESCRIPTION
## Summary
- Read `kioskMode` from URL parameters in map view
- Load service crew map in kiosk mode by default

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf1a79440c83339f73846f5cdad800