### PR TITLE
Remove aggregated stop name from popup header

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -1260,7 +1260,6 @@
 
           popupElement.innerHTML = `
             <button class="custom-popup-close">&times;</button>
-            <span style="font-size: 16px; font-weight: bold;">${sanitizedStopName}</span><br>
             ${stopIdLine}
             ${entriesHtml}
             <div class="custom-popup-arrow"></div>


### PR DESCRIPTION
## Summary
- remove the aggregated stop name string from the popup header so only individual stop sections render names

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68cdc25e2cd0833384c1c253e979d730