### PR TITLE
Fix overlap renderer rbush instantiation

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -971,7 +971,7 @@
 
           if (allSegments.length === 0) return;
 
-          const tree = new RBush();
+          const tree = rbush();
           tree.load(treeItems);
 
           allSegments.forEach(segment => {


### PR DESCRIPTION
## Summary
- instantiate the overlap renderer's spatial index via the global `rbush()` factory

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cb562345608333bf19eb3dcfdbd95c