### PR TITLE
Expand service crew map embed by 20px

### DIFF
--- a/servicecrew.html
+++ b/servicecrew.html
@@ -12,7 +12,7 @@
   table{width:100%;border-collapse:collapse;table-layout:fixed;}
   th,td{border:1px solid var(--line);padding:2px 4px;text-align:left;}
   #layout{flex:1;display:flex;overflow:hidden;height:100vh;gap:8px;padding:0 8px;}
-  #table-wrapper{width:680px;overflow:hidden;display:flex;flex-direction:column;}
+  #table-wrapper{width:660px;overflow:hidden;display:flex;flex-direction:column;}
   #mapframe{border:1px solid var(--line);flex:1;height:100%;}
   .credit{position:fixed;bottom:8px;right:8px;font-size:12px;color:var(--muted,#9fb0c9);}
 </style>


### PR DESCRIPTION
## Summary
- Expand service crew map iframe by reducing table wrapper width by 20px

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf2232f88c8333b50afa595f73276b