### PR TITLE
Widen service crew map and adjust table layout

### DIFF
--- a/servicecrew.html
+++ b/servicecrew.html
@@ -9,10 +9,10 @@
   @font-face{font-family:'FGDC';src:url('FGDC.ttf') format('truetype');font-weight:normal;font-style:normal;}
   :root{ --bg:#0b0e11; --panel:#0f141a; --ink:#e8eef5; --muted:#9fb0c9; --line:#1f2630; --chip:#2a3442; }
   body{margin:0;background:var(--bg);color:var(--ink);font:14px/1.2 'FGDC',sans-serif;height:100vh;width:100vw;display:flex;flex-direction:column;}
-  table{width:100%;border-collapse:collapse;}
+  table{width:100%;border-collapse:collapse;table-layout:fixed;}
   th,td{border:1px solid var(--line);padding:2px 4px;text-align:left;}
   #layout{flex:1;display:flex;overflow:hidden;height:100vh;gap:8px;padding:0 8px;}
-  #table-wrapper{width:700px;overflow:hidden;display:flex;flex-direction:column;}
+  #table-wrapper{width:680px;overflow:hidden;display:flex;flex-direction:column;}
   #mapframe{border:1px solid var(--line);flex:1;height:100%;}
   .credit{position:fixed;bottom:8px;right:8px;font-size:12px;color:var(--muted,#9fb0c9);}
 </style>


### PR DESCRIPTION
## Summary
- Reduce service crew table wrapper to 680px to widen embedded map by ~20px
- Enable fixed table layout so columns fit new width

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf207258e4833397ccdcb7f4656657