### PR TITLE
Allow ticker to request inactive alerts via URL

### DIFF
--- a/transloc_ticker.html
+++ b/transloc_ticker.html
@@ -124,7 +124,14 @@
     }
 
     async function fetchAlerts() {
-      const showInactive = (qp('showInactiveAlerts','false') === 'true');
+      const showInactive = (() => {
+        const direct = qp('showInactive');
+        if (direct !== null) {
+          const value = direct.trim().toLowerCase();
+          return value === '' || value === 'true';
+        }
+        return qp('showInactiveAlerts','false') === 'true';
+      })();
       const url = 'https://uva.transloc.com/Secure/Services/RoutesService.svc/GetMessagesPaged';
       const resp = await axios.get(url, {
         params: {


### PR DESCRIPTION
## Summary
- allow the transloc ticker to honour a `showInactive` URL parameter when requesting alerts
- keep the previous `showInactiveAlerts` parameter as a fallback for backwards compatibility

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8d0efd2ec8333b44a6504d839731f