### PR TITLE
Fix route layer transforms and add minimal repro

### DIFF
--- a/testmap-minimal.html
+++ b/testmap-minimal.html
@@ -1,0 +1,338 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Headway Guard Minimal Route Viewer</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+    <script src="https://unpkg.com/@mapbox/polyline@1.1.1"></script>
+    <style>
+      html, body {
+        height: 100%;
+        margin: 0;
+      }
+      #map {
+        height: 100%;
+        width: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="map"></div>
+    <script>
+      (async () => {
+        const params = new URLSearchParams(window.location.search);
+        const forcedBaseURL = params.get('baseURL');
+        const forcedRouteIdParam = params.get('routeId');
+        const forcedRouteId = forcedRouteIdParam !== null ? Number(forcedRouteIdParam) : null;
+
+        const DEFAULT_ROUTE_STROKE_WEIGHT = 6;
+        const MIN_ROUTE_STROKE_WEIGHT = 3;
+        const MAX_ROUTE_STROKE_WEIGHT = 12;
+        const ROUTE_WEIGHT_ZOOM_DELTA_LIMIT = 3;
+        const ROUTE_WEIGHT_STEP_PER_ZOOM = 0;
+
+        let routeWeightReferenceZoom = null;
+        let zoomStartValue = null;
+        let routeLayer = null;
+
+        function ensureContainerHasNoTransforms(element) {
+          if (!element) return [];
+          const cleared = [];
+          element.style.transform = 'none';
+          element.style.willChange = '';
+          let current = element.parentElement;
+          while (current && current !== document.body && current !== document.documentElement) {
+            const computed = window.getComputedStyle(current);
+            if (computed && computed.transform && computed.transform !== 'none') {
+              cleared.push({ element: current.tagName, previousTransform: computed.transform });
+              current.style.transform = 'none';
+            }
+            if (current.style && current.style.willChange) {
+              cleared.push({ element: current.tagName, previousWillChange: current.style.willChange });
+              current.style.willChange = '';
+            }
+            current = current.parentElement;
+          }
+          return cleared;
+        }
+
+        function auditPaneStyles(mapInstance, { sanitize = false } = {}) {
+          const panes = mapInstance && mapInstance._panes ? mapInstance._panes : null;
+          const results = [];
+          if (!panes) {
+            return results;
+          }
+          Object.entries(panes).forEach(([paneKey, paneElement]) => {
+            if (!paneElement || !paneElement.style) return;
+            const transform = paneElement.style.transform || '';
+            const willChange = paneElement.style.willChange || '';
+            const hasCustomTransform = /scale|rotate|matrix|skew/i.test(transform);
+            const hasCustomWillChange = willChange && willChange !== 'auto';
+            if (sanitize) {
+              if (hasCustomTransform) {
+                paneElement.style.transform = '';
+              }
+              if (hasCustomWillChange) {
+                paneElement.style.willChange = '';
+              }
+            }
+            results.push({
+              pane: paneKey,
+              transform,
+              willChange,
+              hasCustomTransform,
+              hasCustomWillChange
+            });
+          });
+          return results;
+        }
+
+        function mergeRouteLayerOptions(renderer, paneName, overrides = {}) {
+          const base = {
+            updateWhenZooming: false,
+            updateWhenIdle: true
+          };
+          if (renderer) {
+            base.renderer = renderer;
+          }
+          if (typeof paneName === 'string' && paneName) {
+            base.pane = paneName;
+          }
+          return Object.assign(base, overrides || {});
+        }
+
+        function computeRouteStrokeWeight(zoom, referenceZoom = routeWeightReferenceZoom) {
+          const baseWeight = DEFAULT_ROUTE_STROKE_WEIGHT;
+          const minWeight = MIN_ROUTE_STROKE_WEIGHT;
+          const maxWeight = MAX_ROUTE_STROKE_WEIGHT;
+          if (!Number.isFinite(zoom)) {
+            return Math.max(minWeight, Math.min(maxWeight, baseWeight));
+          }
+          const baselineZoom = Number.isFinite(referenceZoom) ? referenceZoom : zoom;
+          const zoomDeltaRaw = zoom - baselineZoom;
+          const limitedDelta = Math.max(-ROUTE_WEIGHT_ZOOM_DELTA_LIMIT, Math.min(ROUTE_WEIGHT_ZOOM_DELTA_LIMIT, zoomDeltaRaw));
+          const computed = baseWeight + ROUTE_WEIGHT_STEP_PER_ZOOM * limitedDelta;
+          if (!Number.isFinite(computed)) {
+            return Math.max(minWeight, Math.min(maxWeight, baseWeight));
+          }
+          return Math.max(minWeight, Math.min(maxWeight, computed));
+        }
+
+        function setRouteWeightBaseline(zoom) {
+          if (!Number.isFinite(zoom)) return;
+          routeWeightReferenceZoom = zoom;
+        }
+
+        const mapElement = document.getElementById('map');
+        const containerFixes = ensureContainerHasNoTransforms(mapElement);
+        const map = L.map('map', { crs: L.CRS.EPSG3857 }).setView([38.03799212281404, -78.50981502838886], 15);
+        const routePaneName = 'routesPane';
+        map.createPane(routePaneName);
+        const routesPane = map.getPane(routePaneName);
+        if (routesPane) {
+          routesPane.style.zIndex = 425;
+          routesPane.style.pointerEvents = 'none';
+        }
+        const sharedRouteRenderer = L.svg({ padding: 0, pane: routePaneName });
+        map.addLayer(sharedRouteRenderer);
+        const paneAuditAfterInit = auditPaneStyles(map, { sanitize: true });
+        console.debug('[minimal:init]', {
+          containerFixes,
+          sanitizedPaneStyles: paneAuditAfterInit.filter(entry => entry.hasCustomTransform || entry.hasCustomWillChange)
+        });
+
+        const tileLayer = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+          attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
+        });
+        tileLayer.addTo(map);
+
+        function logZoomDiagnostics(stage, extra = {}) {
+          const zoom = map.getZoom();
+          const paneAudit = auditPaneStyles(map, { sanitize: false });
+          const panesWithCustomStyles = paneAudit.filter(entry => entry.hasCustomTransform || entry.hasCustomWillChange);
+          console.debug(`[minimal:${stage}]`, Object.assign({
+            zoom,
+            routeLayerCount: routeLayer ? 1 : 0,
+            cachedPixelPointsReused: false,
+            panesWithCustomStyles
+          }, extra || {}));
+        }
+
+        function collectRoutePathTransformIssues() {
+          const issues = [];
+          if (typeof window === 'undefined') {
+            return issues;
+          }
+          const path = routeLayer && routeLayer._path;
+          if (!path) {
+            return issues;
+          }
+          let parent = path.parentElement;
+          while (parent && parent !== document.body && parent !== document.documentElement) {
+            const inlineTransform = parent.style ? parent.style.transform || '' : '';
+            let computedTransform = '';
+            try {
+              const computed = window.getComputedStyle(parent);
+              if (computed && computed.transform && computed.transform !== 'none') {
+                computedTransform = computed.transform;
+              }
+            } catch (error) {
+              computedTransform = '';
+            }
+            const transformToCheck = inlineTransform || computedTransform;
+            if (transformToCheck && transformToCheck !== 'none' && /scale|rotate|matrix|skew/i.test(transformToCheck)) {
+              issues.push({
+                parentTag: parent.tagName,
+                transform: transformToCheck
+              });
+              break;
+            }
+            if (parent.classList && parent.classList.contains('leaflet-map-pane')) {
+              break;
+            }
+            parent = parent.parentElement;
+          }
+          return issues;
+        }
+
+        map.on('zoomstart', () => {
+          zoomStartValue = map.getZoom();
+          logZoomDiagnostics('zoomstart', {
+            oldZoom: zoomStartValue,
+            newZoom: null
+          });
+        });
+
+        map.on('zoom', event => {
+          const targetZoom = typeof event?.zoom === 'number' ? event.zoom : map.getZoom();
+          logZoomDiagnostics('zoom', { targetZoom });
+        });
+
+        map.on('zoomend', () => {
+          const currentZoom = map.getZoom();
+          if (!Number.isFinite(routeWeightReferenceZoom)) {
+            setRouteWeightBaseline(currentZoom);
+          }
+          if (routeLayer && typeof routeLayer.setStyle === 'function') {
+            const updatedWeight = computeRouteStrokeWeight(currentZoom);
+            routeLayer.setStyle({ weight: updatedWeight });
+            if (typeof routeLayer.redraw === 'function') {
+              routeLayer.redraw();
+            }
+          }
+          logZoomDiagnostics('zoomend', {
+            oldZoom: zoomStartValue,
+            newZoom: currentZoom,
+            pathTransformIssues: collectRoutePathTransformIssues()
+          });
+          zoomStartValue = null;
+        });
+
+        function normalizeBaseUrl(value) {
+          if (!value) return '';
+          const trimmed = value.trim();
+          if (trimmed === '') return '';
+          if (trimmed.startsWith('http')) {
+            return trimmed.replace(/^http:\/\//i, 'https://');
+          }
+          return `https://${trimmed}`;
+        }
+
+        async function resolveBaseURL() {
+          if (forcedBaseURL) {
+            return normalizeBaseUrl(forcedBaseURL);
+          }
+          try {
+            const response = await fetch('https://admin.ridesystems.net/api/Clients/GetClients');
+            const contentType = response.headers.get('content-type') || '';
+            let clients = [];
+            if (contentType.includes('application/json')) {
+              clients = await response.json();
+            } else {
+              const text = await response.text();
+              const parser = new DOMParser();
+              const xml = parser.parseFromString(text, 'application/xml');
+              clients = Array.from(xml.getElementsByTagName('Client')).map(node => ({
+                Name: node.getElementsByTagName('Name')[0]?.textContent.trim(),
+                WebAddress: node.getElementsByTagName('WebAddress')[0]?.textContent.trim()
+              }));
+            }
+            const cleaned = clients
+              .map(client => ({
+                name: client.Name?.trim(),
+                url: normalizeBaseUrl(client.WebAddress)
+              }))
+              .filter(entry => entry.name && entry.url);
+            const uva = cleaned.find(entry => entry.name === 'University of Virginia');
+            if (uva) {
+              return uva.url;
+            }
+            return cleaned[0]?.url || '';
+          } catch (error) {
+            console.error('[minimal] Failed to resolve base URL', error);
+            return '';
+          }
+        }
+
+        const baseURL = await resolveBaseURL();
+        if (!baseURL) {
+          console.error('[minimal] No base URL available; aborting');
+          return;
+        }
+
+        try {
+          const routesResponse = await fetch(`${baseURL}/Services/JSONPRelay.svc/GetRoutesForMapWithScheduleWithEncodedLine?APIKey=8882812681`);
+          const routesData = await routesResponse.json();
+          if (!Array.isArray(routesData)) {
+            console.error('[minimal] Route response is not an array', routesData);
+            return;
+          }
+          let chosenRoute = null;
+          if (Number.isFinite(forcedRouteId)) {
+            chosenRoute = routesData.find(route => Number(route.RouteID) === forcedRouteId);
+          }
+          if (!chosenRoute) {
+            chosenRoute = routesData.find(route => route && route.EncodedPolyline);
+          }
+          if (!chosenRoute || !chosenRoute.EncodedPolyline) {
+            console.error('[minimal] Unable to find a route with an encoded polyline');
+            return;
+          }
+          const decoded = polyline.decode(chosenRoute.EncodedPolyline);
+          const latLngPath = decoded.map(coords => L.latLng(coords[0], coords[1]));
+          if (!Array.isArray(latLngPath) || latLngPath.length < 2) {
+            console.error('[minimal] Decoded path is invalid');
+            return;
+          }
+          const initialZoom = map.getZoom();
+          if (Number.isFinite(initialZoom)) {
+            setRouteWeightBaseline(initialZoom);
+          }
+          const routeColor = typeof chosenRoute.MapLineColor === 'string' && chosenRoute.MapLineColor.trim() !== ''
+            ? chosenRoute.MapLineColor
+            : '#000000';
+          const initialWeight = computeRouteStrokeWeight(map.getZoom());
+          routeLayer = L.polyline(latLngPath, mergeRouteLayerOptions(sharedRouteRenderer, routePaneName, {
+            color: routeColor,
+            weight: initialWeight,
+            opacity: 1,
+            lineCap: 'round',
+            lineJoin: 'round'
+          })).addTo(map);
+          const bounds = routeLayer.getBounds();
+          if (bounds && bounds.isValid && bounds.isValid()) {
+            map.fitBounds(bounds, { padding: [20, 20] });
+          }
+          logZoomDiagnostics('loaded', {
+            baseURL,
+            routeId: chosenRoute.RouteID
+          });
+        } catch (error) {
+          console.error('[minimal] Failed to load route data', error);
+        }
+      })();
+    </script>
+  </body>
+</html>

