### PR TITLE
Refactor schematic map rendering

### DIFF
--- a/schematic.html
+++ b/schematic.html
@@ -24,46 +24,6 @@
     const width = 1000;
     const height = 800;
 
-    function stylizePolyline(coords) {
-      if (!coords.length) return [];
-      const result = [[coords[0][0], coords[0][1]]];
-      for (let i = 1; i < coords.length; i++) {
-        const [lat1, lon1] = coords[i - 1];
-        const [lat2, lon2] = coords[i];
-        const dx = lon2 - lon1;
-        const dy = lat2 - lat1;
-        const len = Math.hypot(dx, dy);
-        if (len === 0) continue;
-        const angle = Math.atan2(dy, dx);
-        const snapped = Math.round(angle / (Math.PI / 4)) * (Math.PI / 4); // multiples of 45°
-        const [prevY, prevX] = result[result.length - 1];
-        const newX = prevX + len * Math.cos(snapped);
-        const newY = prevY + len * Math.sin(snapped);
-        result.push([newY, newX]);
-      }
-      return result;
-    }
-
-    function offsetScaledPoints(points, offset) {
-      if (!offset) return points;
-      const shifted = [];
-      for (let i = 0; i < points.length; i++) {
-        let dx, dy;
-        if (i < points.length - 1) {
-          dx = points[i + 1][0] - points[i][0];
-          dy = points[i + 1][1] - points[i][1];
-        } else {
-          dx = points[i][0] - points[i - 1][0];
-          dy = points[i][1] - points[i - 1][1];
-        }
-        const len = Math.hypot(dx, dy) || 1;
-        const offX = -dy / len * offset;
-        const offY = dx / len * offset;
-        shifted.push([points[i][0] + offX, points[i][1] + offY]);
-      }
-      return shifted;
-    }
-
     function scaleAndRender(routes) {
       let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
       routes.forEach(r => r.points.forEach(([y, x]) => {
@@ -77,31 +37,76 @@
       const offsetX = (width - (maxX - minX) * scale) / 2;
       const offsetY = (height - (maxY - minY) * scale) / 2;
 
-      const grouped = {};
+      // Scale all points first
       routes.forEach(r => {
-        const key = JSON.stringify(r.points);
-        if (!grouped[key]) grouped[key] = [];
-        grouped[key].push(r);
+        r.scaled = r.points.map(([y, x]) => {
+          const sx = (x - minX) * scale + offsetX;
+          const sy = height - ((y - minY) * scale + offsetY); // invert y
+          return [sx, sy];
+        });
       });
 
-      Object.values(grouped).forEach(group => {
-        group.forEach((r, idx) => {
-          const ptsScaled = r.points.map(([y, x]) => {
-            const sx = (x - minX) * scale + offsetX;
-            const sy = height - ((y - minY) * scale + offsetY); // invert y
-            return [sx, sy];
-          });
-          const offset = (idx - (group.length - 1) / 2) * 5; // 5px spacing
-          const ptsOffset = offsetScaledPoints(ptsScaled, offset);
-          const ptsStr = ptsOffset.map(([x, y]) => `${x},${y}`).join(' ');
-          const poly = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
-          poly.setAttribute('points', ptsStr);
-          poly.setAttribute('fill', 'none');
-          poly.setAttribute('stroke', r.color || '#000');
-          poly.setAttribute('stroke-width', '4');
-          poly.setAttribute('stroke-linejoin', 'round');
-          svg.appendChild(poly);
+      // Map of segments to routes that share them
+      const segMap = new Map();
+      routes.forEach((r, ridx) => {
+        const pts = r.scaled;
+        for (let i = 0; i < pts.length - 1; i++) {
+          const [x1, y1] = pts[i];
+          const [x2, y2] = pts[i + 1];
+          const key = (x1 < x2 || (x1 === x2 && y1 <= y2))
+            ? `${x1.toFixed(3)},${y1.toFixed(3)},${x2.toFixed(3)},${y2.toFixed(3)}`
+            : `${x2.toFixed(3)},${y2.toFixed(3)},${x1.toFixed(3)},${y1.toFixed(3)}`;
+          if (!segMap.has(key)) segMap.set(key, []);
+          segMap.get(key).push({ route: ridx, idx: i });
+        }
+      });
+
+      // Prepare offset accumulators
+      routes.forEach(r => {
+        r.offsets = Array(r.scaled.length).fill(0).map(() => [0, 0]);
+        r.counts = Array(r.scaled.length).fill(0);
+      });
+
+      // Compute offsets for overlapping segments
+      segMap.forEach(group => {
+        const n = group.length;
+        group.forEach((info, idx) => {
+          const route = routes[info.route];
+          const pts = route.scaled;
+          const i = info.idx;
+          const [x1, y1] = pts[i];
+          const [x2, y2] = pts[i + 1];
+          const dx = x2 - x1;
+          const dy = y2 - y1;
+          const len = Math.hypot(dx, dy) || 1;
+          const offset = (idx - (n - 1) / 2) * 5;
+          const offX = -dy / len * offset;
+          const offY = dx / len * offset;
+          route.offsets[i][0] += offX;
+          route.offsets[i][1] += offY;
+          route.offsets[i + 1][0] += offX;
+          route.offsets[i + 1][1] += offY;
+          route.counts[i]++;
+          route.counts[i + 1]++;
         });
+      });
+
+      // Render polylines with averaged offsets
+      routes.forEach(r => {
+        const pts = r.scaled.map((p, i) => {
+          if (r.counts[i]) {
+            return [p[0] + r.offsets[i][0] / r.counts[i], p[1] + r.offsets[i][1] / r.counts[i]];
+          }
+          return p;
+        });
+        const ptsStr = pts.map(([x, y]) => `${x},${y}`).join(' ');
+        const poly = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
+        poly.setAttribute('points', ptsStr);
+        poly.setAttribute('fill', 'none');
+        poly.setAttribute('stroke', r.color || '#000');
+        poly.setAttribute('stroke-width', '4');
+        poly.setAttribute('stroke-linejoin', 'round');
+        svg.appendChild(poly);
       });
     }
 
@@ -126,10 +131,9 @@
           ) {
             seenRouteIds.add(route.RouteID);
             const decoded = polyline.decode(route.EncodedPolyline);
-            const stylized = stylizePolyline(decoded);
             routes.push({
               color: route.MapLineColor || route.Color || '#000',
-              points: stylized
+              points: decoded
             });
           }
         });


### PR DESCRIPTION
## Summary
- Render routes using raw decoded polylines instead of snapping to 45°
- Offset shared route segments so overlapping lines are visible

## Testing
- `node -e "const fs=require('fs');const html=fs.readFileSync('schematic.html','utf8');const scripts=[...html.matchAll(/<script>([\\s\\S]*?)<\\/script>/g)];const code=scripts[scripts.length-1][1];new Function(code);"`


------
https://chatgpt.com/codex/tasks/task_e_68c4c1b5f6708333a9d047c033946448