### PR TITLE
Adjust service crew table header

### DIFF
--- a/servicecrew.html
+++ b/servicecrew.html
@@ -11,6 +11,7 @@
   body{margin:0;background:var(--bg);color:var(--ink);font:14px/1.2 'FGDC',sans-serif;height:100vh;width:100vw;display:flex;flex-direction:column;}
   table{width:100%;border-collapse:collapse;table-layout:fixed;font-size:32px;}
   th,td{border:1px solid var(--line);padding:4px 8px;text-align:left;}
+  #bustable th{font-size:24px;white-space:nowrap;}
   #bustable th:nth-child(1), #bustable td:nth-child(1),
   #bustable th:nth-child(3), #bustable td:nth-child(3){
     text-align:center;
@@ -38,7 +39,7 @@
         <tr>
           <th>Bus</th>
           <th>Blocks</th>
-          <th>Total Miles Today</th>
+          <th>Miles Today</th>
         </tr>
       </thead>
       <tbody></tbody>


### PR DESCRIPTION
## Summary
- Shrink service crew table header font size and prevent wrapping
- Rename "Total Miles Today" column header to "Miles Today"

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bfa56eead88333a6382234aad29643