### PR TITLE
Use #24234b for service crew page background

### DIFF
--- a/servicecrew.html
+++ b/servicecrew.html
@@ -7,7 +7,7 @@
 <link rel="preload" href="FGDC.ttf" as="font" type="font/ttf" crossorigin />
 <style>
   @font-face{font-family:'FGDC';src:url('FGDC.ttf') format('truetype');font-weight:normal;font-style:normal;}
-  :root{ --bg:#0b0e11; --panel:#0f141a; --ink:#e8eef5; --muted:#9fb0c9; --line:#24234b; --chip:#2a3442; }
+  :root{ --bg:#24234b; --panel:#24234b; --ink:#e8eef5; --muted:#9fb0c9; --line:#24234b; --chip:#2a3442; }
   body{margin:0;background:var(--bg);color:var(--ink);font:14px/1.2 'FGDC',sans-serif;height:100vh;width:100vw;display:flex;flex-direction:column;}
   table{width:100%;border-collapse:collapse;table-layout:fixed;font-size:32px;background:#24234b;}
   th,td{border:1px solid var(--line);padding:4px 8px;text-align:left;}


### PR DESCRIPTION
## Summary
- Replace default dark backgrounds with #24234b on the service crew page

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bfb07aec9c83338e89ed19ae2fd972