### PR TITLE
Add label toggle and smooth 10x playback

### DIFF
--- a/replay.html
+++ b/replay.html
@@ -220,6 +220,8 @@
     let activeBuses = new Set();
     let showSpeed = true; // default to showing speed
     let showBlockNumbers = false;
+    let showLabels = true;
+    let lastPositions = {};
     let currentFrameIndex = 0;
     const outOfServiceRouteColor = '#000000';
     let isPlaying = false;
@@ -347,6 +349,13 @@
       refreshReplay();
     }
 
+    function toggleLabels() {
+      showLabels = !showLabels;
+      const btn = document.getElementById('toggleLabelsButton');
+      if (btn) btn.innerHTML = showLabels ? 'Hide Labels' : 'Show Labels';
+      refreshReplay();
+    }
+
     function updateBusSelector(activeBusesSet) {
       const container = document.getElementById('busSelector');
       if (!container) return;
@@ -423,7 +432,10 @@
       const container = document.getElementById('routeSelector');
       if (!container) return;
       let html = "";
-      html += "<div style='margin-bottom:10px;'><button id='toggleDisplayButton' onclick='toggleSpeedOrBlock()'>" + (showSpeed ? "Show Block Numbers" : "Show Speed") + "</button></div>";
+      html += "<div style='margin-bottom:10px;'>" +
+        "<button id='toggleLabelsButton' onclick='toggleLabels()'>" + (showLabels ? "Hide Labels" : "Show Labels") + "</button>" +
+        "<button id='toggleDisplayButton' onclick='toggleSpeedOrBlock()'>" + (showSpeed ? "Show Block Numbers" : "Show Speed") + "</button>" +
+        "</div>";
       html += "<h3>Select Routes</h3>" +
         "<button onclick='selectAllRoutes()'>Select All</button>" +
         "<button onclick='deselectAllRoutes()'>Deselect All</button><br/><br/>";
@@ -628,10 +640,17 @@
       drawRoutes();
       clearMarkers();
       const blocks = entry.blocks || {};
+      const seen = new Set();
+      let smoothDuration = 0;
+      if (playbackSpeed === 10 && i > 0) {
+        smoothDuration = (new Date(playbackData[i].ts) - new Date(playbackData[i-1].ts)) / playbackSpeed;
+      }
       entry.vehicles.forEach(vehicle => {
         const routeID = vehicle.RouteID || 0;
         if (!isRouteSelected(routeID) || !isBusSelected(vehicle.VehicleID)) return;
+        seen.add(vehicle.VehicleID);
         const pos = [vehicle.Latitude, vehicle.Longitude];
+        const startPos = (playbackSpeed === 10 && lastPositions[vehicle.VehicleID]) ? lastPositions[vehicle.VehicleID] : pos;
         const isMoving = vehicle.GroundSpeed > 0;
         const heading = vehicle.Heading;
         const routeColor = getRouteColor(routeID);
@@ -648,10 +667,16 @@
             </g>
           </svg>`;
         const busIcon = L.divIcon({ html: svgIcon, className: '', iconSize: [40,40], iconAnchor: [20,20] });
-        const marker = L.marker(pos, { icon: busIcon }).addTo(map);
+        const marker = L.marker(startPos, { icon: busIcon }).addTo(map);
+        if (playbackSpeed === 10 && smoothDuration > 0) {
+          marker._icon.style.transition = `transform ${smoothDuration}ms linear`;
+          setTimeout(() => marker.setLatLng(pos), 0);
+        } else {
+          marker.setLatLng(pos);
+        }
         markers[vehicle.VehicleID] = marker;
 
-        if (showSpeed) {
+        if (showLabels && showSpeed) {
           const speedBubble = `
             <svg width="60" height="20" viewBox="0 0 60 20" xmlns="http://www.w3.org/2000/svg">
               <g>
@@ -660,10 +685,17 @@
               </g>
             </svg>`;
           const speedIcon = L.divIcon({ html: speedBubble, className: '', iconSize: [60,20], iconAnchor: [30,-15] });
-          speedMarkers[vehicle.VehicleID] = L.marker(pos, { icon: speedIcon, interactive: false }).addTo(map);
+          const sm = L.marker(startPos, { icon: speedIcon, interactive: false }).addTo(map);
+          if (playbackSpeed === 10 && smoothDuration > 0) {
+            sm._icon.style.transition = `transform ${smoothDuration}ms linear`;
+            setTimeout(() => sm.setLatLng(pos), 0);
+          } else {
+            sm.setLatLng(pos);
+          }
+          speedMarkers[vehicle.VehicleID] = sm;
         }
 
-        if (showBlockNumbers) {
+        if (showLabels && showBlockNumbers) {
           const blockName = blocks[vehicle.VehicleID];
           if (blockName && blockName.includes('[')) {
             const ctx = document.createElement('canvas').getContext('2d');
@@ -678,12 +710,19 @@
                 </g>
               </svg>`;
             const blockIcon = L.divIcon({ html: blockBubble, className: '', iconSize: [blockWidth,30], iconAnchor: [blockWidth/2,-13] });
-            blockMarkers[vehicle.VehicleID] = L.marker(pos, { icon: blockIcon, interactive: false }).addTo(map);
+            const bm = L.marker(startPos, { icon: blockIcon, interactive: false }).addTo(map);
+            if (playbackSpeed === 10 && smoothDuration > 0) {
+              bm._icon.style.transition = `transform ${smoothDuration}ms linear`;
+              setTimeout(() => bm.setLatLng(pos), 0);
+            } else {
+              bm.setLatLng(pos);
+            }
+            blockMarkers[vehicle.VehicleID] = bm;
           }
         }
 
         const busName = vehicle.Name ? vehicle.Name.slice(0, -2) : '';
-        if (busName) {
+        if (showLabels && busName) {
           const bubbleWidth = Math.max(40, busName.length * 10);
           const nameBubble = `
             <svg width="${bubbleWidth}" height="30" viewBox="0 0 ${bubbleWidth} 30" xmlns="http://www.w3.org/2000/svg">
@@ -693,10 +732,23 @@
               </g>
             </svg>`;
           const nameIcon = L.divIcon({ html: nameBubble, className: '', iconSize: [bubbleWidth,30], iconAnchor: [bubbleWidth/2,40] });
-          const nameMarker = L.marker(pos, { icon: nameIcon, interactive: false }).addTo(map);
-          nameMarkers[vehicle.VehicleID] = nameMarker;
+          const nm = L.marker(startPos, { icon: nameIcon, interactive: false }).addTo(map);
+          if (playbackSpeed === 10 && smoothDuration > 0) {
+            nm._icon.style.transition = `transform ${smoothDuration}ms linear`;
+            setTimeout(() => nm.setLatLng(pos), 0);
+          } else {
+            nm.setLatLng(pos);
+          }
+          nameMarkers[vehicle.VehicleID] = nm;
         }
+
+        lastPositions[vehicle.VehicleID] = pos;
       });
+      for (let id in lastPositions) {
+        if (!seen.has(Number(id))) {
+          delete lastPositions[id];
+        }
+      }
     }
 
     function scheduleNext() {


### PR DESCRIPTION
## Summary
- add route selector control to hide bus names and block/speed labels
- smooth bus marker transitions when playing at 10x speed

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf64bd05fc8333bb378cd91e03c529