### PR TITLE
Improve mobile controls layout and add collapse toggle

### DIFF
--- a/replay.html
+++ b/replay.html
@@ -59,6 +59,10 @@
       z-index: 1200;
       backdrop-filter: blur(12px);
       box-sizing: border-box;
+      transition: transform 0.35s ease, opacity 0.3s ease;
+    }
+    #controlsToggle {
+      display: none;
     }
     .controls-row {
       display: flex;
@@ -498,16 +502,95 @@
     @media (max-width: 720px) {
       #controls.playback-controls {
         gap: 14px;
+        max-height: calc(100vh - 120px);
+        overflow-y: auto;
+        padding: 16px 16px 18px;
+        scrollbar-width: thin;
+        scrollbar-color: rgba(35, 45, 75, 0.35) transparent;
+        -webkit-overflow-scrolling: touch;
+      }
+      #controls.playback-controls::-webkit-scrollbar {
+        width: 6px;
+      }
+      #controls.playback-controls::-webkit-scrollbar-thumb {
+        background: rgba(35, 45, 75, 0.35);
+        border-radius: 999px;
       }
       .controls-row {
         flex-direction: column;
         align-items: stretch;
+        gap: 12px;
       }
       .control-field {
         width: 100%;
       }
+      .control-field input {
+        padding: 9px 12px;
+        font-size: 15px;
+      }
       .speed-button-group {
         justify-content: flex-start;
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        gap: 10px;
+        padding-bottom: 6px;
+        -webkit-overflow-scrolling: touch;
+      }
+      .speed-button-group::-webkit-scrollbar {
+        height: 6px;
+      }
+      .speed-button-group::-webkit-scrollbar-thumb {
+        background: rgba(35, 45, 75, 0.35);
+        border-radius: 999px;
+      }
+      .speed-button-group .pill-button {
+        flex: 0 0 auto;
+      }
+      #controls.playback-controls.is-collapsed {
+        transform: translateX(-50%) translateY(calc(100% + 24px));
+        opacity: 0;
+        pointer-events: none;
+      }
+      #controlsToggle {
+        position: fixed;
+        left: 50%;
+        bottom: calc(var(--controls-height) + 24px);
+        transform: translateX(-50%);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 10px 18px;
+        border-radius: 999px;
+        border: none;
+        font-family: 'FGDC', sans-serif;
+        font-size: 14px;
+        font-weight: 600;
+        letter-spacing: 0.3px;
+        color: #f8fafc;
+        background: linear-gradient(135deg, var(--navy), var(--navy-dark));
+        box-shadow: 0 12px 24px rgba(15, 23, 42, 0.25);
+        cursor: pointer;
+        z-index: 1250;
+        transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, transform 0.3s ease;
+      }
+      #controlsToggle:hover {
+        box-shadow: 0 16px 30px rgba(15, 23, 42, 0.28);
+      }
+      #controlsToggle:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 3px var(--accent-soft), 0 16px 30px rgba(15, 23, 42, 0.3);
+      }
+      body.controls-collapsed #controlsToggle {
+        bottom: 16px;
+        color: #1f1300;
+        background: linear-gradient(135deg, var(--accent), var(--accent-bright));
+        box-shadow: 0 12px 24px rgba(229, 114, 0, 0.35);
+      }
+      body.controls-collapsed #controlsToggle:hover {
+        box-shadow: 0 16px 32px rgba(229, 114, 0, 0.4);
+      }
+      body.controls-collapsed #controlsToggle:focus-visible {
+        box-shadow: 0 0 0 3px var(--accent-soft), 0 16px 32px rgba(229, 114, 0, 0.4);
       }
       .panel-toggle {
         width: 40px;
@@ -584,6 +667,7 @@
       </div>
     </div>
   </div>
+  <button id="controlsToggle" type="button" aria-controls="controls" aria-expanded="true">Hide Controls</button>
   <div id="loadingOverlay" class="loading-overlay" aria-live="polite" aria-busy="false">
     <div class="loading-overlay__inner">
       <div class="loading-overlay__spinner" aria-hidden="true"></div>
@@ -653,6 +737,10 @@
     const ff200Btn = document.getElementById('ff200Btn');
     const ff500Btn = document.getElementById('ff500Btn');
     const ff1000Btn = document.getElementById('ff1000Btn');
+    const controlsContainer = document.getElementById('controls');
+    const controlsToggleButton = document.getElementById('controlsToggle');
+    let controlsCollapsed = false;
+    const controlsViewportQuery = window.matchMedia ? window.matchMedia('(max-width: 720px)') : null;
     let activeRangeLoadCount = 0;
 
     function showLoadingOverlay() {
@@ -743,11 +831,36 @@
       positionPanelTab('routeSelector', 'routeSelectorTab', 'right');
     }
 
+    function setControlsCollapsed(collapsed) {
+      controlsCollapsed = collapsed;
+      document.body.classList.toggle('controls-collapsed', collapsed);
+      if (controlsContainer) {
+        controlsContainer.classList.toggle('is-collapsed', collapsed);
+        if (typeof controlsContainer.inert === 'boolean') {
+          controlsContainer.inert = collapsed;
+        } else if (collapsed) {
+          controlsContainer.setAttribute('inert', '');
+        } else {
+          controlsContainer.removeAttribute('inert');
+        }
+        controlsContainer.setAttribute('aria-hidden', collapsed ? 'true' : 'false');
+      }
+      if (controlsToggleButton) {
+        controlsToggleButton.setAttribute('aria-expanded', String(!collapsed));
+        controlsToggleButton.textContent = collapsed ? 'Show Controls' : 'Hide Controls';
+      }
+      updateControlsHeight();
+    }
+
     function updateControlsHeight() {
-      const controls = document.getElementById('controls');
+      const controls = controlsContainer || document.getElementById('controls');
       if (!controls) return;
-      const height = controls.offsetHeight;
-      document.documentElement.style.setProperty('--controls-height', `${height}px`);
+      if (controls.classList.contains('is-collapsed')) {
+        document.documentElement.style.setProperty('--controls-height', '0px');
+      } else {
+        const height = controls.offsetHeight;
+        document.documentElement.style.setProperty('--controls-height', `${height}px`);
+      }
       positionAllPanelTabs();
     }
 
@@ -765,6 +878,38 @@
       positionAllPanelTabs();
       updateControlsHeight();
     });
