### PR TITLE
Ensure stop markers render above route polylines

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -710,6 +710,12 @@
 
       function initMap() {
           map = L.map('map', { zoomControl: false }).setView([38.03799212281404, -78.50981502838886], 15);
+          map.createPane('stopsPane');
+          const stopsPane = map.getPane('stopsPane');
+          if (stopsPane) {
+              stopsPane.style.zIndex = 450;
+              stopsPane.style.pointerEvents = 'auto';
+          }
           const cartoLight = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
               attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
           });
@@ -774,6 +780,7 @@
                               color: "#000000",
                               fillColor: "#FFFFFF",
                               fillOpacity: 1,
+                              pane: 'stopsPane',
                               weight: 3
                           }).addTo(map);
                           const routeStopIds = groupedStops[key]


### PR DESCRIPTION
## Summary
- create a dedicated Leaflet pane for stop markers so they render above route paths
- render stop circle markers in that pane to maintain their z-order after rerenders

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ccb43300788333bc7278c0344c4d97