### PR TITLE
Add custom 404 page with navigation to home

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>Page Not Found</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<link rel="preload" href="FGDC.ttf" as="font" type="font/ttf" crossorigin />
+<style>
+  @font-face{font-family:'FGDC';src:url('FGDC.ttf') format('truetype');font-weight:normal;font-style:normal;}
+  :root{ --bg:#0b0e11; --panel:#0f141a; --ink:#e8eef5; --line:#1f2630; }
+  body{margin:0;background:var(--bg);color:var(--ink);font:16px/1.45 'FGDC',sans-serif;display:flex;flex-direction:column;align-items:center;justify-content:center;height:100vh;}
+  h1{margin-bottom:24px;}
+  button{padding:10px 20px;border-radius:8px;border:1px solid var(--line);background:var(--panel);color:var(--ink);font-family:'FGDC',sans-serif;cursor:pointer;}
+  button:hover{background:var(--line);}
+</style>
+</head>
+<body>
+<h1>404 - Page Not Found</h1>
+<button onclick="window.location.href='/'">Return to Home</button>
+</body>
+</html>

--- a/app.py
+++ b/app.py
@@ -33,7 +33,7 @@ from zoneinfo import ZoneInfo
 import httpx
 from collections import deque
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse, HTMLResponse, FileResponse
 from pathlib import Path
 from urllib.parse import quote
@@ -653,6 +653,14 @@ RIDERSHIP_HTML = (BASE_DIR / "ridership.html").read_text(encoding="utf-8")
 ARRIVALSDISPLAY_HTML = (BASE_DIR / "arrivalsdisplay.html").read_text(encoding="utf-8")
 REGISTERDISPLAY_HTML = (BASE_DIR / "registerdisplay.html").read_text(encoding="utf-8")
 BUS_TABLE_HTML = (BASE_DIR / "buses.html").read_text(encoding="utf-8")
+NOT_FOUND_HTML = (BASE_DIR / "404.html").read_text(encoding="utf-8")
+
+@app.exception_handler(404)
+async def not_found_handler(request: Request, exc: HTTPException):
+    if "text/html" in request.headers.get("accept", ""):
+        return HTMLResponse(NOT_FOUND_HTML, status_code=404)
+    detail = getattr(exc, "detail", "Not Found")
+    return JSONResponse({"detail": detail}, status_code=404)
 
 DEVICE_STOP_NAME = Path(os.environ.get("DEVICE_STOP_FILE", "device_stops.json")).name
 DEVICE_STOP_FILE = PRIMARY_DATA_DIR / DEVICE_STOP_NAME


### PR DESCRIPTION
## Summary
- create stylized `404.html` with button returning to landing page
- serve custom 404 via FastAPI exception handler and preserve JSON errors

## Testing
- `python -m py_compile app.py`
- `python - <<'PY'
from fastapi.testclient import TestClient
from app import app
client = TestClient(app)
resp = client.get('/nonexistent', headers={'accept':'text/html'})
print(resp.status_code)
print(resp.text.split('\n')[0])
resp2 = client.get('/nonexistent', headers={'accept':'application/json'})
print(resp2.status_code)
print(resp2.json())
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c7891058cc8333bc1dbb775ff1e1c1