### PR TITLE
Clear overlap renderer layers before drawing new groups

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -1742,6 +1742,8 @@
             return;
           }
 
+          this.clearLayers();
+
           const step = Number.isFinite(this.options.sampleStepPx) && this.options.sampleStepPx > 0
             ? this.options.sampleStepPx
             : 8;


### PR DESCRIPTION
## Summary
- clear any existing route layers at the start of each render cycle so zoom frames do not accumulate duplicate polylines

## Testing
- not run (HTML/JS changes only)

------
https://chatgpt.com/codex/tasks/task_e_68cdb6b5c2a08333a499ffa3fb2012bc