### PR TITLE
Use route colors for stop ETA pills

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -1879,7 +1879,11 @@
           });
           const etaRows = etas.length > 0
               ? etas.sort((a, b) => a.etaMinutes - b.etaMinutes || a.routeDescription.localeCompare(b.routeDescription))
-                    .map(eta => `<tr><td style="padding: 5px; text-align: center;"><div class="route-pill" style="background-color: ${getRouteColor(eta.RouteId)}; color: ${getContrastColor(getRouteColor(eta.RouteId))};">${eta.routeDescription}</div></td><td style="padding: 5px; text-align: center;">${eta.etaMinutes < 1 ? 'Arriving' : eta.etaMinutes + ' min'}</td></tr>`)
+                    .map(eta => {
+                        const routeColor = getRouteColor(eta.RouteId);
+                        const textColor = getContrastColor(routeColor);
+                        return `<tr><td style="padding: 5px; text-align: center;"><div class="route-pill" style="background: ${routeColor}; color: ${textColor};">${eta.routeDescription}</div></td><td style="padding: 5px; text-align: center;">${eta.etaMinutes < 1 ? 'Arriving' : eta.etaMinutes + ' min'}</td></tr>`;
+                    })
                     .join('')
               : '<tr><td colspan="2" style="padding: 5px; text-align: center;">No upcoming arrivals</td></tr>';
           return `


### PR DESCRIPTION
## Summary
- ensure stop ETA route pills take on the associated route color instead of the default accent gradient

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cddd4ae0d083339a07853f15df6d82