### PR TITLE
Add 200x replay speed option

### DIFF
--- a/replay.html
+++ b/replay.html
@@ -175,6 +175,7 @@
     <button id="ff10Btn" class="speed-btn">10x</button>
     <button id="ff30Btn" class="speed-btn">30x</button>
     <button id="ff100Btn" class="speed-btn">100x</button>
+    <button id="ff200Btn" class="speed-btn">200x</button>
     <input type="range" id="timeline" min="0" value="0">
     <span id="timeLabel"></span>
     <span id="lastUpdateLabel"></span>
@@ -215,7 +216,7 @@
     let blockMarkers = {};
     let routeLayers = [];
     let timer = null;       // handle for scheduled frame advance
-    let playbackSpeed = 1;  // 1x, 2x, 4x, 8x, 10x, 30x, 100x
+    let playbackSpeed = 1;  // 1x, 2x, 4x, 8x, 10x, 30x, 100x, 200x
     let routeColors = {};
     let allRoutes = {};
     let routeSelections = {};
@@ -238,6 +239,7 @@
     const ff10Btn = document.getElementById('ff10Btn');
     const ff30Btn = document.getElementById('ff30Btn');
     const ff100Btn = document.getElementById('ff100Btn');
+    const ff200Btn = document.getElementById('ff200Btn');
 
     function positionBusTab() {
       const panel = document.getElementById('busSelector');
@@ -284,6 +286,7 @@
       ff10Btn.classList.remove('selected');
       ff30Btn.classList.remove('selected');
       ff100Btn.classList.remove('selected');
+      ff200Btn.classList.remove('selected');
       if (!isPlaying) {
         pauseBtn.classList.add('selected');
       } else if (playbackSpeed === 1) {
@@ -300,6 +303,8 @@
         ff30Btn.classList.add('selected');
       } else if (playbackSpeed === 100) {
         ff100Btn.classList.add('selected');
+      } else if (playbackSpeed === 200) {
+        ff200Btn.classList.add('selected');
       }
     }
 
@@ -846,6 +851,7 @@
     ff10Btn.onclick = () => { playbackSpeed = 10; play(); };
     ff30Btn.onclick = () => { playbackSpeed = 30; play(); };
     ff100Btn.onclick = () => { playbackSpeed = 100; play(); };
+    ff200Btn.onclick = () => { playbackSpeed = 200; play(); };
     document.getElementById('timeline').addEventListener('input', async e => {
       pause();
       const ms = parseInt(e.target.value);


### PR DESCRIPTION
## Summary
- add 200x playback speed button in `replay.html`
- handle 200x speed in controls and playback logic

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfdd7cc5888333910153c76fca8120