### PR TITLE
Adjust route legend layout

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -558,11 +558,11 @@
         left: 10px;
         z-index: 1100;
         background: var(--panel-surface);
-        padding: 18px 20px 20px;
-        border-radius: 18px;
+        padding: 12px 14px 16px;
+        border-radius: 16px;
         border: 1px solid var(--panel-border-color);
         box-shadow: var(--panel-shadow);
-        max-width: 320px;
+        max-width: 240px;
         display: none;
         max-height: 70vh;
         overflow-y: auto;
@@ -595,15 +595,15 @@
       #routeLegend .legend-item {
         display: flex;
         align-items: center;
-        gap: 12px;
-        padding: 12px 14px;
+        gap: 10px;
+        padding: 8px 10px;
         background: var(--panel-highlight);
-        border-radius: 14px;
+        border-radius: 12px;
         border: 1px solid transparent;
         transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
       }
       #routeLegend .legend-item + .legend-item {
-        margin-top: 12px;
+        margin-top: 10px;
       }
       #routeLegend .legend-item:hover {
         transform: translateY(-1px);
@@ -622,15 +622,19 @@
         display: flex;
         flex-direction: column;
         gap: 3px;
+        min-width: 0;
+        flex: 1;
       }
       #routeLegend .legend-name {
         font-weight: 600;
         letter-spacing: 0.2px;
         color: var(--panel-heading-color);
+        overflow-wrap: anywhere;
       }
       #routeLegend .legend-description {
         font-size: 13px;
         color: var(--panel-muted-text);
+        overflow-wrap: anywhere;
       }
       @media (max-width: 600px) {
         .selector-panel {


### PR DESCRIPTION
## Summary
- reduce the route legend container padding and width to shrink its footprint
- tighten spacing within legend entries while preserving existing font sizes
- allow legend text to wrap within the constrained layout to avoid overflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ceef8f41948333ac4af5797a3ebe9e