### PR TITLE
Fix schematic snapping for 45-degree grid alignment

### DIFF
--- a/schematic.js
+++ b/schematic.js
@@ -217,6 +217,12 @@ function buildPath(points) {
     segMap = groupSegments(routes, KEY_TOL);
     alignSharedSegments(segMap);
     snapVertices(routes, GRID_SIZE);
+
+    // Ensure final geometry uses 45° angles on a shared grid
+    routes.forEach(r => {
+      r.scaled = snap45(r.scaled);
+      r.scaled = snapToGrid(r.scaled, GRID_SIZE);
+    });
     segMap = groupSegments(routes, KEY_TOL);
     alignSharedSegments(segMap);
 


### PR DESCRIPTION
## Summary
- Reapply 45° snapping and grid alignment after shared-segment processing
- Align road segments again so routes on the same road share coordinates

## Testing
- `node --check schematic.js`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c73aafad8883339fad06b70ee77af1