### PR TITLE
Display feed errors inline in dispatcher header

### DIFF
--- a/dispatcher.html
+++ b/dispatcher.html
@@ -8,6 +8,7 @@
 body{font:17px 'FGDC',system-ui;margin:0;background:#0b0e11;color:#e8eef5}
 header{display:flex;gap:10px;align-items:center;padding:12px 14px;border-bottom:1px solid #1f2630;flex-wrap:wrap}
 header h1{flex-basis:100%}
+ #controls{display:flex;gap:10px;align-items:center;position:relative;padding-right:200px}
 select{background:#10151c;color:#e8eef5;border:1px solid #2a3442;border-radius:10px;padding:8px 10px}
 .chip{display:inline-block;border:1px solid #2a3442;border-radius:999px;padding:2px 8px;margin-left:8px;color:#cfe1ff}
 table{width:100%;border-collapse:collapse;margin-top:8px}
@@ -25,7 +26,7 @@ th,td{border-bottom:1px solid #1f2630;padding:10px;text-align:left}
 .warn{color:#ffe29a}.warn .dot{background:#ffbf47}
 .bad{color:#ffb0b0}.bad .dot{background:#ff6b6b}
 .hint{color:#9fb0c9}
-.banner{display:none;margin-left:auto;padding:4px 8px;text-align:right;border-radius:4px}
+.banner{display:none;position:absolute;right:0;top:50%;transform:translateY(-50%);padding:4px 8px;text-align:right;border-radius:4px}
 .banner.error{background:#3b1f1f;color:#ffbfbf;border:1px solid #5a2b2b}
 .banner.info{background:#121922;color:#cfe1ff;border:1px solid #2a3442}
 h2{font-size:18px;margin:16px 0 0}
@@ -38,10 +39,12 @@ h2{font-size:18px;margin:16px 0 0}
 </style>
 <header>
   <h1 style="font-size:18px;margin:0">UTS Anti-Bunching — Dispatcher</h1>
-  <label>Route: <select id="route"></select></label>
-  <span id="target" class="chip">Target —</span>
-  <span id="upd" class="chip">Updated — ago</span>
-  <div id="banner" class="banner info"></div>
+  <div id="controls">
+    <label>Route: <select id="route"></select></label>
+    <span id="target" class="chip">Target —</span>
+    <span id="upd" class="chip">Updated — ago</span>
+    <div id="banner" class="banner info"></div>
+  </div>
 </header>
 <div id="layout">
   <main style="flex:1;padding:0 12px 16px">


### PR DESCRIPTION
## Summary
- keep header height stable by grouping route selector and status chips in new `#controls` container
- position feed error banner absolutely so messages appear to the right without shifting page layout

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf54f3083083338fb57f316438df30