### PR TITLE
Stop slicing vehicle names on map

### DIFF
--- a/map.html
+++ b/map.html
@@ -748,7 +748,7 @@
                           const vehicleID = vehicle.VehicleID;
                           const newPosition = [vehicle.Latitude, vehicle.Longitude];
                           const isMoving = vehicle.GroundSpeed > 0;
-                          const busName = vehicle.Name.slice(0, -2);
+                          const busName = vehicle.Name;
                           let routeID = vehicle.RouteID;
                           if (!routeID && adminMode) {
                               routeID = 0;


### PR DESCRIPTION
## Summary
- show full vehicle names on live map

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7ab2b3f908333945e47e9ad83bee7