### PR TITLE
Ensure route overlays animate during zoom

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -992,6 +992,9 @@
           if (routesPane) {
               routesPane.style.zIndex = 425;
               routesPane.style.pointerEvents = 'none';
+              if (!routesPane.classList.contains('leaflet-zoom-animated')) {
+                  routesPane.classList.add('leaflet-zoom-animated');
+              }
           }
           map.createPane('stopsPane');
           const stopsPane = map.getPane('stopsPane');
@@ -1053,6 +1056,13 @@
           map.on('zoom', event => {
               const targetZoom = typeof event?.zoom === 'number' ? event.zoom : (typeof map?.getZoom === 'function' ? map.getZoom() : null);
               logZoomDiagnostics('zoom', { targetZoom });
+          });
+          map.on('zoomanim', event => {
+              if (sharedRouteRenderer && typeof sharedRouteRenderer._handleZoomAnim === 'function') {
+                  sharedRouteRenderer._handleZoomAnim(event);
+              } else {
+                  syncRendererView(sharedRouteRenderer, map);
+              }
           });
           map.on('zoomstart', () => {
               const startZoom = typeof map?.getZoom === 'function' ? map.getZoom() : null;


### PR DESCRIPTION
## Summary
- mark the custom routes pane as `leaflet-zoom-animated` so Leaflet animates route SVGs during zooming
- synchronize the shared SVG renderer on `zoomanim` events to keep paths aligned while the zoom animation runs

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cd88d0f6b483339f872ac3724ea26f