### PR TITLE
Offset overlapping routes and smooth schematic lines

### DIFF
--- a/schematic.html
+++ b/schematic.html
@@ -23,6 +23,60 @@
     const svg = document.getElementById('mapSvg');
     const width = 1000;
     const height = 800;
+    const STROKE_WIDTH = 4;
+
+    // Ramer-Douglas-Peucker line simplification
+    function simplifyLine(points, tolerance) {
+      if (points.length <= 2) return points;
+      const sqTol = tolerance * tolerance;
+
+      function getSqSegDist(p, a, b) {
+        let x = a[0], y = a[1];
+        let dx = b[0] - x, dy = b[1] - y;
+        if (dx !== 0 || dy !== 0) {
+          const t = ((p[0] - x) * dx + (p[1] - y) * dy) / (dx * dx + dy * dy);
+          if (t > 1) { x = b[0]; y = b[1]; }
+          else if (t > 0) { x += dx * t; y += dy * t; }
+        }
+        dx = p[0] - x; dy = p[1] - y;
+        return dx * dx + dy * dy;
+      }
+
+      function simplifyDP(pts, first, last, res) {
+        let maxDist = 0, index = first;
+        for (let i = first + 1; i < last; i++) {
+          const dist = getSqSegDist(pts[i], pts[first], pts[last]);
+          if (dist > maxDist) { index = i; maxDist = dist; }
+        }
+        if (maxDist > sqTol) {
+          if (index - first > 1) simplifyDP(pts, first, index, res);
+          res.push(pts[index]);
+          if (last - index > 1) simplifyDP(pts, index, last, res);
+        }
+      }
+
+      const res = [points[0]];
+      simplifyDP(points, 0, points.length - 1, res);
+      res.push(points[points.length - 1]);
+      return res;
+    }
+
+    // Build a smooth SVG path using quadratic curves
+    function buildSmoothPath(points) {
+      if (!points.length) return '';
+      if (points.length === 1) return `M ${points[0][0]} ${points[0][1]}`;
+      let d = `M ${points[0][0]} ${points[0][1]}`;
+      for (let i = 1; i < points.length - 1; i++) {
+        const [x0, y0] = points[i];
+        const [x1, y1] = points[i + 1];
+        const mx = (x0 + x1) / 2;
+        const my = (y0 + y1) / 2;
+        d += ` Q ${x0} ${y0} ${mx} ${my}`;
+      }
+      const last = points[points.length - 1];
+      d += ` L ${last[0]} ${last[1]}`;
+      return d;
+    }
 
     function scaleAndRender(routes) {
       let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
@@ -37,13 +91,14 @@
       const offsetX = (width - (maxX - minX) * scale) / 2;
       const offsetY = (height - (maxY - minY) * scale) / 2;
 
-      // Scale all points first
+      // Scale and simplify all points first
       routes.forEach(r => {
         r.scaled = r.points.map(([y, x]) => {
           const sx = (x - minX) * scale + offsetX;
           const sy = height - ((y - minY) * scale + offsetY); // invert y
           return [sx, sy];
         });
+        r.scaled = simplifyLine(r.scaled, 2);
       });
 
       // Map of segments to routes that share them
@@ -65,11 +120,14 @@
       routes.forEach(r => {
         r.offsets = Array(r.scaled.length).fill(0).map(() => [0, 0]);
         r.counts = Array(r.scaled.length).fill(0);
+        r.overlapSegments = [];
       });
 
       // Compute offsets for overlapping segments
-      segMap.forEach(group => {
+      const overlaps = [];
+      segMap.forEach((group, key) => {
         const n = group.length;
+        if (n > 1) overlaps.push({ segment: key, routes: group.map(g => g.route) });
         group.forEach((info, idx) => {
           const route = routes[info.route];
           const pts = route.scaled;
@@ -79,7 +137,7 @@
           const dx = x2 - x1;
           const dy = y2 - y1;
           const len = Math.hypot(dx, dy) || 1;
-          const offset = (idx - (n - 1) / 2) * 5;
+          const offset = (idx - (n - 1) / 2) * STROKE_WIDTH;
           const offX = -dy / len * offset;
           const offY = dx / len * offset;
           route.offsets[i][0] += offX;
@@ -88,10 +146,12 @@
           route.offsets[i + 1][1] += offY;
           route.counts[i]++;
           route.counts[i + 1]++;
+          if (n > 1) route.overlapSegments.push(i);
         });
       });
+      if (overlaps.length) console.log('Overlapping segments', overlaps);
 
-      // Render polylines with averaged offsets
+      // Render smooth paths with averaged offsets
       routes.forEach(r => {
         const pts = r.scaled.map((p, i) => {
           if (r.counts[i]) {
@@ -99,14 +159,15 @@
           }
           return p;
         });
-        const ptsStr = pts.map(([x, y]) => `${x},${y}`).join(' ');
-        const poly = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
-        poly.setAttribute('points', ptsStr);
-        poly.setAttribute('fill', 'none');
-        poly.setAttribute('stroke', r.color || '#000');
-        poly.setAttribute('stroke-width', '4');
-        poly.setAttribute('stroke-linejoin', 'round');
-        svg.appendChild(poly);
+        const d = buildSmoothPath(pts);
+        const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        path.setAttribute('d', d);
+        path.setAttribute('fill', 'none');
+        path.setAttribute('stroke', r.color || '#000');
+        path.setAttribute('stroke-width', STROKE_WIDTH);
+        path.setAttribute('stroke-linejoin', 'round');
+        path.setAttribute('stroke-linecap', 'round');
+        svg.appendChild(path);
       });
     }
 


### PR DESCRIPTION
## Summary
- simplify and smooth route geometry for cleaner schematics
- offset overlapping routes so parallel lines touch like a metro map
- log and track overlapping segments for future use

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4c34b111483338a36fac3da726b5c