### PR TITLE
Add service crew refresh broadcast

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -13,6 +13,7 @@ button{margin-top:12px;padding:10px 14px;border-radius:6px;border:1px solid #2a3
 <h1>Headway Guard Admin</h1>
 <form id="cfg"></form>
 <button id="save">Save</button>
+<button id="forceRefresh">Force Refresh</button>
 <div class="credit">proof of concept created by pat cox • phc6j@virginia.edu</div>
 <script>
 async function load(){
@@ -51,5 +52,8 @@ async function save(){
   alert('Saved!');
 }
 document.getElementById('save').onclick=save;
+document.getElementById('forceRefresh').onclick=()=>{
+  fetch('/v1/servicecrew/refresh',{method:'POST'});
+};
 load();
 </script>

--- a/servicecrew.html
+++ b/servicecrew.html
@@ -143,15 +143,17 @@ async function fetchData(){
     tbody.appendChild(tr);
   }
 }
-async function init(){
-  await loadConfig();
-  await loadBlockMap();
-  fetchData();
-  setInterval(fetchData,30000);
-  setInterval(loadBlockMap,30000);
-  setInterval(loadConfig,30000);
-}
-init();
-</script>
-</body>
-</html>
+  async function init(){
+    await loadConfig();
+    await loadBlockMap();
+    fetchData();
+    setInterval(fetchData,30000);
+    setInterval(loadBlockMap,30000);
+    setInterval(loadConfig,30000);
+  }
+  init();
+  const svcES=new EventSource('/v1/stream/servicecrew_refresh');
+  svcES.onmessage=()=>location.reload();
+  </script>
+  </body>
+  </html>


### PR DESCRIPTION
## Summary
- Broadcast service crew refresh events via new SSE endpoint and POST trigger
- Auto-reload service crew view when refresh events arrive
- Add admin control to force service crew page refresh

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfa4b8b5f08333b02682d0b5aa84bd