### PR TITLE
Ensure route paths update while panning

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -1124,6 +1124,9 @@
               updatePopupPositions();
               zoomDebugState.zoomStart = null;
           });
+          map.on('move', () => {
+              syncRendererView(sharedRouteRenderer, map);
+          });
           map.on('moveend', () => {
               const currentZoom = typeof map?.getZoom === 'function' ? map.getZoom() : null;
               if (routeWeightBaselinePending || !Number.isFinite(routeWeightReferenceZoom)) {


### PR DESCRIPTION
## Summary
- trigger the shared SVG renderer to refresh on every map movement
- keep route paths visible while the user pans across the map view

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd86fb2e548333b35083f836466f01