### PR TITLE
Preserve route selector scroll position

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -1263,6 +1263,13 @@
         }
         lastRouteSelectorSignature = signature;
 
+        const previousContent = container.querySelector('.selector-content');
+        const previousScrollTop = previousContent ? previousContent.scrollTop : 0;
+        const activeElement = document.activeElement;
+        const focusedElementId = activeElement && container.contains(activeElement) && activeElement.id
+          ? activeElement.id
+          : null;
+
         let html = `
           <div class="selector-header">
             <div class="selector-header-text">
@@ -1334,6 +1341,21 @@
         `;
 
         container.innerHTML = html;
+
+        const newContent = container.querySelector('.selector-content');
+        if (newContent) {
+          newContent.scrollTop = previousScrollTop;
+        }
+        if (focusedElementId) {
+          const replacementElement = document.getElementById(focusedElementId);
+          if (replacementElement && typeof replacementElement.focus === 'function') {
+            try {
+              replacementElement.focus({ preventScroll: true });
+            } catch (error) {
+              replacementElement.focus();
+            }
+          }
+        }
         updateControlPanel();
 
         let outChk = document.getElementById("route_0");


### PR DESCRIPTION
## Summary
- preserve the route selector scroll offset before rebuilding the panel so the list no longer jumps back to the top after a selection
- restore focus to the previously active route checkbox without triggering additional scrolling

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cdefbcfe5483339daf9e409ddd3839