### PR TITLE
Refactor schematic map script into separate file

### DIFF
--- a/app.py
+++ b/app.py
@@ -1477,6 +1477,10 @@ async def stream_api_calls():
 async def fgdc_font():
     return FileResponse(BASE_DIR / "FGDC.ttf", media_type="font/ttf")
 
+@app.get("/schematic.js", include_in_schema=False)
+async def schematic_js():
+    return FileResponse(BASE_DIR / "schematic.js", media_type="application/javascript")
+
 @app.get("/vehicle_log/{log_name}", include_in_schema=False)
 async def vehicle_log_file(log_name: str):
     if not re.fullmatch(r"\d{8}_\d{2}\.jsonl", log_name):


### PR DESCRIPTION
## Summary
- move large inline script from `schematic.html` into new `schematic.js`
- keep HTML lean and load new script file
- serve `schematic.js` as a static asset in FastAPI

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c719c305008333b60a07bd9ac82ebb