### PR TITLE
Update bus marker artwork

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -904,34 +904,39 @@
       const BUS_MARKER_MAX_WIDTH_PX = 56;
       const BUS_MARKER_BASE_ZOOM = 15;
       const BUS_MARKER_OUTLINE_RATIO = 0.075;
-      const BUS_MARKER_RING_RATIO = 0.11;
+      const BUS_MARKER_RING_RATIO = 0.115;
       const BUS_MARKER_MIN_OUTLINE_PX = 1.3;
-      const BUS_MARKER_MIN_RING_PX = 1.05;
+      const BUS_MARKER_MIN_RING_PX = 1.3;
       const BUS_MARKER_SELECTION_DELTA_PX = 1.4;
       const BUS_MARKER_HOVER_DELTA_PX = 0.85;
-      const BUS_MARKER_ROTATION_CENTER_X = 44.4;
+      const BUS_MARKER_ROTATION_CENTER_X = BUS_MARKER_VIEWBOX_WIDTH * 0.444;
       const BUS_MARKER_ROTATION_CENTER_Y = BUS_MARKER_VIEWBOX_HEIGHT / 2;
       const BUS_MARKER_ROTATION_CENTER_X_RATIO = BUS_MARKER_ROTATION_CENTER_X / BUS_MARKER_VIEWBOX_WIDTH;
       const BUS_MARKER_ROTATION_CENTER_X_PERCENT = BUS_MARKER_ROTATION_CENTER_X_RATIO * 100;
       const BUS_MARKER_DEFAULT_HEADING = 0;
       const BUS_MARKER_OUTLINE_COLOR = 'rgba(0, 0, 0, 0.88)';
       const BUS_MARKER_DARK_GLYPH_COLOR = 'rgba(15, 23, 42, 0.92)';
-      const BUS_MARKER_LIGHT_GLYPH_COLOR = 'rgba(255, 255, 255, 0.9)';
       const BUS_MARKER_RING_RADIUS = BUS_MARKER_VIEWBOX_HEIGHT * 0.4 * 0.5;
       const BUS_MARKER_RING_CENTER_X = BUS_MARKER_ROTATION_CENTER_X;
       const BUS_MARKER_RING_CENTER_Y = BUS_MARKER_ROTATION_CENTER_Y;
-      const BUS_MARKER_PLAY_BASE_X = 78;
-      const BUS_MARKER_PLAY_TIP_X = 92;
-      const BUS_MARKER_PLAY_HEIGHT_RATIO = 0.24;
       const MIN_HEADING_DISTANCE_METERS = 2;
       const MIN_POSITION_UPDATE_METERS = 0.5;
       const MIN_HEADING_SPEED_METERS_PER_SECOND = 1;
       const METERS_PER_SECOND_PER_MPH = 0.44704;
       const GPS_STALE_THRESHOLD_SECONDS = 60;
 
-      const BUS_MARKER_OUTER_PATH = 'M97 31 C94 31 78 9 56 9 S18 15 12 31 S18 47 56 53 S100 31 97 31 Z';
-      const BUS_MARKER_RING_PATH = 'M 56.8 31 a 12.4 12.4 0 1 1 -24.8 0 a 12.4 12.4 0 1 1 24.8 0 Z';
-      const BUS_MARKER_PLAY_PATH = 'M 78 23.56 L 78 38.44 L 92 31 Z';
+      const BUS_MARKER_OUTER_PATH = 'M 100 31 C 99.3 20.9 94.6 10.4 82.4 6 S 23 8 12.8 17.6 S 3.2 36.8 12.8 44.4 S 70.2 59.2 82.4 56 S 99.3 41.1 100 31 Z';
+      const BUS_MARKER_RING_PATH = (() => {
+          const cx = BUS_MARKER_RING_CENTER_X;
+          const cy = BUS_MARKER_RING_CENTER_Y;
+          const r = BUS_MARKER_RING_RADIUS;
+          const startX = (cx + r).toFixed(3);
+          const radius = r.toFixed(3);
+          const diameter = (r * 2).toFixed(3);
+          const cyFixed = cy.toFixed(3);
+          return `M ${startX} ${cyFixed} a ${radius} ${radius} 0 1 1 -${diameter} 0 a ${radius} ${radius} 0 1 1 ${diameter} 0 Z`;
+      })();
+      const BUS_MARKER_PLAY_PATH = 'M 82 23.8 Q 82 22 83.8 22.8 L 94.6 28.5 Q 96.4 29.4 96.4 31 Q 96.4 32.6 94.6 33.5 L 83.8 38.8 Q 82 39.8 82 38.8 Z';
 
       let routeColors = {};
       let routeLayers = [];
@@ -4167,9 +4172,8 @@
           state.baseRingRatio = metrics.ringRatio;
       }
 
-      function computeBusMarkerGlyphColor(fillColor) {
-          const contrast = getContrastColor(fillColor || '#000000');
-          return contrast === 'white' ? BUS_MARKER_LIGHT_GLYPH_COLOR : BUS_MARKER_DARK_GLYPH_COLOR;
+      function computeBusMarkerGlyphColor() {
+          return BUS_MARKER_DARK_GLYPH_COLOR;
       }
 
       function updateBusMarkerHeading(state, newPosition, fallbackHeading, groundSpeedMph) {


### PR DESCRIPTION
## Summary
- redraw the bus marker outer shell path to produce the capsule body with an integrated nose
- regenerate the ring path procedurally and tweak width settings to maintain a bold halo across scales
- lock the interior glyph color to the dark palette and update the play triangle path to the rounded chevron design

## Testing
- not run (HTML/JS constants update only)


------
https://chatgpt.com/codex/tasks/task_e_68cf35abcb9083339a78830e2d904a9f