### PR TITLE
Add device registration system for arrivals display

### DIFF
--- a/arrivalsdisplay.html
+++ b/arrivalsdisplay.html
@@ -296,7 +296,7 @@ const Announcement=(()=>{
   const perVeh = Object.create(null); // `${vehId}@${stop}` -> { lastEta, announced:{10,5,1}, cooldown:{10,5,1}, ts }
   const perRoute = Object.create(null); // route -> { leaderId, lastEta, ts }
 
-  function stopKey(){ return getStopIDFromURL() || 'stop'; }
+  function stopKey(){ return currentStopID || 'stop'; }
   function vehKey(id){ return `${id||'nv'}@${stopKey()}`; }
 
   function sayThreshold(route, th){


### PR DESCRIPTION
## Summary
- Add server-side device-to-stop mapping with GET/POST endpoints
- Provide registration page for assigning stop IDs to display devices
- Update arrivals display to generate a deterministic device ID and request its stop mapping
- Ensure announcements use the registered stop ID instead of removed URL helper

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfb63ecde48333ac0fc2ebfb32b2bd