### PR TITLE
Add landing page links and document new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ It gathers live data from TransLoc and the OpenStreetMap Overpass API, computes 
 - Computes arc-based headways and recommended actions (OK/Ease off/HOLD).
 - Exposes REST endpoints for health, routes, vehicles, per-vehicle instructions, and low-clearance warnings.
 - Streams per-route status via Server-Sent Events for live updates.
-- Serves minimal dispatcher and driver web clients with overheight alerts.
+- Serves lightweight web clients for drivers, dispatchers, service crew, a live map, daily ridership dashboard, and replay viewer with overheight alerts for drivers.
+- Logs vehicle positions for later replay and analysis.
+- Displays Red and Blue line daily ridership counts with CSV export.
 
 ## Requirements
 - Python 3.10+

--- a/index.html
+++ b/index.html
@@ -14,11 +14,13 @@
   .card{width:160px;height:160px;border-radius:16px;background:var(--panel);border:1px solid var(--line);display:flex;flex-direction:column;align-items:center;justify-content:center;text-decoration:none;color:var(--ink);}
   .card svg{width:64px;height:64px;margin-bottom:12px;}
   .admin-link{position:fixed;top:12px;right:16px;color:var(--ink);text-decoration:none;font-size:14px;}
+  .github-link{position:fixed;top:12px;left:16px;color:var(--ink);text-decoration:none;font-size:14px;}
   .credit{position:fixed;bottom:8px;right:8px;font-size:12px;color:var(--muted,#9fb0c9);}
   @media(max-width:600px){.container{flex-direction:column;}}
 </style>
 </head>
 <body>
+<a href="https://github.com/disgudname/UTS-Headway-Guard" class="github-link" target="_blank" rel="noopener">GitHub</a>
 <a href="/admin" class="admin-link">Admin</a>
 <div class="title">Welcome to Headway Guard</div>
 <div class="container">
@@ -59,6 +61,15 @@
       <line x1="40" y1="20" x2="40" y2="52" />
     </svg>
     <div>Live Map</div>
+  </a>
+  <a class="card" href="/ridership">
+    <svg viewBox="0 0 64 64" stroke="currentColor" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round">
+      <line x1="8" y1="52" x2="56" y2="52" />
+      <rect x="12" y="32" width="8" height="20" stroke="none" fill="currentColor" />
+      <rect x="28" y="24" width="8" height="28" stroke="none" fill="currentColor" />
+      <rect x="44" y="16" width="8" height="36" stroke="none" fill="currentColor" />
+    </svg>
+    <div>Red/Blue Daily Counts</div>
   </a>
   <a class="card" href="/replay">
     <svg viewBox="0 0 64 64" stroke="currentColor" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round">


### PR DESCRIPTION
## Summary
- add GitHub repository link at top-left of landing page
- link ridership dashboard from landing page
- document current web UI features and ridership logging in README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c064fa7d7c83338167e2694304bc21