### PR TITLE
Avoid distorting routes when snapping to 45°

### DIFF
--- a/schematic.js
+++ b/schematic.js
@@ -53,9 +53,8 @@ function snap45(points) {
     }
     const angle = Math.atan2(dy, dx);
     const snappedAngle = Math.round(angle / (Math.PI / 4)) * (Math.PI / 4);
-    const snappedLen = Math.round(len / GRID_SIZE) * GRID_SIZE;
-    const nx = prev[0] + Math.cos(snappedAngle) * snappedLen;
-    const ny = prev[1] + Math.sin(snappedAngle) * snappedLen;
+    const nx = prev[0] + Math.cos(snappedAngle) * len;
+    const ny = prev[1] + Math.sin(snappedAngle) * len;
     snapped.push([nx, ny]);
   }
   return snapped;


### PR DESCRIPTION
## Summary
- keep original segment length when snapping to 45° to prevent routes from wandering across the map

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7550751f88333914227b39af97229