### PR TITLE
Fix embedded map path in arrivals display

### DIFF
--- a/arrivalsdisplay.html
+++ b/arrivalsdisplay.html
@@ -618,7 +618,7 @@ document.addEventListener('DOMContentLoaded',()=>{
   </div>
 
   <div style="width:50%; height:calc(100vh - 160px); float:right; display:block;">
-    <iframe src="map.html" style="width:100%; height:100%; border:none;"></iframe>
+    <iframe src="/map" style="width:100%; height:100%; border:none;"></iframe>
   </div>
 
   <div class="ticker-wrap"><div class="ticker" id="alerts-container"></div></div>


### PR DESCRIPTION
## Summary
- Load embedded map via `/map` route so the iframe works in arrivals display

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bfbb1f48e08333b4159de67829eb3e