### PR TITLE
Hide system controls panel in kiosk modes

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -1544,6 +1544,14 @@
               if (kioskMode || adminKioskMode) {
                 document.getElementById("routeSelector").style.display = "none";
                 document.getElementById("routeSelectorTab").style.display = "none";
+                const controlPanel = document.getElementById("controlPanel");
+                if (controlPanel) {
+                  controlPanel.style.display = "none";
+                }
+                const controlPanelTab = document.getElementById("controlPanelTab");
+                if (controlPanelTab) {
+                  controlPanelTab.style.display = "none";
+                }
               }
               fetchStopArrivalTimes().then(allEtas => {
                   cachedEtas = allEtas;


### PR DESCRIPTION
## Summary
- hide the system controls panel and its toggle when kioskMode or adminKioskMode are enabled so the kiosk layout stays clean
- ensure the kiosk route legend remains unobstructed by removing the overlapping controls panel

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdde2116708333aa26fbffb7b7c716