### PR TITLE
Add device registration system for arrivals display

### DIFF
--- a/arrivalsdisplay.html
+++ b/arrivalsdisplay.html
@@ -474,19 +474,49 @@ function updateArrivalTable(data, vc){
 }
 
 /* ===================== Helpers ===================== */
-function getStopIDFromURL(){ const p=new URLSearchParams(window.location.search); return p.get('stopID') || '54'; }
+async function generateDeviceID(){
+  const seed = [
+    navigator.userAgent,
+    navigator.language,
+    screen.width + 'x' + screen.height,
+    screen.colorDepth,
+    navigator.hardwareConcurrency
+  ].join('|');
+  const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(seed));
+  const hex = Array.from(new Uint8Array(buf)).map(b=>b.toString(16).padStart(2,'0')).join('');
+  return hex.slice(0,16);
+}
+async function resolveStopID(){
+  const id = await generateDeviceID();
+  try{
+    const r = await axios.get('/device-stop',{params:{id}});
+    return {device:id, stop:r.data.stopID};
+  }catch(e){
+    const div=document.createElement('div');
+    div.style.color='#fff';
+    div.style.textAlign='center';
+    div.style.padding='1rem';
+    div.textContent=`Device ID: ${id}`;
+    document.body.prepend(div);
+    throw e;
+  }
+}
 function getContrastColor(hex){ hex=hex.replace('#',''); const r=parseInt(hex.substring(0,2),16),g=parseInt(hex.substring(2,4),16),b=parseInt(hex.substring(4,6),16); const lum=(0.299*r+0.587*g+0.114*b)/255; return lum>0.565?'black':'white'; }
 
 /* ===================== Boot ===================== */
-document.addEventListener('DOMContentLoaded',()=>{
+document.addEventListener('DOMContentLoaded',async()=>{
   VoicePicker.init();
   AudioPrimer.init(); // harmless if autoplay already allowed
 
-  const stopID=getStopIDFromURL();
-  fetchArrivalTimes(stopID);
-  fetchAlerts();
+  try{
+    const {stop} = await resolveStopID();
+    fetchArrivalTimes(stop);
+    arrivalInterval=setInterval(()=>fetchArrivalTimes(stop),30000);
+  }catch(e){
+    console.warn('[boot] device not registered',e);
+  }
 
-  arrivalInterval=setInterval(()=>fetchArrivalTimes(stopID),30000);
+  fetchAlerts();
   alertInterval=setInterval(fetchAlerts,15000);
 
   window.addEventListener('focus', ()=>{ try{ speechSynthesis.resume(); }catch(e){} });

--- a/registerdisplay.html
+++ b/registerdisplay.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Register Arrivals Display</title>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/axios/0.21.1/axios.min.js"></script>
+<style>
+ body { font-family: sans-serif; margin: 2rem; }
+ label { display: block; margin-top: 1rem; }
+ input { font-size: 1rem; padding: 0.3rem; }
+ button { margin-top: 1rem; padding: 0.5rem 1rem; }
+ #status { margin-top: 1rem; }
+</style>
+</head>
+<body>
+<h1>Register Arrivals Display</h1>
+<p>Enter the device ID shown on the display and its desired stop ID.</p>
+<label>Device ID: <input id="device-id"/></label>
+<label>Stop ID: <input id="stop-id"/></label>
+<button onclick="registerDisplay()">Register</button>
+<div id="status"></div>
+<script>
+async function registerDisplay(){
+  const id=document.getElementById('device-id').value.trim();
+  const stop=document.getElementById('stop-id').value.trim();
+  const status=document.getElementById('status');
+  status.textContent='';
+  if(!id||!stop){ status.textContent='Both fields required.'; return; }
+  try{
+    await axios.post('/device-stop',{id,stopID:stop});
+    status.textContent='Saved!';
+  }catch(e){
+    status.textContent='Error saving.';
+    console.error(e);
+  }
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add server-side device-to-stop mapping with GET/POST endpoints
- Provide registration page for assigning stop IDs to display devices
- Update arrivals display to generate a deterministic device ID and request its stop mapping

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfb335a17083339ba5363b2a553eda