### PR TITLE
Adjust servicecrew date to start at 3AM Charlottesville time

### DIFF
--- a/servicecrew.html
+++ b/servicecrew.html
@@ -111,8 +111,12 @@ async function loadBlockMap(){
 }
 
 function todayStr(){
-  // Ensure date is computed in Charlottesville's timezone
-  return new Date().toLocaleDateString('en-CA',{timeZone:'America/New_York'});
+  // Treat "today" as the 24h period starting at the most recent 3AM
+  const tz='America/New_York';
+  const now=new Date();
+  const hour=parseInt(new Intl.DateTimeFormat('en-US',{timeZone:tz,hour:'2-digit',hour12:false}).format(now),10);
+  const day=hour<3?new Date(now.getTime()-86400000):now;
+  return day.toLocaleDateString('en-CA',{timeZone:tz});
 }
 async function fetchData(){
   const date=todayStr();


### PR DESCRIPTION
## Summary
- Treat "today" as a 24-hour period beginning at the most recent 3AM in Charlottesville time so overnight routes are fully captured

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7b25b0f8c833398a4c27e978b5429