### PR TITLE
Increase tolerance for shared road alignment in schematic

### DIFF
--- a/schematic.js
+++ b/schematic.js
@@ -173,7 +173,9 @@ function buildPath(points) {
       });
     });
 
-    const KEY_TOL = 8;
+    // Tolerance for grouping segments that share the same roadway.
+    // Increased to better align opposite directions separated by a median.
+    const KEY_TOL = 12;
     let segMap = groupSegments(routes, KEY_TOL);
     alignSharedSegments(segMap);
 


### PR DESCRIPTION
## Summary
- Increase segment grouping tolerance to better align opposite-direction routes separated by medians
- Add clarifying comments around tolerance constant

## Testing
- `node --check schematic.js`


------
https://chatgpt.com/codex/tasks/task_e_68c73744cf9883339c11f7b6fcc25c67