### PR TITLE
Revert rbush instantiation change

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -971,7 +971,7 @@
 
           if (allSegments.length === 0) return;
 
-          const tree = rbush();
+          const tree = new RBush();
           tree.load(treeItems);
 
           allSegments.forEach(segment => {


### PR DESCRIPTION
## Summary
- restore the previous `new RBush()` instantiation when building the overlap renderer's spatial index so the map renders correctly

## Testing
- not run (html change only)


------
https://chatgpt.com/codex/tasks/task_e_68cb5804e98c8333b6b8daa5f6a8d553