### PR TITLE
Fix service crew date to use Charlottesville timezone

### DIFF
--- a/servicecrew.html
+++ b/servicecrew.html
@@ -108,7 +108,10 @@ async function loadBlockMap(){
   }catch(_){blockNameMap=new Map();}
 }
 
-function todayStr(){return new Date().toISOString().split('T')[0];}
+function todayStr(){
+  // Ensure date is computed in Charlottesville's timezone
+  return new Date().toLocaleDateString('en-CA',{timeZone:'America/New_York'});
+}
 async function fetchData(){
   const date=todayStr();
   dateSpan.textContent=`Date: ${date}`;


### PR DESCRIPTION
## Summary
- ensure service crew page calculates dates in Charlottesville (America/New_York) timezone

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf7db2db848333bec59158d5a0bd29