### PR TITLE
Fix dispatcher map iframe path

### DIFF
--- a/dispatcher.html
+++ b/dispatcher.html
@@ -80,7 +80,7 @@ h2{font-size:18px;margin:16px 0 0}
 </div>
 <div class="credit">proof of concept created by pat cox • phc6j@virginia.edu</div>
 </div>
-<iframe src="map.html" id="map-frame" style="flex:1;border-left:1px solid #1f2630;border:none;height:100%"></iframe>
+<iframe src="/map" id="map-frame" style="flex:1;border-left:1px solid #1f2630;border:none;height:100%"></iframe>
 <script>
 const $ = s => document.querySelector(s);
 const fmt = s => { if (s==null || !isFinite(s)) return "—"; s = Math.round(s); return String(Math.floor(s/60)).padStart(2,'0')+":"+String(s%60).padStart(2,'0'); };


### PR DESCRIPTION
## Summary
- Correct dispatcher iframe source to reference `/map` route instead of nonexistent `map.html`

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c752f120788333a62149379dfe829b