### PR TITLE
Prevent control panel rerender flicker

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -938,6 +938,7 @@
           } else {
             baseURL = agencies[0]?.url || '';
           }
+          updateControlPanel();
           updateRouteSelector(activeRoutes, true);
         } catch (e) {
           console.error('Failed to load agencies', e);
@@ -1356,8 +1357,6 @@
             }
           }
         }
-        updateControlPanel();
-
         let outChk = document.getElementById("route_0");
         if (outChk) {
           outChk.addEventListener("change", function() {
@@ -1630,6 +1629,7 @@
         beginAgencyLoad();
         clearRefreshIntervals();
         baseURL = url;
+        updateControlPanel();
         Object.values(markers).forEach(m => map.removeLayer(m));
         markers = {};
         Object.values(nameBubbles).forEach(b => {


### PR DESCRIPTION
## Summary
- stop rebuilding the control panel every time the route selector refreshes to avoid button flicker
- refresh the control panel only when agencies are loaded or the agency selection changes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cdf23ebf64833394b1ad6ae43c117d