+
+    if (controlsToggleButton) {
+      controlsToggleButton.addEventListener('click', () => {
+        setControlsCollapsed(!controlsCollapsed);
+      });
+
+      const syncControlsForViewport = (event) => {
+        const isMobile = event?.matches ?? (controlsViewportQuery ? controlsViewportQuery.matches : false);
+        if (!isMobile && controlsCollapsed) {
+          setControlsCollapsed(false);
+        } else {
+          setControlsCollapsed(controlsCollapsed);
+        }
+        if (controlsToggleButton) {
+          controlsToggleButton.setAttribute('aria-hidden', isMobile ? 'false' : 'true');
+          controlsToggleButton.tabIndex = isMobile ? 0 : -1;
+        }
+      };
+
+      if (controlsViewportQuery) {
+        syncControlsForViewport(controlsViewportQuery);
+        if (typeof controlsViewportQuery.addEventListener === 'function') {
+          controlsViewportQuery.addEventListener('change', syncControlsForViewport);
+        } else if (typeof controlsViewportQuery.addListener === 'function') {
+          controlsViewportQuery.addListener(syncControlsForViewport);
+        }
+      } else {
+        setControlsCollapsed(false);
+        controlsToggleButton.setAttribute('aria-hidden', 'true');
+        controlsToggleButton.tabIndex = -1;
+      }
+    }
 
     function updateSpeedButtons() {
       playBtn.classList.remove('is-active');


### PR DESCRIPTION
## Summary
- adjust the replay controls panel for narrow viewports so it stays on-screen and uses internal scrolling where needed
- add a floating mobile-only toggle that collapses the controls, with accompanying script updates to manage state and accessibility

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce39c13b7883339d6b8c33c9393092