--- a/testmap.html
+++ b/testmap.html
@@ -242,6 +242,137 @@
 
       const enableOverlapDashRendering = true;
 
+      const ROUTE_LAYER_BASE_OPTIONS = Object.freeze({
+        updateWhenZooming: false,
+        updateWhenIdle: true
+      });
+      let sharedRouteRenderer = null;
+      let routePaneName = 'overlayPane';
+
+      function mergeRouteLayerOptions(overrides = {}, rendererOverride = null, paneOverride = null) {
+        const base = Object.assign({}, ROUTE_LAYER_BASE_OPTIONS);
+        const renderer = rendererOverride || sharedRouteRenderer;
+        if (renderer) {
+          base.renderer = renderer;
+        }
+        const pane = paneOverride || routePaneName;
+        if (typeof pane === 'string' && pane) {
+          base.pane = pane;
+        }
+        return Object.assign(base, overrides || {});
+      }
+
+      function auditPaneStyles(options = {}) {
+        const { sanitize = false } = options || {};
+        const panes = map && map._panes ? map._panes : null;
+        const results = [];
+        if (!panes) {
+          return results;
+        }
+        Object.entries(panes).forEach(([paneKey, paneElement]) => {
+          if (!paneElement || !paneElement.style) return;
+          const transform = paneElement.style.transform || '';
+          const willChange = paneElement.style.willChange || '';
+          const hasCustomTransform = /scale|rotate|matrix|skew/i.test(transform);
+          const hasCustomWillChange = willChange && willChange !== 'auto';
+          if (sanitize) {
+            if (hasCustomTransform) {
+              paneElement.style.transform = '';
+            }
+            if (hasCustomWillChange) {
+              paneElement.style.willChange = '';
+            }
+          }
+          results.push({
+            pane: paneKey,
+            transform,
+            willChange,
+            hasCustomTransform,
+            hasCustomWillChange
+          });
+        });
+        return results;
+      }
+
+      function ensureContainerHasNoTransforms(element) {
+        if (!element) return [];
+        const cleared = [];
+        element.style.transform = 'none';
+        element.style.willChange = '';
+        let current = element.parentElement;
+        while (current && current !== document.body && current !== document.documentElement) {
+          const computed = window.getComputedStyle(current);
+          if (computed && computed.transform && computed.transform !== 'none') {
+            cleared.push({ element: current.tagName, previousTransform: computed.transform });
+            current.style.transform = 'none';
+          }
+          if (current.style && current.style.willChange) {
+            cleared.push({ element: current.tagName, previousWillChange: current.style.willChange });
+            current.style.willChange = '';
+          }
+          current = current.parentElement;
+        }
+        return cleared;
+      }
+
+      function isPixelGeometryCachedAcrossZooms() {
+        if (enableOverlapDashRendering && overlapRenderer && typeof overlapRenderer.hasPersistentPixelCache === 'function') {
+          return overlapRenderer.hasPersistentPixelCache();
+        }
+        return false;
+      }
+
+      function logZoomDiagnostics(stage, extra = {}) {
+        const zoom = typeof map?.getZoom === 'function' ? map.getZoom() : null;
+        const paneAudit = auditPaneStyles({ sanitize: false });
+        const panesWithCustomStyles = paneAudit.filter(entry => entry.hasCustomTransform || entry.hasCustomWillChange);
+        console.debug(`[routes:${stage}]`, Object.assign({
+          zoom,
+          routeLayerCount: Array.isArray(routeLayers) ? routeLayers.length : 0,
+          cachedPixelPointsReused: isPixelGeometryCachedAcrossZooms(),
+          panesWithCustomStyles
+        }, extra || {}));
+      }
+
+      function collectRoutePathTransformIssues() {
+        const layers = Array.isArray(routeLayers) ? routeLayers : [];
+        const issues = [];
+        if (typeof window === 'undefined') {
+          return issues;
+        }
+        layers.forEach(layer => {
+          const path = layer && layer._path;
+          if (!path) return;
+          let parent = path.parentElement;
+          while (parent && parent !== document.body && parent !== document.documentElement) {
+            const inlineTransform = parent.style ? parent.style.transform || '' : '';
+            let computedTransform = '';
+            try {
+              const computed = window.getComputedStyle(parent);
+              if (computed && computed.transform && computed.transform !== 'none') {
+                computedTransform = computed.transform;
+              }
+            } catch (error) {
+              computedTransform = '';
+            }
+            const transformToCheck = inlineTransform || computedTransform;
+            if (transformToCheck && transformToCheck !== 'none' && /scale|rotate|matrix|skew/i.test(transformToCheck)) {
+              issues.push({
+                layerId: layer && layer._leaflet_id ? layer._leaflet_id : null,
+                parentTag: parent.tagName,
+                transform: transformToCheck
+              });
+              break;
+            }
+            if (parent.classList && parent.classList.contains('leaflet-map-pane')) {
+              break;
+            }
+            parent = parent.parentElement;
+          }
+        });
+        return issues;
+      }
+
       const params = new URLSearchParams(window.location.search);
       const kioskParam = params.get('kioskMode');
       if (kioskParam !== null) {
@@ -815,18 +946,36 @@
       }
 
       function initMap() {
-          map = L.map('map', { zoomControl: false }).setView([38.03799212281404, -78.50981502838886], 15);
-          const initialZoom = typeof map?.getZoom === 'function' ? map.getZoom() : null;
-          if (Number.isFinite(initialZoom)) {
-              setRouteWeightBaseline(initialZoom);
-          } else {
-              resetRouteWeightBaseline();
+          const mapElement = document.getElementById('map');
+          const containerTransformFixes = ensureContainerHasNoTransforms(mapElement);
+          map = L.map('map', { zoomControl: false, crs: L.CRS.EPSG3857 }).setView([38.03799212281404, -78.50981502838886], 15);
+          routePaneName = 'routesPane';
+          map.createPane(routePaneName);
+          const routesPane = map.getPane(routePaneName);
+          if (routesPane) {
+              routesPane.style.zIndex = 425;
+              routesPane.style.pointerEvents = 'none';
           }
           map.createPane('stopsPane');
           const stopsPane = map.getPane('stopsPane');
           if (stopsPane) {
               stopsPane.style.zIndex = 450;
               stopsPane.style.pointerEvents = 'auto';
+          }
+          sharedRouteRenderer = L.svg({ padding: 0, pane: routePaneName });
+          if (sharedRouteRenderer) {
+              map.addLayer(sharedRouteRenderer);
+          }
+          const paneAuditAfterInit = auditPaneStyles({ sanitize: true });
+          console.debug('[routes:init]', {
+              containerTransformFixes,
+              sanitizedPaneStyles: paneAuditAfterInit.filter(entry => entry.hasCustomTransform || entry.hasCustomWillChange)
+          });
+          const initialZoom = typeof map?.getZoom === 'function' ? map.getZoom() : null;
+          if (Number.isFinite(initialZoom)) {
+              setRouteWeightBaseline(initialZoom);
+          } else {
+              resetRouteWeightBaseline();
           }
           const cartoLight = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
               attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
@@ -842,7 +991,9 @@
               strokeWeight: DEFAULT_ROUTE_STROKE_WEIGHT,
               minStrokeWeight: MIN_ROUTE_STROKE_WEIGHT,
               maxStrokeWeight: MAX_ROUTE_STROKE_WEIGHT,
-              referenceZoom: routeWeightReferenceZoom
+              referenceZoom: routeWeightReferenceZoom,
+              renderer: sharedRouteRenderer,
+              pane: routePaneName
             });
             lastOverlapZoom = typeof map?.getZoom === 'function' ? map.getZoom() : null;
           }
