### PR TITLE
Embed TransLoc ticker iframe on arrivals display

### DIFF
--- a/arrivalsdisplay.html
+++ b/arrivalsdisplay.html
@@ -16,10 +16,27 @@
 
   *{box-sizing:border-box;}
   @keyframes ticker{0%{transform:translate3d(0,0,0);visibility:visible;}100%{transform:translate3d(-100%,0,0);}}
-  .ticker-wrap { position:fixed; bottom:80px; left:0; width:50%; overflow:hidden; height:4rem; background:rgba(0,0,0,.9); padding-left:0; box-sizing:content-box; display:none; }
+  .ticker-wrap { display:none !important; }
   .ticker { display:inline-block; height:4rem; line-height:4rem; white-space:nowrap; padding-left:100%; padding-right:100%; box-sizing:content-box; animation: ticker 30s linear infinite; }
   .ticker__item { display:inline-block; padding:0 2rem; font-size:3rem; color:#fff; }
   .ticker__separator { display:inline-block; padding:0 1rem; font-size:2rem; color:#fff; }
+  .ticker-embed-container {
+    position:fixed;
+    bottom:80px;
+    left:50%;
+    transform:translateX(-50%);
+    width:1920px;
+    height:44px;
+    display:flex;
+    justify-content:center;
+    align-items:center;
+    z-index:20;
+  }
+  .ticker-embed-container iframe {
+    width:100%;
+    height:100%;
+    border:none;
+  }
   h1,h2,p{padding:0 5%;}
 
   .footer { position:fixed; bottom:0; width:100%; height:80px; background:#E57200; color:#fff; display:flex; justify-content:space-between; align-items:center; padding:0 20px; box-sizing:border-box; }
@@ -650,6 +667,10 @@ document.addEventListener('DOMContentLoaded',()=>{
   </div>
 
   <div class="ticker-wrap"><div class="ticker" id="alerts-container"></div></div>
+
+  <div class="ticker-embed-container">
+    <iframe src="transloc_ticker.html" title="Transit alerts ticker" width="1920" height="44"></iframe>
+  </div>
 
   <div class="footer">
     <div class="footer-left">UNIVERSITY TRANSIT SERVICE</div>


### PR DESCRIPTION
## Summary
- hide the legacy in-page ticker markup on the arrivals display
- add a fixed-position container that embeds transloc_ticker.html via iframe
- size the embedded ticker to 1920×44 pixels so it sits just above the footer

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8cc63dab08333ab691171c07602ef