### PR TITLE
Preserve kiosk legend on route fetch failures

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -3394,7 +3394,11 @@
               })
               .catch(error => {
                   console.error("Error fetching route paths:", error);
-                  updateRouteLegend([], { forceHide: true });
+                  if (kioskMode || adminKioskMode) {
+                      updateRouteLegend(lastRenderedLegendRoutes, { preserveOnEmpty: true });
+                  } else {
+                      updateRouteLegend([], { forceHide: true });
+                  }
               });
       }
 


### PR DESCRIPTION
## Summary
- prevent the kiosk and admin kiosk route legend from being hidden when route path requests fail by re-rendering the last known legend

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cdf73d6be4833397dd84f53f639934