### PR TITLE
Hide ticker when no messages are available

### DIFF
--- a/transloc_ticker.html
+++ b/transloc_ticker.html
@@ -22,9 +22,10 @@
       --padding-x: 2rem;
     }
     * { box-sizing: border-box; }
-    html, body { height:100%; margin:0; background:transparent; }
+    html, body { height:100%; margin:0; background:transparent !important; }
     html[data-visible="false"] {
       pointer-events: none;
+      background: transparent !important;
     }
     body {
       font-family: 'FGDC', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
@@ -34,10 +35,13 @@
 
     body[data-visible="true"] {
       opacity: 1;
+      display: block;
     }
 
     body[data-visible="false"] {
       pointer-events: none;
+      display: none;
+      background: transparent !important;
     }
 
     @keyframes ticker-scroll {


### PR DESCRIPTION
## Summary
- hide the ticker overlay whenever no alerts are returned so the signage beneath can show through
- force the html/body background to remain transparent when the ticker is hidden

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8bd7bc7488333a7e1553cd6577178