### PR TITLE
Add ridership report page

### DIFF
--- a/app.py
+++ b/app.py
@@ -610,6 +610,7 @@ LANDING_HTML = (BASE_DIR / "index.html").read_text(encoding="utf-8")
 APICALLS_HTML = (BASE_DIR / "apicalls.html").read_text(encoding="utf-8")
 DEBUG_HTML = (BASE_DIR / "debug.html").read_text(encoding="utf-8")
 REPLAY_HTML = (BASE_DIR / "replay.html").read_text(encoding="utf-8")
+RIDERSHIP_HTML = (BASE_DIR / "ridership.html").read_text(encoding="utf-8")
 
 API_CALL_LOG = deque(maxlen=100)
 API_CALL_SUBS: set[asyncio.Queue] = set()
@@ -1473,6 +1474,13 @@ async def dispatcher_page():
 @app.get("/apicalls")
 async def apicalls_page():
     return HTMLResponse(APICALLS_HTML)
+
+# ---------------------------
+# RIDERSHIP PAGE
+# ---------------------------
+@app.get("/ridership")
+async def ridership_page():
+    return HTMLResponse(RIDERSHIP_HTML)
 
 # ---------------------------
 # REPLAY PAGE

--- a/ridership.html
+++ b/ridership.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>Ridership Report - Headway Guard</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<link rel="preload" href="FGDC.ttf" as="font" type="font/ttf" crossorigin />
+<style>
+  @font-face{font-family:'FGDC';src:url('FGDC.ttf') format('truetype');font-weight:normal;font-style:normal;}
+  :root{ --bg:#0b0e11; --panel:#0f141a; --ink:#e8eef5; --muted:#9fb0c9; --line:#1f2630; }
+  body{margin:0;background:var(--bg);color:var(--ink);font:16px 'FGDC',sans-serif;padding:20px;}
+  table{border-collapse:collapse;width:100%;max-width:800px;}
+  th,td{border:1px solid var(--line);padding:4px;text-align:center;}
+  textarea{width:100%;height:60px;}
+  input[type=date]{margin-right:8px;}
+</style>
+</head>
+<body>
+<h1>Ridership Report</h1>
+<label>Date: <input type="date" id="datePicker"></label><button id="loadBtn">Load</button>
+<table id="ridershipTable">
+  <tr><th>Overall Total:</th><td id="overallRedAM"></td><td id="overallRedPM"></td><td id="overallBlue"></td><td colspan="4"></td></tr>
+  <tr><td colspan="8"><textarea id="notes" placeholder="Service Notes..."></textarea></td></tr>
+  <tr><th colspan="8">Scott Stadium West Parking Lots (Red Line)</th></tr>
+  <tr><th>Total Passengers:</th><td id="totalRedAM"></td><td id="totalRedPM"></td><td colspan="5"></td></tr>
+  <tr><th colspan="8">AM Numbers</th></tr>
+  <tr><th>5-6AM</th><th>6-7AM</th><th>AM Total</th><td colspan="5"></td></tr>
+  <tr><td id="am_5_6"></td><td id="am_6_7"></td><td id="am_total"></td><td colspan="5"></td></tr>
+  <tr><th colspan="8">PM Numbers</th></tr>
+  <tr><th>2:30PM-3PM</th><th>3-4PM</th><th>4-5PM</th><th>5-6PM</th><th>6-7PM</th><th>7-8PM</th><th>PM Total</th><th>Day Total</th></tr>
+  <tr><td id="pm_230_3"></td><td id="pm_3_4"></td><td id="pm_4_5"></td><td id="pm_5_6"></td><td id="pm_6_7"></td><td id="pm_7_8"></td><td id="pm_total"></td><td id="day_total"></td></tr>
+</table>
+<script>
+const dateInput=document.getElementById('datePicker');
+const today=new Date().toISOString().split('T')[0];
+dateInput.value=today;
+
+document.getElementById('loadBtn').addEventListener('click',load);
+window.addEventListener('load',load);
+
+function load(){
+  const date=new Date(dateInput.value);
+  const end=new Date(date);
+  end.setDate(end.getDate()+1);
+  const startStr=(date.getMonth()+1)+"/"+date.getDate()+"/"+date.getFullYear();
+  const endStr=(end.getMonth()+1)+"/"+end.getDate()+"/"+end.getFullYear();
+  const url=`https://uva.transloc.com/Services/JSONPRelay.svc/GetRidershipData?startDate=${encodeURIComponent(startStr)}&endDate=${encodeURIComponent(endStr)}`;
+  fetch(url).then(r=>r.json()).then(render).catch(err=>{
+    console.error(err);
+  });
+}
+
+function render(data){
+  const overall={'Red Line AM':0,'Red Line PM':0,'Blue Line':0};
+  const stopName='Scott Stadium West Parking Lots';
+  const stopTotals={'Red Line AM':0,'Red Line PM':0};
+  const amSlots={'5-6':0,'6-7':0};
+  const pmSlots={'14_30-15':0,'15-16':0,'16-17':0,'17-18':0,'18-19':0,'19-20':0};
+  data.forEach(rec=>{
+    const route=rec.Route;
+    const entries=Number(rec.Entries)||0;
+    if(overall[route]!==undefined){overall[route]+=entries;}
+    if((route==='Red Line AM'||route==='Red Line PM') && rec.RouteStop===stopName){
+      stopTotals[route]+=entries;
+      const t=new Date(rec.ClientTime);
+      const h=t.getHours();
+      const m=t.getMinutes();
+      if(h===5){amSlots['5-6']+=entries;}
+      else if(h===6){amSlots['6-7']+=entries;}
+      const mins=h*60+m;
+      if(mins>=14*60+30 && mins<15*60) pmSlots['14_30-15']+=entries;
+      else if(mins>=15*60 && mins<16*60) pmSlots['15-16']+=entries;
+      else if(mins>=16*60 && mins<17*60) pmSlots['16-17']+=entries;
+      else if(mins>=17*60 && mins<18*60) pmSlots['17-18']+=entries;
+      else if(mins>=18*60 && mins<19*60) pmSlots['18-19']+=entries;
+      else if(mins>=19*60 && mins<20*60) pmSlots['19-20']+=entries;
+    }
+  });
+  document.getElementById('overallRedAM').textContent=overall['Red Line AM'];
+  document.getElementById('overallRedPM').textContent=overall['Red Line PM'];
+  document.getElementById('overallBlue').textContent=overall['Blue Line'];
+  document.getElementById('totalRedAM').textContent=stopTotals['Red Line AM'];
+  document.getElementById('totalRedPM').textContent=stopTotals['Red Line PM'];
+  document.getElementById('am_5_6').textContent=amSlots['5-6'];
+  document.getElementById('am_6_7').textContent=amSlots['6-7'];
+  const amTotal=amSlots['5-6']+amSlots['6-7'];
+  document.getElementById('am_total').textContent=amTotal;
+  document.getElementById('pm_230_3').textContent=pmSlots['14_30-15'];
+  document.getElementById('pm_3_4').textContent=pmSlots['15-16'];
+  document.getElementById('pm_4_5').textContent=pmSlots['16-17'];
+  document.getElementById('pm_5_6').textContent=pmSlots['17-18'];
+  document.getElementById('pm_6_7').textContent=pmSlots['18-19'];
+  document.getElementById('pm_7_8').textContent=pmSlots['19-20'];
+  const pmTotal=Object.values(pmSlots).reduce((a,b)=>a+b,0);
+  document.getElementById('pm_total').textContent=pmTotal;
+  document.getElementById('day_total').textContent=pmTotal+amTotal;
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new ridership.html page displaying route totals and time slot breakdowns for a selected date
- wire up /ridership endpoint in app.py to serve the report

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf905a29448333b2e1c8452e36b176