### PR TITLE
Expand bus column width on Service Crew page

### DIFF
--- a/servicecrew.html
+++ b/servicecrew.html
@@ -13,7 +13,7 @@
   th,td{border:1px solid var(--line);padding:2px 4px;text-align:left;}
   #layout{flex:1;display:flex;overflow:hidden;height:100vh;gap:8px;padding:0 8px;}
   #table-wrapper{width:630px;overflow:hidden;display:flex;flex-direction:column;}
-  #bustable col.bus{width:5ch;}
+  #bustable col.bus{width:7ch;}
   #bustable col.miles{width:120px;}
   #mapframe{border:1px solid var(--line);flex:1;height:100%;}
   .credit{position:fixed;bottom:8px;right:8px;font-size:12px;color:var(--muted,#9fb0c9);}


### PR DESCRIPTION
## Summary
- widen bus column to improve readability on Service Crew table

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf25e205588333a0ccaf62751d235f