### PR TITLE
Align shared route segments on 45° grid

### DIFF
--- a/schematic.js
+++ b/schematic.js
@@ -277,7 +277,15 @@ function buildPath(points) {
     segMap = groupSegments(routes, KEY_TOL);
     alignSharedSegments(segMap, KEY_TOL);
 
-    // Prepare offset arrays after final alignment
+    // After aligning, snap again so shared roads follow identical paths
+    snapVertices(routes, GRID_SIZE);
+    insertSharedVertices(routes, GRID_SIZE / 2);
+    routes.forEach(r => {
+      r.scaled = snap45(r.scaled);
+      r.scaled = snapToGrid(r.scaled, GRID_SIZE);
+    });
+
+    // Prepare offset arrays after final alignment and snapping
     routes.forEach(r => {
       r.offsets = Array(r.scaled.length).fill(0).map(() => [0, 0]);
       r.counts = Array(r.scaled.length).fill(0);


### PR DESCRIPTION
## Summary
- Re-snap shared vertices and segments after final alignment so routes using the same road share identical geometry
- Reapply 45° and grid snapping to enforce uniform angles before rendering

## Testing
- `node --check schematic.js`


------
https://chatgpt.com/codex/tasks/task_e_68c75c6731588333825985107e3ef17b