### PR TITLE
Preserve path endpoints in schematic map

### DIFF
--- a/schematic.html
+++ b/schematic.html
@@ -224,6 +224,9 @@
       // Render paths with averaged offsets
       routes.forEach(r => {
         const pts = r.scaled.map((p, i) => {
+          if (i === 0 || i === r.scaled.length - 1) {
+            return p;
+          }
           if (r.counts[i]) {
             return [p[0] + r.offsets[i][0] / r.counts[i], p[1] + r.offsets[i][1] / r.counts[i]];
           }


### PR DESCRIPTION
## Summary
- Keep path start and end points unchanged when applying overlap offsets so endpoints remain anchored.

## Testing
- `node -e "const fs=require('fs');const html=fs.readFileSync('schematic.html','utf8');const match=html.match(/<script>([\s\S]*)<\/script>/);if(match){new Function(match[1]);console.log('syntax ok');}else{console.error('no script');process.exit(1);}"`


------
https://chatgpt.com/codex/tasks/task_e_68c4d1a2c2a0833399fe63f8cfef7ebc