### PR TITLE
Fix ridership default date to use local timezone

### DIFF
--- a/ridership.html
+++ b/ridership.html
@@ -40,8 +40,9 @@
 </table>
 <script>
 const dateInput=document.getElementById('datePicker');
-const today=new Date().toISOString().split('T')[0];
-dateInput.value=today;
+const today=new Date();
+today.setMinutes(today.getMinutes()-today.getTimezoneOffset());
+dateInput.value=today.toISOString().split('T')[0];
 
 document.getElementById('loadBtn').addEventListener('click',load);
 window.addEventListener('load',load);


### PR DESCRIPTION
## Summary
- correct ridership default date to use local timezone instead of UTC

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf9cd99c0483339b15473f18e8e2aa