### PR TITLE
Hide transloc ticker when no alerts

### DIFF
--- a/transloc_ticker.html
+++ b/transloc_ticker.html
@@ -31,6 +31,8 @@
     html[data-visible="false"] {
       pointer-events: none;
       background: transparent !important;
+      height: 0;
+      overflow: hidden;
     }
     body {
       font-family: 'FGDC', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
@@ -42,11 +44,13 @@
 
     body[data-visible="true"] {
       opacity: 1;
+      display: block;
     }
 
     body[data-visible="false"] {
       pointer-events: none;
       opacity: 0;
+      display: none;
     }
 
     @keyframes ticker-scroll {
@@ -159,6 +163,22 @@
       return [...new Set(out)];
     }
 
+    function setTickerVisibility(hasMessages, { forcePageVisible = false, wrap = null } = {}) {
+      const wrapEl = wrap || document.querySelector('.ticker-wrap');
+      if (wrapEl) {
+        wrapEl.style.display = hasMessages ? 'block' : 'none';
+      }
+      const shouldShowPage = hasMessages || forcePageVisible;
+      const htmlEl = document.documentElement;
+      const bodyEl = document.body;
+      if (bodyEl) {
+        bodyEl.setAttribute('data-visible', shouldShowPage ? 'true' : 'false');
+      }
+      if (htmlEl) {
+        htmlEl.setAttribute('data-visible', shouldShowPage ? 'true' : 'false');
+      }
+    }
+
     function render(messages) {
       const list = Array.isArray(messages) ? messages.filter(Boolean) : [];
       const wrap = document.querySelector('.ticker-wrap');
@@ -169,20 +189,13 @@
         error.textContent = '';
       }
       const hasMessages = list.length > 0;
-      if (document.body) {
-        document.body.setAttribute('data-visible', hasMessages ? 'true' : 'false');
-      }
-      if (document.documentElement) {
-        document.documentElement.setAttribute('data-visible', hasMessages ? 'true' : 'false');
-      }
       if (!wrap || !strip) return;
       strip.innerHTML = '';
       if (!hasMessages) {
-        wrap.style.display = 'none';
-        wrap.style.background = 'transparent';
+        setTickerVisibility(false, { wrap });
         return;
       }
-      wrap.style.background = '';
+      setTickerVisibility(true, { wrap });
       const sepText = qp('sep','•');
       list.forEach((msg, i) => {
         const item = document.createElement('div');
@@ -196,19 +209,13 @@
           strip.appendChild(sep);
         }
       });
-      wrap.style.display = 'block';
     }
 
     function showError(text) {
-      const wrap = document.querySelector('.ticker-wrap');
-      if (wrap) {
-        wrap.style.display = 'none';
-      }
-      if (document.body) {
-        document.body.setAttribute('data-visible', 'true');
-      }
-      if (document.documentElement) {
-        document.documentElement.setAttribute('data-visible', 'true');
+      setTickerVisibility(false, { forcePageVisible: true });
+      const strip = document.getElementById('alerts-container');
+      if (strip) {
+        strip.innerHTML = '';
       }
       const e = document.querySelector('.ticker-error');
       if (!e) return;


### PR DESCRIPTION
## Summary
- mirror the arrivals ticker behavior so the TransLoc ticker fully hides when no alerts are available
- centralize ticker visibility handling and collapse the page while keeping error messaging visible when needed
- clear leftover ticker content when surfacing an error message

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8c6df89fc8333b64d1700e396fc9f