### PR TITLE
fix: enforce https for agency URLs

### DIFF
--- a/map.html
+++ b/map.html
@@ -209,7 +209,9 @@
             const name = c.Name?.trim();
             const webAddress = c.WebAddress?.trim();
             if (!name || !webAddress) return null;
-            const url = webAddress.startsWith('http') ? webAddress : `http://${webAddress}`;
+            const url = webAddress.startsWith('http')
+              ? webAddress.replace(/^http:\/\//i, 'https://')
+              : `https://${webAddress}`;
             return { name, url };
           }).filter(Boolean);
           agencies.sort((a, b) => a.name.localeCompare(b.name));


### PR DESCRIPTION
## Summary
- Prevent mixed content blocking by forcing agency web addresses to use HTTPS

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7c61aa7f883339698b087c1e5f977