### PR TITLE
Fix route canvas overlay ordering on test map

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -72,6 +72,7 @@
       #route-canvas {
         position: absolute;
         inset: 0;
+        z-index: 350;
         pointer-events: none;
       }
       html, body {


### PR DESCRIPTION
## Summary
- ensure the route canvas is layered above the tile pane so routes stay visible

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cb1fded3fc83338ab78993e24468fa