### PR TITLE
Update madmap disclaimer text and button colors

### DIFF
--- a/madmap.html
+++ b/madmap.html
@@ -192,12 +192,12 @@
         cursor: pointer;
       }
       #disclaimerConfirm {
-        background-color: #E57200;
-        color: black;
-      }
-      #disclaimerCancel {
         background-color: #f00;
         color: white;
+      }
+      #disclaimerCancel {
+        background-color: #E57200;
+        color: black;
       }
     </style>
     <script>
@@ -1107,7 +1107,7 @@
   <body>
     <div id="disclaimerModal">
       <div class="modal-content">
-        <p>THIS PAGE WILL ATTEMPT TO LOAD VEHICLE LOCATIONS, STOPS, ROUTES, AND SCHEDULES FROM 53 DIFFERENT AGENCIES. MOBILE PHONES CANNOT SUPPORT THE MEMORY USAGE. MOST CONSUMER COMPUTERS CANNOT SUPPORT THE MEMORY USAGE. THIS EXPLOSION OF INTERNET TRAFFIC WILL LIKELY BE SEEN AS A DDOS BY TRANSLOC. ARE YOU SURE YOU WISH TO PROCEED?</p>
+        <p>THIS PAGE WILL ATTEMPT TO LOAD VEHICLE LOCATIONS, STOPS, ROUTES, AND SCHEDULES FROM 53 DIFFERENT AGENCIES EVERY FIVE SECONDS. MOBILE PHONES CANNOT SUPPORT THE MEMORY USAGE. MOST CONSUMER COMPUTERS CANNOT SUPPORT THE MEMORY USAGE. THIS EXPLOSION OF INTERNET TRAFFIC WILL LIKELY BE SEEN AS A DDOS BY TRANSLOC. ARE YOU SURE YOU WISH TO PROCEED?</p>
         <div class="modal-buttons">
           <button id="disclaimerConfirm">I'm sure</button>
           <button id="disclaimerCancel">You're right, this is a bad idea</button>


### PR DESCRIPTION
## Summary
- update the madmap disclaimer copy to mention the five-second refresh cadence
- swap the modal confirmation and cancellation button colors to keep styles aligned with their actions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c90ab7559883339449720fb8ecd374