### PR TITLE
Style route selection controls like vehicle labels

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -1303,9 +1303,9 @@
           </div>
           <div class="selector-content">
             <div class="selector-section">
-              <div class="selector-section-heading">
-                <h3>Select Routes</h3>
-                <div class="selector-actions">
+              <div class="selector-group selector-group--route-actions">
+                <div class="selector-label">Select Routes</div>
+                <div class="display-mode-group route-action-buttons">
                   <button type="button" class="pill-button" onclick="selectAllRoutes()">Select All</button>
                   <button type="button" class="pill-button" onclick="selectActiveRoutes()">Select Active</button>
                   <button type="button" class="pill-button" onclick="deselectAllRoutes()">Deselect All</button>


### PR DESCRIPTION
## Summary
- wrap the Select Routes header and buttons in the same selector group styling used for the Vehicle Labels controls
- reuse the display-mode button grid so the Select Routes actions adopt the rounded capsule layout

## Testing
- not run (html change only)


------
https://chatgpt.com/codex/tasks/task_e_68ce124cdb1883338c11a809e137a97f