### PR TITLE
Adjust selector subtitle for admin mode

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -1188,11 +1188,15 @@
           `;
         }
 
+        const selectorSubtitle = adminMode
+          ? 'Choose a transit system and label style.'
+          : 'Choose a transit system.';
+
         let html = `
           <div class="selector-header">
             <div class="selector-header-text">
               <div class="selector-title">System Controls</div>
-              <div class="selector-subtitle">Choose a transit system and label style.</div>
+              <div class="selector-subtitle">${selectorSubtitle}</div>
             </div>
             ${logoHtml}
           </div>


### PR DESCRIPTION
## Summary
- derive the selector subtitle text from the admin mode state
- show simplified copy when admin mode is disabled while keeping the original text when enabled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce29ea3c1c833387a821dc3533ed17