### PR TITLE
Show bracketed block numbers on buses page

### DIFF
--- a/buses.html
+++ b/buses.html
@@ -62,7 +62,9 @@ function parseBlocks(res){
     for(const b of g.Blocks||[]){
       const bus=b.Trips?.[0]?.VehicleName;
       if(!bus) continue;
-      const key=aliasBlock(b.BlockId || g.BlockGroupId);
+      let key=g.BlockGroupId;
+      if(!String(key).includes('[')) key=b.BlockId || key;
+      key=aliasBlock(key);
       const prev=busMap.get(bus);
       if(!prev || (!prev.includes('[') && key.includes('['))){
         busMap.set(bus,key);


### PR DESCRIPTION
## Summary
- Preserve block group bracket formatting when loading bus blocks

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c79db6d99c8333a8ea5b1954a5ccd9