### PR TITLE
Ensure replay timestamp uses 24-hour format

### DIFF
--- a/replay.html
+++ b/replay.html
@@ -1295,7 +1295,16 @@
       const entry = playbackData[i];
       const timeline = document.getElementById('timeline');
       const timeMs = (typeof displayMs !== 'undefined') ? displayMs : playbackTimes[i];
-      const formatted = new Date(timeMs).toLocaleString('en-US', {timeZone: 'America/New_York'});
+      const formatted = new Date(timeMs).toLocaleString('en-US', {
+        timeZone: 'America/New_York',
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: false
+      });
       timeline.value = timeMs;
       timeline.title = formatted; // show date/time when hovering the slider
       document.getElementById('timeLabel').textContent = `Showing: ${formatted}`;


### PR DESCRIPTION
## Summary
- update the replay timestamp formatting to use a 24-hour clock while keeping the New York timezone

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce36c9be64833388bbd1edde1a57a2