### PR TITLE
Add admin-mode toggle and kiosk map embedding

### DIFF
--- a/arrivalsdisplay.html
+++ b/arrivalsdisplay.html
@@ -618,7 +618,7 @@ document.addEventListener('DOMContentLoaded',()=>{
   </div>
 
   <div style="width:50%; height:calc(100vh - 160px); float:right; display:block;">
-    <iframe src="/map" style="width:100%; height:100%; border:none;"></iframe>
+    <iframe src="/map?kioskMode=true&adminMode=false" style="width:100%; height:100%; border:none;"></iframe>
   </div>
 
   <div class="ticker-wrap"><div class="ticker" id="alerts-container"></div></div>

--- a/map.html
+++ b/map.html
@@ -149,7 +149,8 @@
     </style>
     <script>
       // Manually set these variables.
-      // adminMode: true for admin view (with route selector, speed bubbles, etc.)
+      // adminMode: true for admin view (with route selector, speed bubbles, etc.).
+      //            Can be disabled via URL param `adminMode=false`.
       // kioskMode: true to hide the route selector panel and tab.
       // showSpeed/showBlockNumbers: only one may be true at a time.
       let adminMode = true; // shows unit numbers, enables route selector and show/hide toggle
@@ -161,6 +162,10 @@
       const kioskParam = params.get('kioskMode');
       if (kioskParam !== null) {
         kioskMode = kioskParam.toLowerCase() === 'true';
+      }
+      const adminParam = params.get('adminMode');
+      if (adminParam !== null) {
+        adminMode = adminParam.toLowerCase() === 'true';
       }
       
       const outOfServiceRouteColor = '#000000';


### PR DESCRIPTION
## Summary
- Allow disabling map admin features via `adminMode=false` URL param
- Embed map on arrivals display with kiosk mode and admin mode off

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfbc8bfb1083339033dd390d2d863f