### PR TITLE
Embed map alongside dispatcher content

### DIFF
--- a/dispatcher.html
+++ b/dispatcher.html
@@ -5,7 +5,7 @@
 <style>
 @font-face{font-family:'FGDC';src:url('FGDC.ttf') format('truetype')}
 :root{--route-color:#2a3442}
-body{font:17px 'FGDC',system-ui;margin:0;background:#0b0e11;color:#e8eef5}
+body{font:17px 'FGDC',system-ui;margin:0;background:#0b0e11;color:#e8eef5;display:flex;height:100vh}
 header{display:flex;gap:10px;align-items:center;padding:12px 14px;border-bottom:1px solid #1f2630;flex-wrap:wrap}
 header h1{flex-basis:100%}
  #controls{display:flex;gap:10px;align-items:center;position:relative;padding-right:200px}
@@ -35,8 +35,10 @@ h2{font-size:18px;margin:16px 0 0}
   #layout{flex-direction:column}
   #layout aside{border-left:none !important;border-top:1px solid #1f2630}
 }
-.credit{position:fixed;bottom:8px;right:8px;font-size:12px;color:var(--muted,#9fb0c9)}
-</style>
+.credit{position:absolute;bottom:8px;right:8px;font-size:12px;color:var(--muted,#9fb0c9)}
+ </style>
+<body>
+<div id="left" style="flex:1;overflow:auto;position:relative">
 <header>
   <h1 style="font-size:18px;margin:0">UTS Anti-Bunching — Dispatcher</h1>
   <div id="controls">
@@ -77,6 +79,8 @@ h2{font-size:18px;margin:16px 0 0}
   </aside>
 </div>
 <div class="credit">proof of concept created by pat cox • phc6j@virginia.edu</div>
+</div>
+<iframe src="map.html" id="map-frame" style="flex:1;border-left:1px solid #1f2630;border:none;height:100%"></iframe>
 <script>
 const $ = s => document.querySelector(s);
 const fmt = s => { if (s==null || !isFinite(s)) return "—"; s = Math.round(s); return String(Math.floor(s/60)).padStart(2,'0')+":"+String(s%60).padStart(2,'0'); };
@@ -468,3 +472,4 @@ document.addEventListener('DOMContentLoaded', async ()=>{
 });
 document.getElementById('route').addEventListener('change', e=> { userLocked=true; start(e.target.value); });
 </script>
+</body>


### PR DESCRIPTION
## Summary
- Split dispatcher layout into flex-based left and right panes
- Place existing dispatcher interface in left pane and embed `map.html` on the right via iframe

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7515ecbc48333a6ddf1226a94b0c9