### PR TITLE
feat: add metro map page

### DIFF
--- a/app.py
+++ b/app.py
@@ -635,6 +635,7 @@ BASE_DIR = Path(__file__).resolve().parent
 DRIVER_HTML = (BASE_DIR / "driver.html").read_text(encoding="utf-8")
 DISPATCHER_HTML = (BASE_DIR / "dispatcher.html").read_text(encoding="utf-8")
 MAP_HTML = (BASE_DIR / "map.html").read_text(encoding="utf-8")
+METROMAP_HTML = (BASE_DIR / "metromap.html").read_text(encoding="utf-8")
 ADMIN_HTML = (BASE_DIR / "admin.html").read_text(encoding="utf-8")
 SERVICECREW_HTML = (BASE_DIR / "servicecrew.html").read_text(encoding="utf-8")
 LANDING_HTML = (BASE_DIR / "index.html").read_text(encoding="utf-8")
@@ -1503,6 +1504,13 @@ async def landing_page():
 @app.get("/map")
 async def map_page():
     return HTMLResponse(MAP_HTML)
+
+# ---------------------------
+# METRO MAP PAGE
+# ---------------------------
+@app.get("/metromap")
+async def metromap_page():
+    return HTMLResponse(METROMAP_HTML)
 
 # ---------------------------
 # DEBUG PAGE

--- a/metromap.html
+++ b/metromap.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Metro Map - Headway Guard</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <script src="https://unpkg.com/@mapbox/polyline@1.1.1"></script>
+  <style>
+    html, body, #metroMap {
+      height: 100%;
+      margin: 0;
+      width: 100%;
+    }
+    #metroMap {
+      background: #ffffff;
+    }
+  </style>
+</head>
+<body>
+  <svg id="metroMap"></svg>
+  <script>
+    async function fetchActiveRouteShapes() {
+      const resp = await fetch('/v1/routes');
+      const data = await resp.json();
+      const active = data.routes.filter(r => r.active_vehicles > 0);
+      const shapes = await Promise.all(active.map(async (r) => {
+        const s = await fetch(`/v1/routes/${r.id}/shape`).then(x => x.json());
+        return {
+          id: r.id,
+          color: s.color,
+          pts: polyline.decode(s.polyline).map(p => ({ lat: p[0], lon: p[1] }))
+        };
+      }));
+      return shapes;
+    }
+
+    function snapSegment(p1, p2) {
+      let dx = p2.lon - p1.lon;
+      let dy = p2.lat - p1.lat;
+      const len = Math.hypot(dx, dy);
+      if (len === 0) return null;
+      const step = Math.PI / 4;
+      const angle = Math.atan2(dy, dx);
+      const snap = Math.round(angle / step) * step;
+      const nx = Math.cos(snap) * len;
+      const ny = Math.sin(snap) * len;
+      return { start: { lat: p1.lat, lon: p1.lon }, end: { lat: p1.lat + ny, lon: p1.lon + nx } };
+    }
+
+    function keyForSeg(seg) {
+      const r = v => Math.round(v * 1e5) / 1e5;
+      const a = [r(seg.start.lat), r(seg.start.lon), r(seg.end.lat), r(seg.end.lon)];
+      if (a[0] > a[2] || (a[0] === a[2] && a[1] > a[3])) {
+        [a[0], a[1], a[2], a[3]] = [a[2], a[3], a[0], a[1]];
+      }
+      return a.join(',');
+    }
+
+    function prepareSegments(shapes) {
+      const segs = {};
+      for (const route of shapes) {
+        const pts = route.pts;
+        for (let i = 1; i < pts.length; i++) {
+          const seg = snapSegment(pts[i - 1], pts[i]);
+          if (!seg) continue;
+          const key = keyForSeg(seg);
+          if (!segs[key]) segs[key] = { start: seg.start, end: seg.end, routes: [] };
+          if (!segs[key].routes.find(r => r.id === route.id)) {
+            segs[key].routes.push({ id: route.id, color: route.color });
+          }
+        }
+      }
+      return segs;
+    }
+
+    function project(lat, lon, box, width, height) {
+      const x = (lon - box.minLon) / (box.maxLon - box.minLon) * width;
+      const y = height - (lat - box.minLat) / (box.maxLat - box.minLat) * height;
+      return [x, y];
+    }
+
+    function render(segs) {
+      const svg = document.getElementById('metroMap');
+      const width = svg.clientWidth || window.innerWidth;
+      const height = svg.clientHeight || window.innerHeight;
+      svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+      let minLat = 90, maxLat = -90, minLon = 180, maxLon = -180;
+      Object.values(segs).forEach(s => {
+        minLat = Math.min(minLat, s.start.lat, s.end.lat);
+        maxLat = Math.max(maxLat, s.start.lat, s.end.lat);
+        minLon = Math.min(minLon, s.start.lon, s.end.lon);
+        maxLon = Math.max(maxLon, s.start.lon, s.end.lon);
+      });
+      const box = { minLat, maxLat, minLon, maxLon };
+      const offset = 4;
+      for (const seg of Object.values(segs)) {
+        const [x1, y1] = project(seg.start.lat, seg.start.lon, box, width, height);
+        const [x2, y2] = project(seg.end.lat, seg.end.lon, box, width, height);
+        const dx = x2 - x1, dy = y2 - y1;
+        const len = Math.hypot(dx, dy);
+        const ux = dx / len, uy = dy / len;
+        const px = -uy, py = ux;
+        const routes = seg.routes;
+        routes.forEach((r, idx) => {
+          const off = (idx - (routes.length - 1) / 2) * offset;
+          const sx1 = x1 + px * off;
+          const sy1 = y1 + py * off;
+          const sx2 = x2 + px * off;
+          const sy2 = y2 + py * off;
+          const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+          line.setAttribute('x1', sx1);
+          line.setAttribute('y1', sy1);
+          line.setAttribute('x2', sx2);
+          line.setAttribute('y2', sy2);
+          line.setAttribute('stroke', r.color || '#000');
+          line.setAttribute('stroke-width', 6);
+          line.setAttribute('stroke-linecap', 'round');
+          svg.appendChild(line);
+        });
+      }
+    }
+
+    async function init() {
+      const shapes = await fetchActiveRouteShapes();
+      const segs = prepareSegments(shapes);
+      render(segs);
+    }
+    init();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `metromap.html` that fetches active TransLoc routes, snaps segments to 45° angles and draws overlapping lines side by side
- serve Metro Map page at `/metromap`

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c768a032f88333b8ff4bd3c48a50e8