### PR TITLE
Increase service crew table readability

### DIFF
--- a/servicecrew.html
+++ b/servicecrew.html
@@ -9,17 +9,17 @@
   @font-face{font-family:'FGDC';src:url('FGDC.ttf') format('truetype');font-weight:normal;font-style:normal;}
   :root{ --bg:#0b0e11; --panel:#0f141a; --ink:#e8eef5; --muted:#9fb0c9; --line:#1f2630; --chip:#2a3442; }
   body{margin:0;background:var(--bg);color:var(--ink);font:14px/1.2 'FGDC',sans-serif;height:100vh;width:100vw;display:flex;flex-direction:column;}
-  table{width:100%;border-collapse:collapse;table-layout:fixed;font-size:16px;}
-  th,td{border:1px solid var(--line);padding:2px 4px;text-align:left;}
+  table{width:100%;border-collapse:collapse;table-layout:fixed;font-size:32px;}
+  th,td{border:1px solid var(--line);padding:4px 8px;text-align:left;}
   #bustable th:nth-child(1), #bustable td:nth-child(1),
   #bustable th:nth-child(3), #bustable td:nth-child(3){
     text-align:center;
   }
   #layout{flex:1;display:flex;overflow:hidden;height:100vh;gap:8px;padding:0 8px;}
-  #table-wrapper{width:630px;overflow:hidden;display:flex;flex-direction:column;}
+  #table-wrapper{width:876px;overflow:hidden;display:flex;flex-direction:column;}
   #bustable col.bus{width:7ch;}
   #bustable col.miles{width:120px;}
-  #mapframe{border:1px solid var(--line);flex:1;height:100%;}
+  #mapframe{border:1px solid var(--line);width:876px;height:100%;flex:0 0 876px;}
   .credit{position:fixed;bottom:8px;right:8px;font-size:12px;color:var(--muted,#9fb0c9);}
   td.high-mileage{background:red;}
 </style>


### PR DESCRIPTION
## Summary
- Enlarge service crew table font and cell padding for improved visibility
- Widen table and shrink map frame to 876px so both elements match

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfa3ac6eb88333b8964a0cf313230c