### PR TITLE
Fix route continuity near overlap boundaries

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -1011,6 +1011,13 @@
               if (!segment.sharedRoutes || segment.sharedRoutes.length === 0) return;
               if (segment.primaryRoute !== routeId) {
                 if (currentGroup) {
+                  const boundaryLatLng = segment?.start?.latlng;
+                  if (boundaryLatLng) {
+                    const lastPoint = currentGroup.points[currentGroup.points.length - 1];
+                    if (!this.latLngEquals(lastPoint, boundaryLatLng)) {
+                      currentGroup.points.push(boundaryLatLng);
+                    }
+                  }
                   groups.push(currentGroup);
                   currentGroup = null;
                   lastKey = null;


### PR DESCRIPTION
## Summary
- extend single-route segments to the start of overlapping sections when another route becomes the primary renderer
- prevent short gaps from appearing where overlapping routes meet at intersections

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb682b91a48333803372183611b8be