### PR TITLE
Centralize TransLoc route data via backend

### DIFF
--- a/app.py
+++ b/app.py
@@ -747,6 +747,7 @@ async def startup():
                         block_groups = []
                         print(f"[updater] block fetch error: {e}")
                     async with state.lock:
+                        state.routes_raw = routes_raw
                         # Update complete routes & roster (all buses/all routes)
                         try:
                             state.routes_all = {}
@@ -1169,6 +1170,11 @@ async def dispatch_blocks():
         state.blocks_cache = res
         state.blocks_cache_ts = time.time()
         return res
+
+@app.get("/v1/transloc/routes")
+async def transloc_routes():
+    async with state.lock:
+        return getattr(state, "routes_raw", [])
 
 @app.get("/v1/transloc/anti_bunching")
 async def anti_bunching_raw():

--- a/replay.html
+++ b/replay.html
@@ -288,40 +288,21 @@
       }
     }
 
-    function fetchRouteColors() {
-      const routesApiUrl = "https://uva.transloc.com/Services/JSONPRelay.svc/GetRoutes?APIKey=8882812681";
-      return fetch(routesApiUrl)
+    function fetchRoutes() {
+      return fetch('/v1/transloc/routes')
         .then(r => r.json())
         .then(data => {
           if (Array.isArray(data)) {
             data.forEach(route => {
               routeColors[route.RouteID] = route.MapLineColor;
               allRoutes[route.RouteID] = route;
-            });
-          }
-        });
-    }
-
-    function fetchRouteInfo() {
-      const routePathsApiUrl = "https://uva.transloc.com/Services/JSONPRelay.svc/GetRoutesForMapWithScheduleWithEncodedLine?APIKey=8882812681";
-      return fetch(routePathsApiUrl)
-        .then(r => r.json())
-        .then(data => {
-          if (Array.isArray(data)) {
-            data.forEach(route => {
-              if (allRoutes[route.RouteID]) {
-                allRoutes[route.RouteID].InfoText = route.InfoText;
-                allRoutes[route.RouteID].EncodedPolyline = route.EncodedPolyline;
-              } else {
-                allRoutes[route.RouteID] = route;
-              }
               if (route.EncodedPolyline) {
                 allRoutes[route.RouteID].decodedPolyline = polyline.decode(route.EncodedPolyline);
               }
             });
           }
         })
-        .catch(err => console.error('Error fetching route info', err));
+        .catch(err => console.error('Error fetching routes', err));
     }
 
     function getContrastColor(hexColor) {
@@ -772,7 +753,7 @@
     document.getElementById('loadRangeBtn').onclick = () => { pause(); applyRange(); };
 
     pause();
-    fetchRouteColors().then(fetchRouteInfo).then(loadLog);
+    fetchRoutes().then(loadLog);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- cache raw TransLoc route data in the updater
- expose `/v1/transloc/routes` endpoint for clients
- replay page pulls route info from backend instead of TransLoc API

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf6126a61c833394903fd0b55e406c