### PR TITLE
Offset near-overlapping routes

### DIFF
--- a/schematic.html
+++ b/schematic.html
@@ -25,6 +25,15 @@
     const height = 800;
     const STROKE_WIDTH = 4;
     const OVERLAP_SPACING = STROKE_WIDTH + 2;
+    const SEGMENT_TOLERANCE = STROKE_WIDTH * 2; // pixels used to detect near-overlaps
+
+    function segmentKey(x1, y1, x2, y2) {
+      const q = v => Math.round(v / SEGMENT_TOLERANCE) * SEGMENT_TOLERANCE;
+      if (x1 < x2 || (x1 === x2 && y1 <= y2)) {
+        return `${q(x1)},${q(y1)},${q(x2)},${q(y2)}`;
+      }
+      return `${q(x2)},${q(y2)},${q(x1)},${q(y1)}`;
+    }
 
     // Ramer-Douglas-Peucker line simplification
     function simplifyLine(points, tolerance) {
@@ -103,9 +112,7 @@
         for (let i = 0; i < pts.length - 1; i++) {
           const [x1, y1] = pts[i];
           const [x2, y2] = pts[i + 1];
-          const key = (x1 < x2 || (x1 === x2 && y1 <= y2))
-            ? `${x1.toFixed(3)},${y1.toFixed(3)},${x2.toFixed(3)},${y2.toFixed(3)}`
-            : `${x2.toFixed(3)},${y2.toFixed(3)},${x1.toFixed(3)},${y1.toFixed(3)}`;
+          const key = segmentKey(x1, y1, x2, y2);
           if (!segMap.has(key)) segMap.set(key, []);
           segMap.get(key).push({ route: ridx, idx: i });
         }
@@ -123,22 +130,36 @@
       segMap.forEach((group, key) => {
         const n = group.length;
         if (n > 1) overlaps.push({ segment: key, routes: group.map(g => g.route) });
+
+        // Average start and end points so near-overlaps align to a common centerline
+        const avgStart = [0, 0];
+        const avgEnd = [0, 0];
+        group.forEach(info => {
+          const pts = routes[info.route].scaled;
+          const p1 = pts[info.idx];
+          const p2 = pts[info.idx + 1];
+          avgStart[0] += p1[0];
+          avgStart[1] += p1[1];
+          avgEnd[0] += p2[0];
+          avgEnd[1] += p2[1];
+        });
+        avgStart[0] /= n; avgStart[1] /= n;
+        avgEnd[0] /= n; avgEnd[1] /= n;
+        const dx = avgEnd[0] - avgStart[0];
+        const dy = avgEnd[1] - avgStart[1];
+        const len = Math.hypot(dx, dy) || 1;
+
         group.forEach((info, idx) => {
           const route = routes[info.route];
           const pts = route.scaled;
           const i = info.idx;
-          const [x1, y1] = pts[i];
-          const [x2, y2] = pts[i + 1];
-          const dx = x2 - x1;
-          const dy = y2 - y1;
-          const len = Math.hypot(dx, dy) || 1;
           const offset = (idx - (n - 1) / 2) * OVERLAP_SPACING;
           const offX = -dy / len * offset;
           const offY = dx / len * offset;
-          route.offsets[i][0] += offX;
-          route.offsets[i][1] += offY;
-          route.offsets[i + 1][0] += offX;
-          route.offsets[i + 1][1] += offY;
+          route.offsets[i][0] += (avgStart[0] - pts[i][0]) + offX;
+          route.offsets[i][1] += (avgStart[1] - pts[i][1]) + offY;
+          route.offsets[i + 1][0] += (avgEnd[0] - pts[i + 1][0]) + offX;
+          route.offsets[i + 1][1] += (avgEnd[1] - pts[i + 1][1]) + offY;
           route.counts[i]++;
           route.counts[i + 1]++;
           if (n > 1) route.overlapSegments.push(i);


### PR DESCRIPTION
## Summary
- Detect near-overlapping route segments using a pixel tolerance
- Align overlapping segments to a shared centerline before applying offsets

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4c65744d8833385827d07105015a6