### PR TITLE
Mirror Fly.io volume data across multiple mounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,12 @@ Open the [driver](http://localhost:8080/driver) and [dispatcher](http://localhos
 A lightweight logger and replay page are included for reviewing past vehicle
 positions. The application automatically polls TransLoc every few seconds and
 appends snapshots to hourly files under `/data/vehicle_logs` (configurable via
-the `VEH_LOG_DIR` environment variable), pruning files older than one week.
-The `/data` directory is backed by Fly.io's `mileage_data` volume (see
-`fly.toml`) so logs survive reboots. Open `/replay` in a running server to view
-the logged data with a timeline and playback controls (pause, play and fast
-forward).
+the `VEH_LOG_DIRS` environment variable), pruning files older than one week.
+The paths listed in `DATA_DIRS` (defaulting to `/data`) are backed by Fly.io
+volumes (see `fly.toml`). If multiple volumes are specified, data is mirrored
+across them so logs and configuration survive reboots. Open `/replay` in a
+running server to view the logged data with a timeline and playback controls
+(pause, play and fast forward).
 
 ## API
 
@@ -55,8 +56,8 @@ Key endpoints exposed by the service:
 ## Configuration
 Runtime settings can be tuned with environment variables such as `TRANSLOC_BASE`, `TRANSLOC_KEY` and `OVERPASS_EP`.
 See `app.py` for the full list and default values. Changes made through the `/admin` page
-are persisted to `/data/config.json` on the `mileage_data` volume so they survive
-redeployments.
+are persisted to `config.json` within each directory listed in `DATA_DIRS` so they
+survive redeployments.
 
 ## Docker
 Build and run a containerised instance:

--- a/fly.toml
+++ b/fly.toml
@@ -22,8 +22,8 @@ kill_timeout = "5s"
   OVERPASS_EP = "https://overpass-api.de/api/interpreter"
   TRANSLOC_BASE = "https://uva.transloc.com/Services/JSONPRelay.svc"
   PORT = "8080"
-  VEH_LOG_DIR = "/data/vehicle_logs"
-  DEVICE_STOP_FILE = "/data/device_stops.json"
+  DATA_DIRS = "/data:/data2"
+  VEH_LOG_DIRS = "/data/vehicle_logs:/data2/vehicle_logs"
 
 [http_service]
   internal_port = 8080
@@ -48,3 +48,7 @@ kill_timeout = "5s"
 [[mounts]]
   source = "mileage_data"
   destination = "/data"
+
+[[mounts]]
+  source = "mileage_data_2"
+  destination = "/data2"

--- a/start.sh
+++ b/start.sh
@@ -1,11 +1,22 @@
 #!/bin/sh
 set -e
-# Ensure /data is writable by appuser for persistence
-if [ -d /data ]; then
-  chown -R appuser:appuser /data || true
-else
-  mkdir -p /data
-  chown appuser:appuser /data
+# Ensure data directories are writable by appuser for persistence
+DATA_DIRS=${DATA_DIRS:-/data}
+for d in $(echo "$DATA_DIRS" | tr ':' ' '); do
+  if [ -d "$d" ]; then
+    chown -R appuser:appuser "$d" || true
+  else
+    mkdir -p "$d"
+    chown appuser:appuser "$d"
+  fi
+done
+
+if [ -n "$VEH_LOG_DIRS" ]; then
+  for d in $(echo "$VEH_LOG_DIRS" | tr ':' ' '); do
+    if [ -d "$d" ]; then
+      chown -R appuser:appuser "$d" || true
+    fi
+  done
 fi
 exec su appuser -c "exec python -m uvicorn app:app --host 0.0.0.0 --port ${PORT:-8080}"
 


### PR DESCRIPTION
## Summary
- Allow configuring multiple persistent data paths via `DATA_DIRS` and `VEH_LOG_DIRS` to mirror state across Fly.io volumes
- Sync config, device stops, mileage, and vehicle logs to every configured volume
- Update startup script, docs, and Fly.io config for two mounted volumes

## Testing
- `python -m py_compile app.py`
- `bash -n start.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bfc5ca6fbc833386bf90eea73d7eb8