### PR TITLE
Move feed errors into dispatcher header

### DIFF
--- a/dispatcher.html
+++ b/dispatcher.html
@@ -25,9 +25,9 @@ th,td{border-bottom:1px solid #1f2630;padding:10px;text-align:left}
 .warn{color:#ffe29a}.warn .dot{background:#ffbf47}
 .bad{color:#ffb0b0}.bad .dot{background:#ff6b6b}
 .hint{color:#9fb0c9}
-.banner{padding:8px 12px;display:none}
-.banner.error{background:#3b1f1f;color:#ffbfbf;border-bottom:1px solid #5a2b2b}
-.banner.info{background:#121922;color:#cfe1ff;border-bottom:1px solid #2a3442}
+.banner{display:none;margin-left:auto;padding:4px 8px;text-align:right;border-radius:4px}
+.banner.error{background:#3b1f1f;color:#ffbfbf;border:1px solid #5a2b2b}
+.banner.info{background:#121922;color:#cfe1ff;border:1px solid #2a3442}
 h2{font-size:18px;margin:16px 0 0}
 #layout{display:flex}
 @media(max-width:600px){
@@ -41,8 +41,8 @@ h2{font-size:18px;margin:16px 0 0}
   <label>Route: <select id="route"></select></label>
   <span id="target" class="chip">Target —</span>
   <span id="upd" class="chip">Updated — ago</span>
+  <div id="banner" class="banner info"></div>
 </header>
-<div id="banner" class="banner info"></div>
 <div id="layout">
   <main style="flex:1;padding:0 12px 16px">
     <h2>Headway Guard AntiBunching</h2>


### PR DESCRIPTION
## Summary
- Show feed errors within dispatcher header instead of between controls and content
- Style header banner with flex layout so it disappears completely when no error

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf51f61e70833388635ee385eabc5e