### PR TITLE
Snap segments before smoothing in schematic paths

### DIFF
--- a/schematic.js
+++ b/schematic.js
@@ -161,11 +161,18 @@ function buildPath(points) {
     const scale = Math.min(scaleX, scaleY);
 
     routes.forEach(r => {
-      let pts = r.points.map(([lat, lon]) => {
+      r.scaled = r.points.map(([lat, lon]) => {
         const x = (lon - minLon) * scale + padding;
         const y = height - ((lat - minLat) * scale + padding);
         return [x, y];
       });
+    });
+
+    const KEY_TOL = 8;
+    snapSegments(routes, KEY_TOL);
+
+    routes.forEach(r => {
+      let pts = r.scaled;
       pts = simplifyLine(pts, 8);
       pts = smoothPath(pts);
       pts = snap45(pts);
@@ -173,9 +180,6 @@ function buildPath(points) {
       r.offsets = Array(pts.length).fill(0).map(() => [0, 0]);
       r.counts = Array(pts.length).fill(0);
     });
-
-    const KEY_TOL = 8;
-    snapSegments(routes, KEY_TOL);
 
     // Detect overlapping segments and offset
     const segMap = new Map();


### PR DESCRIPTION
## Summary
- Snap overlapping route segments before applying simplification and smoothing
- Preserve smoothing and snapping after shared segments are aligned

## Testing
- `node --check schematic.js`


------
https://chatgpt.com/codex/tasks/task_e_68c7317fc06483338a0ae5e212a99c97