### PR TITLE
Fix map route selector script error

### DIFF
--- a/map.html
+++ b/map.html
@@ -433,7 +433,7 @@
           });
         }
         routeIDs.forEach(routeID => {
-          if (!canDisplayRoute(routeID) || Number(routeID) === 0) continue;
+          if (!canDisplayRoute(routeID) || Number(routeID) === 0) return;
           let chk = document.getElementById("route_" + routeID);
           if (chk) {
             chk.addEventListener("change", function() {


### PR DESCRIPTION
## Summary
- replace the invalid `continue` inside the route selector forEach loop with a return so the script no longer throws

## Testing
- playwright http://127.0.0.1:8000/map.html

------
https://chatgpt.com/codex/tasks/task_e_68c9f70c6c7c8333b451adf1e25f9017