### PR TITLE
Avoid map recenter in kiosk mode

### DIFF
--- a/map.html
+++ b/map.html
@@ -740,7 +740,9 @@
                       if (bounds) {
                           allRouteBounds = bounds;
                           if (!mapHasFitAllRoutes) {
-                              map.fitBounds(allRouteBounds, { padding: [20, 20] });
+                              if (!kioskMode) {
+                                  map.fitBounds(allRouteBounds, { padding: [20, 20] });
+                              }
                               mapHasFitAllRoutes = true;
                           }
                       }


### PR DESCRIPTION
## Summary
- prevent the map from fitting route bounds when kiosk mode is enabled so the default view remains in place

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c8ea918fa88333929d69087008f738