### PR TITLE
Skip cookie banner in kiosk mode

### DIFF
--- a/map.html
+++ b/map.html
@@ -422,6 +422,9 @@
       }
 
       function showCookieBanner() {
+        if (kioskMode) {
+          return;
+        }
         if (localStorage.getItem('agencyConsent') !== 'true') {
           const banner = document.getElementById('cookieBanner');
           banner.style.display = 'block';


### PR DESCRIPTION
## Summary
- prevent the cookie consent banner from appearing when the map runs in kiosk mode

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8ebfb51cc8333b4120e08e4ae418a