### PR TITLE
Preserve agency dropdown open state during data refresh

### DIFF
--- a/map.html
+++ b/map.html
@@ -257,6 +257,12 @@
       function updateRouteSelector(activeRoutes) {
         const container = document.getElementById("routeSelector");
         if (!container) return;
+        // If the agency dropdown is currently focused (open), skip rebuilding
+        // the selector to avoid closing the dropdown.
+        const agencyDropdown = document.getElementById('agencySelect');
+        if (agencyDropdown && document.activeElement === agencyDropdown) {
+          return;
+        }
         let html = "";
         html += "<label for='agencySelect'>Select System:</label>";
         html += "<select id='agencySelect' onchange='changeAgency(this.value)'>";


### PR DESCRIPTION
## Summary
- Avoid rebuilding route selector when agency dropdown is focused to keep it open during data reload

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c7aeef0598833382e8c8a3f315bb2a