### PR TITLE
Fetch overheight bus list dynamically on service crew page

### DIFF
--- a/servicecrew.html
+++ b/servicecrew.html
@@ -52,7 +52,7 @@ const dateSpan=document.getElementById('dateDisplay');
 const tbody=document.querySelector('#bustable tbody');
 let blockNameMap=new Map();
 
-let OVERHEIGHT_BUSES=['25131','25231','25331','25431','17132','14132','12432','18532'];
+let OVERHEIGHT_BUSES=[];
 
 function contrastColor(hex){
   if(!hex) return '#e8eef5';


### PR DESCRIPTION
## Summary
- Remove hardcoded overheight bus IDs from service crew page
- Continue loading list from `/v1/config` so admin settings drive highlighting

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bf3db141008333a06c4380b7d54417