### PR TITLE
Ensure ticker overlay is transparent without alerts

### DIFF
--- a/transloc_ticker.html
+++ b/transloc_ticker.html
@@ -168,18 +168,21 @@
         error.style.display = 'none';
         error.textContent = '';
       }
+      const hasMessages = list.length > 0;
       if (document.body) {
-        document.body.setAttribute('data-visible', list.length ? 'true' : 'false');
+        document.body.setAttribute('data-visible', hasMessages ? 'true' : 'false');
       }
       if (document.documentElement) {
-        document.documentElement.setAttribute('data-visible', list.length ? 'true' : 'false');
+        document.documentElement.setAttribute('data-visible', hasMessages ? 'true' : 'false');
       }
       if (!wrap || !strip) return;
       strip.innerHTML = '';
-      if (!list.length) {
+      if (!hasMessages) {
         wrap.style.display = 'none';
+        wrap.style.background = 'transparent';
         return;
       }
+      wrap.style.background = '';
       const sepText = qp('sep','•');
       list.forEach((msg, i) => {
         const item = document.createElement('div');


### PR DESCRIPTION
## Summary
- ensure the ticker background is forced to transparent when no messages are available
- restore the configured background once alerts exist again

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c8c4f76a5c8333bbc7b3e91feb9723