### PR TITLE
Persist display registrations on Fly.io volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,8 @@ RUN python -m pip install --upgrade pip && \
 # Copy app
 COPY . /app
 
-# Non-root user
+# Non-root user for running the app, but keep root for startup tasks
 RUN useradd -m appuser
-USER appuser
 
 # Fly will provide $PORT (defaults to 8080). We must use a shell form to expand it.
 ENV PORT=8080
@@ -32,6 +31,5 @@ ENV PORT=8080
 # Expose port (doc-only; Fly ignores EXPOSE but it’s still useful)
 EXPOSE 8080
 
-# Start the service (single worker to avoid duplicate background updaters)
-# NOTE: exec-form (JSON array) does NOT expand ${PORT}. Use shell to expand env vars.
-CMD sh -lc 'exec python -m uvicorn app:app --host 0.0.0.0 --port ${PORT:-8080}'
+# Start via helper script that ensures /data permissions before dropping to appuser
+CMD ["/app/start.sh"]

--- a/fly.toml
+++ b/fly.toml
@@ -23,6 +23,7 @@ kill_timeout = "5s"
   TRANSLOC_BASE = "https://uva.transloc.com/Services/JSONPRelay.svc"
   PORT = "8080"
   VEH_LOG_DIR = "/data/vehicle_logs"
+  DEVICE_STOP_FILE = "/data/device_stops.json"
 
 [http_service]
   internal_port = 8080

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+# Ensure /data is writable by appuser for persistence
+if [ -d /data ]; then
+  chown -R appuser:appuser /data || true
+else
+  mkdir -p /data
+  chown appuser:appuser /data
+fi
+exec su appuser -c "exec python -m uvicorn app:app --host 0.0.0.0 --port ${PORT:-8080}"
+


### PR DESCRIPTION
## Summary
- run startup script that fixes `/data` permissions then launches the app
- explicitly store device registration file on the `/data` volume

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `sh -n start.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bfbe3e07c8833380a120d48f76b0de