### PR TITLE
Adjust mobile spacing for replay controls (follow-up)

### DIFF
--- a/replay.html
+++ b/replay.html
@@ -558,7 +558,7 @@
         align-items: stretch;
         gap: 6px;
         width: 100%;
-        max-height: 260px;
+        max-height: 320px;
       }
       .speed-button-row {
         width: 100%;


### PR DESCRIPTION
## Summary
- increase the `.speed-button-group` max-height to 320px so mobile grids no longer clip the lowest speed buttons

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ceed6251f08333bf01ef07c937a88e