### PR TITLE
Snap schematic segments to grid

### DIFF
--- a/schematic.js
+++ b/schematic.js
@@ -53,8 +53,9 @@ function snap45(points) {
     }
     const angle = Math.atan2(dy, dx);
     const snappedAngle = Math.round(angle / (Math.PI / 4)) * (Math.PI / 4);
-    const nx = prev[0] + Math.cos(snappedAngle) * len;
-    const ny = prev[1] + Math.sin(snappedAngle) * len;
+    const snappedLen = Math.round(len / GRID_SIZE) * GRID_SIZE;
+    const nx = prev[0] + Math.cos(snappedAngle) * snappedLen;
+    const ny = prev[1] + Math.sin(snappedAngle) * snappedLen;
     snapped.push([nx, ny]);
   }
   return snapped;


### PR DESCRIPTION
## Summary
- quantize snapped segments to multiples of GRID_SIZE for cleaner 45° paths

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c73c7efb3883338141dbce76da6d5d