### PR TITLE
Improve WebKit compatibility for ticker

### DIFF
--- a/transloc_ticker.html
+++ b/transloc_ticker.html
@@ -11,9 +11,9 @@
       font-display: swap;
     }
 
-    :root{
+    :root {
       --height: 4rem;
-      --bg: rgba(0,0,0,0.9);
+      --bg: rgba(0, 0, 0, 0.9);
       --fg: #ffffff;
       --sep-fg: #ffffff;
       --size: 3rem;
@@ -21,19 +21,26 @@
       --duration: 30s;
       --padding-x: 2rem;
     }
-    * { box-sizing: border-box; }
-    html, body {
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html,
+    body {
       height: 100%;
       margin: 0;
       background: transparent !important;
       background-color: transparent !important;
     }
+
     html[data-visible="false"] {
       pointer-events: none;
       background: transparent !important;
       height: 0;
       overflow: hidden;
     }
+
     body {
       font-family: 'FGDC', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
       opacity: 0;
@@ -53,44 +60,84 @@
       display: none;
     }
 
-    @keyframes ticker-scroll {
-      0%   { transform: translate3d(0,0,0); visibility: visible; }
-      100% { transform: translate3d(-100%,0,0); }
+    @-webkit-keyframes ticker-scroll {
+      0% {
+        -webkit-transform: translate3d(0, 0, 0);
+        transform: translate3d(0, 0, 0);
+        visibility: visible;
+      }
+
+      100% {
+        -webkit-transform: translate3d(-100%, 0, 0);
+        transform: translate3d(-100%, 0, 0);
+      }
     }
+
+    @keyframes ticker-scroll {
+      0% {
+        -webkit-transform: translate3d(0, 0, 0);
+        transform: translate3d(0, 0, 0);
+        visibility: visible;
+      }
+
+      100% {
+        -webkit-transform: translate3d(-100%, 0, 0);
+        transform: translate3d(-100%, 0, 0);
+      }
+    }
+
     .ticker-wrap {
       position: relative;
       width: 100%;
       overflow: hidden;
+      height: 4rem;
       height: var(--height);
+      background: rgba(0, 0, 0, 0.9);
       background: var(--bg);
       padding-left: 100%;
       box-sizing: content-box;
       display: none;
     }
+
     .ticker {
       display: inline-block;
+      height: 4rem;
       height: var(--height);
+      line-height: 4rem;
       line-height: var(--height);
       white-space: nowrap;
       padding-right: 100%;
       box-sizing: content-box;
+      -webkit-animation: ticker-scroll 30s linear infinite;
+      animation: ticker-scroll 30s linear infinite;
+      -webkit-animation: ticker-scroll var(--duration) linear infinite;
       animation: ticker-scroll var(--duration) linear infinite;
     }
+
     .ticker__item {
       display: inline-block;
+      padding: 0 2rem;
       padding: 0 var(--padding-x);
+      font-size: 3rem;
       font-size: var(--size);
+      color: #ffffff;
       color: var(--fg);
     }
+
     .ticker__separator {
       display: inline-block;
       padding: 0 1rem;
+      font-size: 2rem;
       font-size: var(--sep-size);
+      color: #ffffff;
       color: var(--sep-fg);
     }
+
     .ticker-error {
       display: none;
+      height: 4rem;
       height: var(--height);
+      line-height: 4rem;
       line-height: var(--height);
       background: #7a0000;
       color: #fff;
@@ -100,160 +147,373 @@
     }
   </style>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/0.21.1/axios.min.js" defer></script>
   <script>
-    function qp(name, def=null) {
-      const params = new URLSearchParams(window.location.search);
-      return params.has(name) ? params.get(name) : def;
-    }
-    function applyRuntimeStyles() {
-      const root = document.documentElement.style;
-      [
-        ['--height','height'],
-        ['--bg','bg'],
-        ['--fg','fg'],
-        ['--sep-fg','sepfg'],
-        ['--size','size'],
-        ['--sep-size','sepsize'],
-        ['--duration','duration'],
-        ['--padding-x','pad']
-      ].forEach(([css,varname]) => {
-        const v = qp(varname);
-        if (v) root.setProperty(css, v);
-      });
-    }
+    (function () {
+      var queryCache = null;
 
-    async function fetchAlerts() {
-      const showInactive = (() => {
-        const direct = qp('showInactive');
-        if (direct !== null) {
-          const value = direct.trim().toLowerCase();
-          return value === '' || value === 'true';
+      function isArray(value) {
+        return Object.prototype.toString.call(value) === '[object Array]';
+      }
+
+      function toLowerCase(value) {
+        if (value === null || typeof value === 'undefined') {
+          return '';
         }
-        return qp('showInactiveAlerts','false') === 'true';
-      })();
-      const url = 'https://uva.transloc.com/Secure/Services/RoutesService.svc/GetMessagesPaged';
-      const resp = await axios.get(url, {
-        params: {
-          showInactive: showInactive,
-          includeDeleted: false,
-          messageTypeId: 1,
-          search: false,
-          rows: 10,
-          page: 1,
-          sortIndex: 'StartDateUtc',
-          sortOrder: 'asc'
+        return String(value).toLowerCase();
+      }
+
+      function parseQuery() {
+        if (queryCache) {
+          return queryCache;
         }
-      });
-      const data = resp.data || {};
-      return Array.isArray(data.Rows) ? data.Rows.map(r => r.MessageText).filter(Boolean) : [];
-    }
-
-    async function fetchArrivals() {
-      const stopsParam = qp('stops','');
-      if (!stopsParam) return [];
-      const url = 'https://uva.transloc.com/Services/JSONPRelay.svc/GetStopArrivalTimes';
-      const resp = await axios.get(url, { params: { stops: stopsParam }});
-      const payload = resp.data || {};
-      const out = [];
-      if (payload.Arrivals && Array.isArray(payload.Arrivals)) {
-        payload.Arrivals.forEach(stop => {
-          const routeLabel = stop.RouteShortName || stop.RouteName || `Route ${stop.RouteId}`;
-          const stopLabel  = stop.StopName || `Stop ${stop.StopId}`;
-          const arr = Array.isArray(stop.Arrivals) ? stop.Arrivals : [];
-          arr.forEach(a => {
-            const mins = Math.round((a.SecondsToArrival||0) / 60);
-            out.push(`${routeLabel} → ${stopLabel}: ${mins} min`);
-          });
-        });
-      }
-      return [...new Set(out)];
-    }
-
-    function setTickerVisibility(hasMessages, { forcePageVisible = false, wrap = null } = {}) {
-      const wrapEl = wrap || document.querySelector('.ticker-wrap');
-      if (wrapEl) {
-        wrapEl.style.display = hasMessages ? 'block' : 'none';
-      }
-      const shouldShowPage = hasMessages || forcePageVisible;
-      const htmlEl = document.documentElement;
-      const bodyEl = document.body;
-      if (bodyEl) {
-        bodyEl.setAttribute('data-visible', shouldShowPage ? 'true' : 'false');
-      }
-      if (htmlEl) {
-        htmlEl.setAttribute('data-visible', shouldShowPage ? 'true' : 'false');
-      }
-    }
-
-    function render(messages) {
-      const list = Array.isArray(messages) ? messages.filter(Boolean) : [];
-      const wrap = document.querySelector('.ticker-wrap');
-      const strip = document.getElementById('alerts-container');
-      const error = document.querySelector('.ticker-error');
-      if (error) {
-        error.style.display = 'none';
-        error.textContent = '';
-      }
-      const hasMessages = list.length > 0;
-      if (!wrap || !strip) return;
-      strip.innerHTML = '';
-      if (!hasMessages) {
-        setTickerVisibility(false, { wrap });
-        return;
-      }
-      setTickerVisibility(true, { wrap });
-      const sepText = qp('sep','•');
-      list.forEach((msg, i) => {
-        const item = document.createElement('div');
-        item.className = 'ticker__item';
-        item.textContent = msg;
-        strip.appendChild(item);
-        if (i < list.length - 1) {
-          const sep = document.createElement('span');
-          sep.className = 'ticker__separator';
-          sep.textContent = ` ${sepText} `;
-          strip.appendChild(sep);
+        var out = {};
+        var search = window.location && window.location.search ? window.location.search : '';
+        if (search && search.charAt(0) === '?') {
+          search = search.substring(1);
         }
-      });
-    }
-
-    function showError(text) {
-      setTickerVisibility(false, { forcePageVisible: true });
-      const strip = document.getElementById('alerts-container');
-      if (strip) {
-        strip.innerHTML = '';
+        if (!search) {
+          queryCache = out;
+          return out;
+        }
+        var pairs = search.split('&');
+        for (var i = 0; i < pairs.length; i += 1) {
+          var part = pairs[i];
+          if (!part) {
+            continue;
+          }
+          var eqIndex = part.indexOf('=');
+          var rawKey = eqIndex >= 0 ? part.substring(0, eqIndex) : part;
+          var rawValue = eqIndex >= 0 ? part.substring(eqIndex + 1) : '';
+          var key = decodeURIComponent(rawKey.replace(/\+/g, ' '));
+          if (!key) {
+            continue;
+          }
+          var value = decodeURIComponent(rawValue.replace(/\+/g, ' '));
+          out[key] = value;
+        }
+        queryCache = out;
+        return out;
       }
-      const e = document.querySelector('.ticker-error');
-      if (!e) return;
-      e.textContent = text || 'Error';
-      e.style.display = 'block';
-    }
 
-    async function runOnce() {
-      try {
-        const source = (qp('source','alerts') || 'alerts').toLowerCase();
-        let msgs = [];
-        if (source === 'arrivals') {
-          msgs = await fetchArrivals();
+      function qp(name, def) {
+        var params = parseQuery();
+        if (Object.prototype.hasOwnProperty.call(params, name)) {
+          return params[name];
+        }
+        return typeof def === 'undefined' ? null : def;
+      }
+
+      function applyRuntimeStyles() {
+        var docEl = document.documentElement;
+        if (!docEl || !docEl.style) {
+          return;
+        }
+        var style = docEl.style;
+        var mappings = [
+          ['--height', 'height'],
+          ['--bg', 'bg'],
+          ['--fg', 'fg'],
+          ['--sep-fg', 'sepfg'],
+          ['--size', 'size'],
+          ['--sep-size', 'sepsize'],
+          ['--duration', 'duration'],
+          ['--padding-x', 'pad'],
+        ];
+        for (var i = 0; i < mappings.length; i += 1) {
+          var entry = mappings[i];
+          var cssName = entry[0];
+          var paramName = entry[1];
+          var value = qp(paramName, null);
+          if (value !== null && value !== '') {
+            if (style.setProperty) {
+              style.setProperty(cssName, value);
+            } else {
+              style[cssName] = value;
+            }
+          }
+        }
+      }
+
+      function buildQueryString(params) {
+        if (!params) {
+          return '';
+        }
+        var parts = [];
+        for (var key in params) {
+          if (!Object.prototype.hasOwnProperty.call(params, key)) {
+            continue;
+          }
+          var value = params[key];
+          if (value === null || typeof value === 'undefined') {
+            continue;
+          }
+          parts.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));
+        }
+        return parts.length ? parts.join('&') : '';
+      }
+
+      function httpGet(url, params, onSuccess, onError) {
+        var finalUrl = url;
+        var query = buildQueryString(params);
+        if (query) {
+          finalUrl += (url.indexOf('?') === -1 ? '?' : '&') + query;
+        }
+        try {
+          var xhr = new XMLHttpRequest();
+          xhr.open('GET', finalUrl, true);
+          xhr.onreadystatechange = function () {
+            if (xhr.readyState === 4) {
+              var status = typeof xhr.status === 'number' ? xhr.status : 0;
+              if ((status >= 200 && status < 300) || status === 304 || status === 0) {
+                var data = null;
+                try {
+                  var rawText = xhr.responseText ? String(xhr.responseText) : '';
+                  if (rawText) {
+                    rawText = rawText.replace(/^\uFEFF/, '').trim();
+                  }
+                  data = rawText ? JSON.parse(rawText) : {};
+                } catch (parseErr) {
+                  if (onError) {
+                    onError(parseErr);
+                  }
+                  return;
+                }
+                if (onSuccess) {
+                  onSuccess(data);
+                }
+              } else if (onError) {
+                onError(status);
+              }
+            }
+          };
+          xhr.onerror = function () {
+            if (onError) {
+              onError('network');
+            }
+          };
+          xhr.send(null);
+        } catch (err) {
+          if (onError) {
+            onError(err);
+          }
+        }
+      }
+
+      function uniqueMessages(list) {
+        if (!isArray(list)) {
+          return [];
+        }
+        var seen = {};
+        var out = [];
+        for (var i = 0; i < list.length; i += 1) {
+          var item = list[i];
+          if (!item) {
+            continue;
+          }
+          var key = String(item);
+          if (!Object.prototype.hasOwnProperty.call(seen, key)) {
+            seen[key] = true;
+            out.push(key);
+          }
+        }
+        return out;
+      }
+
+      function fetchAlerts(onSuccess, onError) {
+        var direct = qp('showInactive', null);
+        var showInactive = false;
+        if (direct !== null && typeof direct !== 'undefined') {
+          var trimmed = String(direct).replace(/^\s+|\s+$/g, '');
+          var lower = toLowerCase(trimmed);
+          showInactive = lower === '' || lower === 'true';
         } else {
-          msgs = await fetchAlerts();
+          showInactive = toLowerCase(qp('showInactiveAlerts', 'false')) === 'true';
         }
-        render(msgs);
-      } catch (e) {
-        console.error(e);
-        showError('Data unavailable');
-      }
-    }
 
-    document.addEventListener('DOMContentLoaded', () => {
-      applyRuntimeStyles();
-      runOnce();
-      const refreshMs = parseInt(qp('refresh','15000'), 10);
-      if (!isNaN(refreshMs) && refreshMs > 0) {
-        setInterval(runOnce, refreshMs);
+        httpGet(
+          'https://uva.transloc.com/Secure/Services/RoutesService.svc/GetMessagesPaged',
+          {
+            showInactive: showInactive,
+            includeDeleted: false,
+            messageTypeId: 1,
+            search: false,
+            rows: 10,
+            page: 1,
+            sortIndex: 'StartDateUtc',
+            sortOrder: 'asc',
+          },
+          function (data) {
+            var rows = data && data.Rows ? data.Rows : [];
+            var messages = [];
+            if (isArray(rows)) {
+              for (var i = 0; i < rows.length; i += 1) {
+                var row = rows[i];
+                if (row && row.MessageText) {
+                  messages.push(row.MessageText);
+                }
+              }
+            }
+            if (onSuccess) {
+              onSuccess(uniqueMessages(messages));
+            }
+          },
+          onError
+        );
       }
-    });
+
+      function fetchArrivals(onSuccess, onError) {
+        var stopsParam = qp('stops', '');
+        if (!stopsParam) {
+          if (onSuccess) {
+            onSuccess([]);
+          }
+          return;
+        }
+        httpGet(
+          'https://uva.transloc.com/Services/JSONPRelay.svc/GetStopArrivalTimes',
+          { stops: stopsParam },
+          function (payload) {
+            var out = [];
+            var arrivals = payload && payload.Arrivals ? payload.Arrivals : [];
+            if (isArray(arrivals)) {
+              for (var i = 0; i < arrivals.length; i += 1) {
+                var stop = arrivals[i];
+                if (!stop) {
+                  continue;
+                }
+                var routeLabel = stop.RouteShortName || stop.RouteName || ('Route ' + stop.RouteId);
+                var stopLabel = stop.StopName || ('Stop ' + stop.StopId);
+                var stopArrivals = stop.Arrivals && isArray(stop.Arrivals) ? stop.Arrivals : [];
+                for (var j = 0; j < stopArrivals.length; j += 1) {
+                  var arrival = stopArrivals[j];
+                  var seconds = arrival && arrival.SecondsToArrival ? arrival.SecondsToArrival : 0;
+                  var mins = Math.round(seconds / 60);
+                  out.push(routeLabel + ' → ' + stopLabel + ': ' + mins + ' min');
+                }
+              }
+            }
+            if (onSuccess) {
+              onSuccess(uniqueMessages(out));
+            }
+          },
+          onError
+        );
+      }
+
+      function setTickerVisibility(hasMessages, options) {
+        var opts = options || {};
+        var wrapEl = opts.wrap || document.querySelector('.ticker-wrap');
+        if (wrapEl) {
+          wrapEl.style.display = hasMessages ? 'block' : 'none';
+        }
+        var shouldShowPage = hasMessages || !!opts.forcePageVisible;
+        var htmlEl = document.documentElement;
+        var bodyEl = document.body;
+        if (bodyEl && bodyEl.setAttribute) {
+          bodyEl.setAttribute('data-visible', shouldShowPage ? 'true' : 'false');
+        }
+        if (htmlEl && htmlEl.setAttribute) {
+          htmlEl.setAttribute('data-visible', shouldShowPage ? 'true' : 'false');
+        }
+      }
+
+      function render(messages) {
+        var list = isArray(messages) ? messages : [];
+        var wrap = document.querySelector('.ticker-wrap');
+        var strip = document.getElementById('alerts-container');
+        var error = document.querySelector('.ticker-error');
+        if (error) {
+          error.style.display = 'none';
+          error.textContent = '';
+        }
+        var hasMessages = list.length > 0;
+        if (!wrap || !strip) {
+          return;
+        }
+        strip.innerHTML = '';
+        if (!hasMessages) {
+          setTickerVisibility(false, { wrap: wrap });
+          return;
+        }
+        setTickerVisibility(true, { wrap: wrap });
+        var sepText = qp('sep', '•');
+        for (var i = 0; i < list.length; i += 1) {
+          var message = list[i];
+          if (!message) {
+            continue;
+          }
+          var item = document.createElement('div');
+          item.className = 'ticker__item';
+          item.textContent = message;
+          strip.appendChild(item);
+          if (i < list.length - 1) {
+            var sep = document.createElement('span');
+            sep.className = 'ticker__separator';
+            sep.textContent = ' ' + sepText + ' ';
+            strip.appendChild(sep);
+          }
+        }
+      }
+
+      function showError(text) {
+        setTickerVisibility(false, { forcePageVisible: true });
+        var strip = document.getElementById('alerts-container');
+        if (strip) {
+          strip.innerHTML = '';
+        }
+        var error = document.querySelector('.ticker-error');
+        if (!error) {
+          return;
+        }
+        error.textContent = text || 'Error';
+        error.style.display = 'block';
+      }
+
+      function logError(err) {
+        if (window.console && console.error) {
+          console.error(err);
+        }
+      }
+
+      function runOnce() {
+        var sourceRaw = qp('source', 'alerts') || 'alerts';
+        var source = toLowerCase(sourceRaw);
+        var handleSuccess = function (messages) {
+          render(messages);
+        };
+        var handleError = function (err) {
+          logError(err);
+          showError('Data unavailable');
+        };
+        if (source === 'arrivals') {
+          fetchArrivals(handleSuccess, handleError);
+        } else {
+          fetchAlerts(handleSuccess, handleError);
+        }
+      }
+
+      function onReady(fn) {
+        if (document.readyState === 'complete' || document.readyState === 'interactive') {
+          setTimeout(fn, 0);
+          return;
+        }
+        if (document.addEventListener) {
+          document.addEventListener('DOMContentLoaded', fn);
+        } else if (window.attachEvent) {
+          window.attachEvent('onload', fn);
+        }
+      }
+
+      onReady(function () {
+        applyRuntimeStyles();
+        runOnce();
+        var refreshStr = qp('refresh', '15000');
+        var refreshMs = parseInt(refreshStr, 10);
+        if (!isNaN(refreshMs) && refreshMs > 0) {
+          setInterval(runOnce, refreshMs);
+        }
+      });
+    })();
   </script>
 </head>
 <body data-visible="false">


### PR DESCRIPTION
## Summary
- replace axios and modern JavaScript features with XMLHttpRequest-based helpers that run in older WebKit engines
- add resilient query parsing, runtime style application, and message rendering logic that avoid modern language constructs
- provide CSS fallbacks and WebKit-prefixed keyframes/animations so the ticker displays in browsers without custom property support

## Testing
- not run (HTML-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c8d299ad1c833389f7da32e92740f7