### PR TITLE
Load entire day data in replay and adjust end time

### DIFF
--- a/replay.html
+++ b/replay.html
@@ -592,6 +592,8 @@
           if (endInput && endInput._flatpickr) {
             endInput._flatpickr.setDate(new Date(lastMs), true);
           }
+          endTime = new Date(lastMs);
+          userEndTime = new Date(lastMs);
         }
       } catch (err) {
         console.error('Failed to load log hour', err);
@@ -841,7 +843,9 @@
       const timeline = document.getElementById('timeline');
       timeline.min = startTime.getTime();
       timeline.max = userEndTime.getTime();
-      await loadHour(startTime.getTime());
+      for (let ms = startTime.getTime(); ms <= userEndTime.getTime(); ms += 3600 * 1000) {
+        await loadHour(ms);
+      }
       if (playbackTimes.length) {
         const ms = startTime.getTime();
         const idx = findFrameIndex(ms);


### PR DESCRIPTION
## Summary
- Load all hourly logs within the selected range on replay
- Sync replay end time input and timeline to latest available data

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0a8ec05e08333b2e60c07551f3266