### PR TITLE
Ensure replay slider loads necessary logs

### DIFF
--- a/replay.html
+++ b/replay.html
@@ -574,7 +574,8 @@
     }
 
     async function ensureLoaded(ms) {
-      if (!playbackTimes.length || ms > playbackTimes[playbackTimes.length - 1]) {
+      const key = hourKey(ms);
+      if (!loadedHours.has(key)) {
         await loadHour(ms);
       }
     }


### PR DESCRIPTION
## Summary
- Load the appropriate hour of logs when the timeline slider moves in replay view so playback updates correctly.

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfa272cfdc8333904b64ba0e37f50d