### PR TITLE
Adjust service crew map layout

### DIFF
--- a/servicecrew.html
+++ b/servicecrew.html
@@ -20,7 +20,7 @@
   #table-wrapper{width:876px;overflow:hidden;display:flex;flex-direction:column;}
   #bustable col.bus{width:7ch;}
   #bustable col.miles{width:120px;}
-  #mapframe{border:1px solid var(--line);width:876px;height:100%;flex:0 0 876px;}
+  #mapframe{border:1px solid var(--line);height:918px;margin-top:162px;flex:1;}
   .credit{position:fixed;bottom:8px;right:8px;font-size:12px;color:var(--muted,#9fb0c9);}
   td.high-mileage{background:red;}
 </style>


### PR DESCRIPTION
## Summary
- Resize service crew map to fill remaining page width beside table
- Set map frame to 918px height with 162px top offset

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bfa7588ed08333afb6f54a3003f4ce