### PR TITLE
Adjust testmap bus marker icon geometry

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -904,19 +904,21 @@
       const BUS_MARKER_MAX_WIDTH_PX = 56;
       const BUS_MARKER_BASE_ZOOM = 15;
       const BUS_MARKER_OUTLINE_RATIO = 0.075;
-      const BUS_MARKER_RING_RATIO = 0.115;
+      const BUS_MARKER_RING_RATIO = 0.11;
       const BUS_MARKER_MIN_OUTLINE_PX = 1.3;
-      const BUS_MARKER_MIN_RING_PX = 1.3;
+      const BUS_MARKER_MIN_RING_PX = 1.05;
       const BUS_MARKER_SELECTION_DELTA_PX = 1.4;
       const BUS_MARKER_HOVER_DELTA_PX = 0.85;
-      const BUS_MARKER_ROTATION_CENTER_X = BUS_MARKER_VIEWBOX_WIDTH * 0.444;
+      const BUS_MARKER_ROTATION_CENTER_X = 44.4;
       const BUS_MARKER_ROTATION_CENTER_Y = BUS_MARKER_VIEWBOX_HEIGHT / 2;
       const BUS_MARKER_ROTATION_CENTER_X_RATIO = BUS_MARKER_ROTATION_CENTER_X / BUS_MARKER_VIEWBOX_WIDTH;
       const BUS_MARKER_ROTATION_CENTER_X_PERCENT = BUS_MARKER_ROTATION_CENTER_X_RATIO * 100;
+      const BUS_MARKER_ICON_ANCHOR_X_RATIO = 0.99;
+      const BUS_MARKER_ICON_ANCHOR_Y_RATIO = BUS_MARKER_ROTATION_CENTER_Y / BUS_MARKER_VIEWBOX_HEIGHT;
       const BUS_MARKER_DEFAULT_HEADING = 0;
       const BUS_MARKER_OUTLINE_COLOR = 'rgba(0, 0, 0, 0.88)';
       const BUS_MARKER_DARK_GLYPH_COLOR = 'rgba(15, 23, 42, 0.92)';
-      const BUS_MARKER_RING_RADIUS = BUS_MARKER_VIEWBOX_HEIGHT * 0.4 * 0.5;
+      const BUS_MARKER_RING_RADIUS = 12.4;
       const BUS_MARKER_RING_CENTER_X = BUS_MARKER_ROTATION_CENTER_X;
       const BUS_MARKER_RING_CENTER_Y = BUS_MARKER_ROTATION_CENTER_Y;
       const MIN_HEADING_DISTANCE_METERS = 2;
@@ -925,7 +927,7 @@
       const METERS_PER_SECOND_PER_MPH = 0.44704;
       const GPS_STALE_THRESHOLD_SECONDS = 60;
 
-      const BUS_MARKER_OUTER_PATH = 'M 100 31 C 99.3 20.9 94.6 10.4 82.4 6 S 23 8 12.8 17.6 S 3.2 36.8 12.8 44.4 S 70.2 59.2 82.4 56 S 99.3 41.1 100 31 Z';
+      const BUS_MARKER_OUTER_PATH = 'M52 1 C66 1 82 5 92 16 C98 22 100 31 92 46 C82 57 66 61 52 61 C28 61 12 56 6 46 Q0 31 6 16 C12 6 28 1 52 1 Z';
       const BUS_MARKER_RING_PATH = (() => {
           const cx = BUS_MARKER_RING_CENTER_X;
           const cy = BUS_MARKER_RING_CENTER_Y;
@@ -936,7 +938,7 @@
           const cyFixed = cy.toFixed(3);
           return `M ${startX} ${cyFixed} a ${radius} ${radius} 0 1 1 -${diameter} 0 a ${radius} ${radius} 0 1 1 ${diameter} 0 Z`;
       })();
-      const BUS_MARKER_PLAY_PATH = 'M 82 23.8 Q 82 22 83.8 22.8 L 94.6 28.5 Q 96.4 29.4 96.4 31 Q 96.4 32.6 94.6 33.5 L 83.8 38.8 Q 82 39.8 82 38.8 Z';
+      const BUS_MARKER_CHEVRON_PATH = 'M78 23.6 Q78 23.2 78.6 23.5 L91.4 30.3 Q92 31 91.4 31.7 L78.6 38.5 Q78 38.8 78 38.4 Z';
 
       let routeColors = {};
       let routeLayers = [];
@@ -4331,7 +4333,7 @@
           <g class="bus-marker__rotator" style="transform-origin: ${BUS_MARKER_ROTATION_CENTER_X_PERCENT}% 50%; transform: ${transform};">
             <path class="bus-marker__shell" d="${BUS_MARKER_OUTER_PATH}" fill="${fillColor}" stroke="${outlineColor}" stroke-width="${outlineWidthViewBox}" stroke-linecap="round" stroke-linejoin="round" fill-opacity="${fillOpacity}" />
             <path class="bus-marker__ring" d="${BUS_MARKER_RING_PATH}" fill="none" stroke="${glyphColor}" stroke-width="${ringWidthViewBox}" stroke-linecap="round" stroke-linejoin="round" fill-rule="evenodd" />
-            <path class="bus-marker__glyph" d="${BUS_MARKER_PLAY_PATH}" fill="${glyphColor}" />
+            <path class="bus-marker__glyph" d="${BUS_MARKER_CHEVRON_PATH}" fill="${glyphColor}" stroke="none" stroke-miterlimit="1.4" />
           </g>
         </svg>
       </div>`;
@@ -4346,11 +4348,13 @@
           }
           const width = state.size?.widthPx ?? BUS_MARKER_BASE_WIDTH_PX;
           const height = state.size?.heightPx ?? width * BUS_MARKER_ASPECT_RATIO;
+          const anchorX = width * BUS_MARKER_ICON_ANCHOR_X_RATIO;
+          const anchorY = height * BUS_MARKER_ICON_ANCHOR_Y_RATIO;
           return L.divIcon({
               html: renderBusMarkerMarkup(vehicleID, state),
               className: 'bus-marker',
               iconSize: [width, height],
-              iconAnchor: [width, height / 2]
+              iconAnchor: [anchorX, anchorY]
           });
       }
 


### PR DESCRIPTION
## Summary
- update the bus marker outline path, ring thickness, and rotation center constants to match the new SVG specification
- replace the play glyph with a rounded chevron and wire it into the marker template with the required stroke settings
- align the Leaflet icon anchor with the bus nose so the marker pivots and positions correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf421bcb3c83339a65bfd1a3cd91fc