### PR TITLE
Fix route polyline alignment after zoom and refine stop markers

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -278,8 +278,10 @@
       let overlapRenderer = null;
 
       const STOP_GROUPING_PIXEL_DISTANCE = 20;
-      const STOP_MARKER_ICON_SIZE = 28;
+      const STOP_MARKER_ICON_SIZE = 24;
       const STOP_MARKER_BORDER_COLOR = '#000000';
+      const STOP_MARKER_OUTLINE_COLOR = '#FFFFFF';
+      const STOP_MARKER_OUTLINE_WIDTH = 2;
 
       let agencies = [];
       let baseURL = '';
@@ -766,8 +768,12 @@
               matchTolerancePx: 6,
               strokeWeight: 6
             });
-            map.on('zoomend', () => {
-              if (overlapRenderer) {
+            let lastOverlapZoom = map.getZoom();
+            map.on('moveend', () => {
+              if (!overlapRenderer) return;
+              const currentZoom = map.getZoom();
+              if (typeof currentZoom === 'number' && currentZoom !== lastOverlapZoom) {
+                lastOverlapZoom = currentZoom;
                 overlapRenderer.handleZoomEnd();
               }
             });
@@ -1028,7 +1034,8 @@
       function createStopMarkerIcon(routeIds) {
           const gradient = buildStopMarkerGradient(routeIds);
           const size = STOP_MARKER_ICON_SIZE;
-          const html = `<div class="stop-marker-outer" style="width: ${size}px; height: ${size}px; border: 3px solid ${STOP_MARKER_BORDER_COLOR}; background: ${gradient};"></div>`;
+          const outline = Math.max(0, Number(STOP_MARKER_OUTLINE_WIDTH) || 0);
+          const html = `<div class="stop-marker-outer" style="width: ${size}px; height: ${size}px; border: 2px solid ${STOP_MARKER_BORDER_COLOR}; box-shadow: 0 0 0 ${outline}px ${STOP_MARKER_OUTLINE_COLOR}; background: ${gradient};"></div>`;
           return L.divIcon({
               className: 'stop-marker-container leaflet-div-icon',
               html,
@@ -1211,7 +1218,10 @@
                   .filter(Boolean)))
                   .join(' / ') || 'Stop';
               const groupKey = createStopGroupKey(aggregatedRouteStopIds, fallbackStopIdText);
-              const markerIcon = createStopMarkerIcon(Array.from(allRouteIdsForMarker).sort((a, b) => a - b));
+              const markerRouteIds = Array.from(allRouteIdsForMarker)
+                  .filter(routeId => selectedRouteIdsSet.has(routeId))
+                  .sort((a, b) => a - b);
+              const markerIcon = createStopMarkerIcon(markerRouteIds);
 
               const groupInfo = {
                   position: stopPosition,


### PR DESCRIPTION
## Summary
- ensure the overlap route renderer rerenders after zoom changes so route paths stay aligned
- shrink stop markers, add a white outline, and restrict their gradients to the currently selected routes

## Testing
- not run (front-end change)


------
https://chatgpt.com/codex/tasks/task_e_68ccc2449c788333a1a0962fc1e8eaad