### PR TITLE
feat: show stop number in stop popup

### DIFF
--- a/map.html
+++ b/map.html
@@ -436,9 +436,11 @@
               </tbody>
             </table>
           `;
+          const stopNumbers = routeStopIds.join(', ');
           popupElement.innerHTML = `
             <button class="custom-popup-close">&times;</button>
-            <span style="font-size: 16px; font-weight: bold;">${stopName}</span>
+            <span style="font-size: 16px; font-weight: bold;">${stopName}</span><br>
+            <span>Stop #: ${stopNumbers}</span><br>
             ${etaTable}
             <div class="custom-popup-arrow"></div>
           `;
@@ -498,9 +500,11 @@
                       </tbody>
                     </table>
                   `;
+                  const stopNumbers = routeStopIds.join(', ');
                   popupElement.innerHTML = `
                     <button class="custom-popup-close">&times;</button>
                     <span style="font-size: 16px; font-weight: bold;">${popupElement.dataset.stopName}</span><br>
+                    <span>Stop #: ${stopNumbers}</span><br>
                     ${etaTable}
                     <div class="custom-popup-arrow"></div>
                   `;


### PR DESCRIPTION
## Summary
- Display stop numbers in the stop popup alongside arrival times
- Ensure stop numbers persist during popup updates

## Testing
- `python -m py_compile app.py`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7910e90348333ad5f8e844aa269cc