@@ -862,14 +1013,16 @@
               startRefreshIntervals();
           });
           fetchStopArrivalTimes().then(allEtas => { cachedEtas = allEtas; });
-          map.on('move', updatePopupPositions);
-          map.on('zoom', updatePopupPositions);
+          map.on('zoom', event => {
+              const targetZoom = typeof event?.zoom === 'number' ? event.zoom : (typeof map?.getZoom === 'function' ? map.getZoom() : null);
+              logZoomDiagnostics('zoom', { targetZoom });
+          });
           map.on('zoomstart', () => {
               const startZoom = typeof map?.getZoom === 'function' ? map.getZoom() : null;
               zoomDebugState.zoomStart = startZoom;
               const referenceZoom = getActiveReferenceZoom();
               const computedWeight = computeDebugStrokeWeight(startZoom);
-              console.debug('[routes:zoomstart]', {
+              logZoomDiagnostics('zoomstart', {
                   oldZoom: startZoom,
                   newZoom: null,
                   referenceZoom,
@@ -911,7 +1064,8 @@
 
               const referenceZoom = getActiveReferenceZoom();
               const computedWeight = computeDebugStrokeWeight(currentZoom);
-              console.debug('[routes:zoomend]', {
+              const pathTransformIssues = collectRoutePathTransformIssues();
+              logZoomDiagnostics('zoomend', {
                   oldZoom: previousZoom,
                   newZoom: currentZoom,
                   referenceZoom,
@@ -919,7 +1073,8 @@
                   handlers: {
                       overlapRenderer: overlapRendererHandled,
                       simpleStrokeUpdate
-                  }
+                  },
+                  pathTransformIssues: pathTransformIssues
               });
               if (Number.isFinite(currentZoom) && (routeWeightBaselinePending || !Number.isFinite(routeWeightReferenceZoom))) {
                   setRouteWeightBaseline(currentZoom);
@@ -927,16 +1082,17 @@
               if (stopDataCache.length > 0) {
                   renderBusStops(stopDataCache);
               }
+              updatePopupPositions();
               zoomDebugState.zoomStart = null;
           });
           map.on('moveend', () => {
-              if (!routeWeightBaselinePending && Number.isFinite(routeWeightReferenceZoom)) {
-                  return;
-              }
               const currentZoom = typeof map?.getZoom === 'function' ? map.getZoom() : null;
-              if (Number.isFinite(currentZoom)) {
-                  setRouteWeightBaseline(currentZoom);
+              if (routeWeightBaselinePending || !Number.isFinite(routeWeightReferenceZoom)) {
+                  if (Number.isFinite(currentZoom)) {
+                      setRouteWeightBaseline(currentZoom);
+                  }
               }
+              updatePopupPositions();
           });
       }
 
@@ -1429,12 +1585,18 @@
       }
 
       function updatePopupPosition(popupElement, position) {
+          if (!map || typeof map?.latLngToContainerPoint !== 'function') {
+              return;
+          }
           const mapPos = map.latLngToContainerPoint(position);
           popupElement.style.left = `${mapPos.x}px`;
           popupElement.style.top = `${mapPos.y}px`;
       }
 
       function updatePopupPositions() {
+          if (!map || typeof map?.latLngToContainerPoint !== 'function') {
+              return;
+          }
           customPopups.forEach(popupElement => {
               const position = popupElement.dataset.position;
               if (position) {
@@ -1535,6 +1697,8 @@
           this.maxStrokeWeight = Number.isFinite(this.options.maxStrokeWeight)
             ? this.options.maxStrokeWeight
             : Infinity;
+          this.renderer = options.renderer || null;
+          this.routePaneName = typeof options.pane === 'string' && options.pane ? options.pane : routePaneName;
         }
 
         setReferenceZoom(zoom) {
@@ -1988,13 +2152,13 @@
 
             if (sortedRoutes.length === 1) {
               const routeId = sortedRoutes[0];
-              const layer = L.polyline(coords, {
+              const layer = L.polyline(coords, mergeRouteLayerOptions({
                 color: getRouteColor(routeId),
                 weight,
                 opacity: 1,
                 lineCap: 'round',
                 lineJoin: 'round'
-              }).addTo(this.map);
+              }, this.renderer, this.routePaneName)).addTo(this.map);
               newLayers.push(layer);
               return;
             }
@@ -2050,7 +2214,7 @@
                 }
                 dashOffsetValue = ((dashOffsetValue % patternLength) + patternLength) % patternLength;
               }
-              const layer = L.polyline(coords, {
+              const layer = L.polyline(coords, mergeRouteLayerOptions({
                 color: getRouteColor(routeId),
                 weight,
                 opacity: 1,
@@ -2058,7 +2222,7 @@
                 dashOffset: `${dashOffsetValue}`,
                 lineCap: 'butt',
                 lineJoin: 'round'
-              }).addTo(this.map);
+              }, this.renderer, this.routePaneName)).addTo(this.map);
               newLayers.push(layer);
             });
           });
@@ -2215,6 +2379,10 @@
           }
           return Math.abs(a.lat - b.lat) <= this.options.latLngEqualityMargin &&
             Math.abs(a.lng - b.lng) <= this.options.latLngEqualityMargin;
+        }
+
+        hasPersistentPixelCache() {
+          return false;
         }
       }
 
@@ -2406,11 +2574,13 @@
                           } else {
                               const currentStrokeWeight = computeRouteStrokeWeight(typeof map?.getZoom === 'function' ? map.getZoom() : null);
                               simpleGeometries.forEach(({ routeId, latLngPath, routeColor }) => {
-                                  const routeLayer = L.polyline(latLngPath, {
+                              const routeLayer = L.polyline(latLngPath, mergeRouteLayerOptions({
                                       color: routeColor,
                                       weight: currentStrokeWeight,
-                                      opacity: 1
-                                  }).addTo(map);
+                                      opacity: 1,
+                                      lineCap: 'round',
+                                      lineJoin: 'round'
+                                  })).addTo(map);
                                   routeLayers.push(routeLayer);
                               });
                           }


### PR DESCRIPTION
## Summary
- ensure Leaflet route layers share a single renderer, avoid manual transforms during zoom, and add zoom diagnostics
- audit pane/container transforms, recompute geometry on zoomend, and guard popup updates from per-frame zoom handling
- provide a minimal reproduction page that renders a single route with the corrected settings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ccd3c100c4833393d24ca3fa20a68c