### PR TITLE
Use Charlottesville timezone for replay default date

### DIFF
--- a/replay.html
+++ b/replay.html
@@ -185,7 +185,7 @@
 
     flatpickr("#datePicker", {
       dateFormat: "Y-m-d",
-      defaultDate: new Date().toISOString().slice(0,10)
+      defaultDate: new Date().toLocaleDateString('en-CA', { timeZone: 'America/New_York' })
     });
     flatpickr("#startTime", {
       enableTime: true,


### PR DESCRIPTION
## Summary
- Ensure replay date picker uses Charlottesville's local date by default

## Testing
- `pytest`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfa1573c288333aeb41da5af3393f2