### PR TITLE
Adjust service crew layout widths

### DIFF
--- a/servicecrew.html
+++ b/servicecrew.html
@@ -12,7 +12,9 @@
   table{width:100%;border-collapse:collapse;table-layout:fixed;}
   th,td{border:1px solid var(--line);padding:2px 4px;text-align:left;}
   #layout{flex:1;display:flex;overflow:hidden;height:100vh;gap:8px;padding:0 8px;}
-  #table-wrapper{width:660px;overflow:hidden;display:flex;flex-direction:column;}
+  #table-wrapper{width:630px;overflow:hidden;display:flex;flex-direction:column;}
+  #bustable col.bus{width:5ch;}
+  #bustable col.miles{width:120px;}
   #mapframe{border:1px solid var(--line);flex:1;height:100%;}
   .credit{position:fixed;bottom:8px;right:8px;font-size:12px;color:var(--muted,#9fb0c9);}
 </style>
@@ -22,6 +24,11 @@
   <div id="table-wrapper">
     <div id="dateDisplay"></div>
     <table id="bustable">
+      <colgroup>
+        <col class="bus" />
+        <col />
+        <col class="miles" />
+      </colgroup>
       <thead>
         <tr>
           <th>Bus</th>


### PR DESCRIPTION
## Summary
- Widen service crew map by reducing table width
- Restrict bus column to five characters and let blocks column fill saved space

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf23e5f3288333823a49c2a7ca0d6e