### PR TITLE
Add bus overview page with road and speed data

### DIFF
--- a/buses.html
+++ b/buses.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Bus Overview</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+@font-face{font-family:'FGDC';src:url('FGDC.ttf') format('truetype')}
+body{font:16px 'FGDC',system-ui;background:#0b0e11;color:#e8eef5;margin:0;padding:20px;}
+h1{margin-top:0}
+table{border-collapse:collapse;width:100%;margin-top:20px;}
+th,td{padding:8px;border:1px solid #2a3442;text-align:left;}
+th{background:#15202b}
+tr.stale{opacity:0.5}
+.hint{color:var(--muted,#9fb0c9);text-align:center}
+.credit{position:fixed;bottom:8px;right:8px;font-size:12px;color:var(--muted,#9fb0c9)}
+</style>
+<h1>Bus Overview</h1>
+<table id="buses">
+  <thead>
+    <tr><th>Bus</th><th>Block</th><th>Road</th><th>Speed Limit (mph)</th><th>Speed (mph)</th></tr>
+  </thead>
+  <tbody></tbody>
+</table>
+<div class="credit">proof of concept created by pat cox • phc6j@virginia.edu</div>
+<script>
+const MPH_PER_MPS = 2.23694;
+let STALE_LIMIT = 90;
+function parseBlocks(res){
+  const map=new Map();
+  for(const g of res.block_groups||[]){
+    for(const b of g.Blocks||[]){
+      const trip=b.Trips?.[0];
+      const bus=trip?.VehicleName;
+      if(!bus) continue;
+      const key=b.BlockId || g.BlockGroupId;
+      map.set(String(bus), key);
+    }
+  }
+  return map;
+}
+async function load(){
+  try{
+    const cfg=await fetch('/v1/config',{cache:'no-store'}).then(r=>r.json());
+    if(cfg.STALE_FIX_S) STALE_LIMIT=cfg.STALE_FIX_S;
+    const blocksRes=await fetch('/v1/dispatch/blocks').then(r=>r.json());
+    const blockByBus=parseBlocks(blocksRes);
+    const vehRes=await fetch('/v1/vehicles?include_stale=1&include_unassigned=1').then(r=>r.json());
+    const vehs=vehRes.vehicles||[];
+    const routeIds=[...new Set(vehs.map(v=>v.route_id).filter(v=>v!=null))];
+    const detail=new Map();
+    for(const rid of routeIds){
+      try{
+        const raw=await fetch(`/v1/routes/${rid}/vehicles_raw`).then(r=>r.json());
+        for(const v of raw.vehicles||[]){
+          detail.set(String(v.name), v);
+        }
+      }catch{}
+    }
+    const rows=[];
+    for(const v of vehs){
+      const info=detail.get(String(v.name))||{};
+      const age=info.age_s??v.age_seconds??0;
+      const fresh=age<=STALE_LIMIT;
+      const block=blockByBus.get(String(v.name))||'';
+      const road=info.road||'';
+      const limit=info.speed_limit_mps!=null?info.speed_limit_mps*MPH_PER_MPS:null;
+      const speed=info.ground_mps!=null?info.ground_mps*MPH_PER_MPS:null;
+      rows.push({name:v.name,block,road,limit,speed,fresh});
+    }
+    rows.sort((a,b)=>{
+      if(a.fresh!==b.fresh) return a.fresh?-1:1;
+      return parseInt(a.name)-parseInt(b.name);
+    });
+    const tbody=document.querySelector('#buses tbody');
+    if(!rows.length){
+      tbody.innerHTML='<tr><td class="hint" colspan="5">No buses.</td></tr>';
+      return;
+    }
+    tbody.innerHTML=rows.map(r=>`<tr class="${r.fresh?'':'stale'}"><td>${r.name}</td><td>${r.block}</td><td>${r.road}</td><td>${r.limit!=null?r.limit.toFixed(1):''}</td><td>${r.speed!=null?r.speed.toFixed(1):''}</td></tr>`).join('');
+  }catch(e){
+    console.error(e);
+  }
+}
+load();
+</script>


### PR DESCRIPTION
## Summary
- include road names alongside speed limits from Overpass
- expose each vehicle's road and speed limit in raw vehicle endpoint
- add new /buses page listing buses with block, road, limit, and speed

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c78102986c83338c51b95f657c5b1c