### PR TITLE
Enlarge Service Crew table font size

### DIFF
--- a/servicecrew.html
+++ b/servicecrew.html
@@ -9,7 +9,7 @@
   @font-face{font-family:'FGDC';src:url('FGDC.ttf') format('truetype');font-weight:normal;font-style:normal;}
   :root{ --bg:#0b0e11; --panel:#0f141a; --ink:#e8eef5; --muted:#9fb0c9; --line:#1f2630; --chip:#2a3442; }
   body{margin:0;background:var(--bg);color:var(--ink);font:14px/1.2 'FGDC',sans-serif;height:100vh;width:100vw;display:flex;flex-direction:column;}
-  table{width:100%;border-collapse:collapse;table-layout:fixed;}
+  table{width:100%;border-collapse:collapse;table-layout:fixed;font-size:16px;}
   th,td{border:1px solid var(--line);padding:2px 4px;text-align:left;}
   #layout{flex:1;display:flex;overflow:hidden;height:100vh;gap:8px;padding:0 8px;}
   #table-wrapper{width:630px;overflow:hidden;display:flex;flex-direction:column;}


### PR DESCRIPTION
## Summary
- increase the table font size to 16px on service crew view for improved readability

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf2867ed2c83339e7b31d021d855d9