### PR TITLE
Make transloc ticker transparent when no alerts

### DIFF
--- a/transloc_ticker.html
+++ b/transloc_ticker.html
@@ -25,10 +25,16 @@
     html, body { height:100%; margin:0; background:transparent; }
     body {
       font-family: 'FGDC', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+      opacity: 0;
+      transition: opacity 0.2s ease-in-out;
+    }
+
+    body[data-visible="true"] {
+      opacity: 1;
     }
 
     body[data-visible="false"] {
-      display: none;
+      pointer-events: none;
     }
 
     @keyframes ticker-scroll {


### PR DESCRIPTION
## Summary
- fade the ticker page in when alerts are present and keep it fully transparent otherwise
- disable pointer interactions while the ticker is hidden so underlying content remains accessible

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8b5c90b988333aecd645baf249cda