### PR TITLE
Persist admin config to volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ Key endpoints exposed by the service:
 
 ## Configuration
 Runtime settings can be tuned with environment variables such as `TRANSLOC_BASE`, `TRANSLOC_KEY` and `OVERPASS_EP`.
-See `app.py` for the full list and default values.
+See `app.py` for the full list and default values. Changes made through the `/admin` page
+are persisted to `/data/config.json` on the `mileage_data` volume so they survive
+redeployments.
 
 ## Docker
 Build and run a containerised instance:


### PR DESCRIPTION
## Summary
- persist admin configuration to `/data/config.json` so updates survive redeploys
- document configuration persistence in README

## Testing
- `python -m py_compile app.py`
- `python - <<'PY'
import app
print('loaded', app.CONFIG_FILE)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68bf4fcc47948333af1a82b498b2a25f