### PR TITLE
Restore single-stop popup name display

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -1256,10 +1256,14 @@
           popupElement.dataset.stopId = primaryStopIdText || '';
           popupElement.dataset.groupKey = groupKey;
 
+          const stopNameLine = (!multipleStops && sanitizedStopName)
+              ? `<span class="stop-entry-title">${sanitizedStopName}</span><br>`
+              : '';
           const stopIdLine = primaryStopIdText ? `<span>Stop ID: ${primaryStopIdText}</span><br>` : '';
 
           popupElement.innerHTML = `
             <button class="custom-popup-close">&times;</button>
+            ${stopNameLine}
             ${stopIdLine}
             ${entriesHtml}
             <div class="custom-popup-arrow"></div>


### PR DESCRIPTION
## Summary
- restore showing the sanitized stop name within popups that contain a single stop entry while keeping aggregated headers removed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdc455478883338f151627aab8040e