### PR TITLE
Fix ridership date range from selected date

### DIFF
--- a/ridership.html
+++ b/ridership.html
@@ -47,10 +47,11 @@ document.getElementById('loadBtn').addEventListener('click',load);
 window.addEventListener('load',load);
 
 function load(){
-  const date=new Date(dateInput.value);
-  const end=new Date(date);
-  end.setDate(end.getDate()+1);
-  const startStr=(date.getMonth()+1)+"/"+date.getDate()+"/"+date.getFullYear();
+  const [y,m,d]=dateInput.value.split('-').map(Number);
+  const start=new Date(y,m-1,d);
+  const end=new Date(start);
+  end.setDate(start.getDate()+1);
+  const startStr=(start.getMonth()+1)+"/"+start.getDate()+"/"+start.getFullYear();
   const endStr=(end.getMonth()+1)+"/"+end.getDate()+"/"+end.getFullYear();
   const url=`https://uva.transloc.com/Services/JSONPRelay.svc/GetRidershipData?startDate=${encodeURIComponent(startStr)}&endDate=${encodeURIComponent(endStr)}`;
   fetch(url).then(r=>r.json()).then(render).catch(err=>{


### PR DESCRIPTION
## Summary
- Parse selected date locally to avoid timezone shifts
- Always set API endDate to one day after selected startDate

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf9a9b39448333a225e70f9be02719