### PR TITLE
Fetch schematic routes directly from TransLoc

### DIFF
--- a/uts-schematic.html
+++ b/uts-schematic.html
@@ -227,12 +227,19 @@
         </section>
     </main>
     <script type="module">
+        const TRANSLOC_BASE = 'https://uva.transloc.com/Services/JSONPRelay.svc';
+        const TRANSLOC_API_KEY = '8882812681';
+
+        const ROUTE_POLYLINE_URL = `${TRANSLOC_BASE}/GetRoutesForMapWithScheduleWithEncodedLine?APIKey=${TRANSLOC_API_KEY}`;
+        const ROUTE_INFO_URL = `${TRANSLOC_BASE}/GetRoutes?APIKey=${TRANSLOC_API_KEY}`;
+
         const ROUTE_DATA_SOURCES = [
-            '/v1/transloc/routes',
+            ROUTE_POLYLINE_URL,
             'GetRoutesForMapWithScheduleWithEncodedLine.txt'
         ];
         const ROUTE_INFO_SOURCES = [
-            '/v1/transloc/routes',
+            ROUTE_POLYLINE_URL,
+            ROUTE_INFO_URL,
             'GetRoutes.txt'
         ];
 


### PR DESCRIPTION
## Summary
- update the schematic map to request route geometry directly from the TransLoc JSON relay using the known base URL and API key
- retain local dataset fallbacks and include the direct GetRoutes endpoint for metadata retrieval when needed

## Testing
- not run (HTML-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cc4573fcd08333bfe82339790cca3d