### PR TITLE
Fix runaway route snapping in schematic map

### DIFF
--- a/schematic.js
+++ b/schematic.js
@@ -277,15 +277,7 @@ function buildPath(points) {
     segMap = groupSegments(routes, KEY_TOL);
     alignSharedSegments(segMap, KEY_TOL);
 
-    // After aligning, snap again so shared roads follow identical paths
-    snapVertices(routes, GRID_SIZE);
-    insertSharedVertices(routes, GRID_SIZE / 2);
-    routes.forEach(r => {
-      r.scaled = snap45(r.scaled);
-      r.scaled = snapToGrid(r.scaled, GRID_SIZE);
-    });
-
-    // Prepare offset arrays after final alignment and snapping
+    // Prepare offset arrays after final alignment
     routes.forEach(r => {
       r.offsets = Array(r.scaled.length).fill(0).map(() => [0, 0]);
       r.counts = Array(r.scaled.length).fill(0);


### PR DESCRIPTION
## Summary
- Remove redundant vertex snapping loop in `schematic.js`
- Prevent duplicate vertex insertion that caused routes to jump erratically

## Testing
- `node --check schematic.js`
- `node test_local.js`

------
https://chatgpt.com/codex/tasks/task_e_68c7625fe6188333b2b0583843382a0b