### PR TITLE
Replace bus marker SVG with dynamic contrast logic

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -143,19 +143,24 @@
       }
       .bus-marker__rotator {
         transform-box: fill-box;
-        transform-origin: 44.4% 50%;
+        transform-origin: 50% 35%;
         will-change: transform;
       }
-      .bus-marker__shell {
+      .bus-marker__body {
         paint-order: stroke fill;
+      }
+      .bus-marker__body,
+      .bus-marker__center {
         transition: fill 0.2s ease, fill-opacity 0.2s ease;
       }
       .bus-marker__ring,
-      .bus-marker__glyph,
-      .bus-marker__shell {
+      .bus-marker__arrow,
+      .bus-marker__body,
+      .bus-marker__center {
         pointer-events: auto;
       }
-      .bus-marker__root.is-stale .bus-marker__shell {
+      .bus-marker__root.is-stale .bus-marker__body,
+      .bus-marker__root.is-stale .bus-marker__center {
         fill-opacity: 0.6;
       }
       .bus-marker__root.is-hover .bus-marker__svg {
@@ -896,49 +901,33 @@
       let busMarkerVisualUpdateFrame = null;
       let selectedVehicleId = null;
 
-      const BUS_MARKER_VIEWBOX_WIDTH = 100;
-      const BUS_MARKER_VIEWBOX_HEIGHT = 62;
+      const BUS_MARKER_VIEWBOX_WIDTH = 56;
+      const BUS_MARKER_VIEWBOX_HEIGHT = 80;
       const BUS_MARKER_ASPECT_RATIO = BUS_MARKER_VIEWBOX_HEIGHT / BUS_MARKER_VIEWBOX_WIDTH;
       const BUS_MARKER_BASE_WIDTH_PX = 30;
       const BUS_MARKER_MIN_WIDTH_PX = 20;
       const BUS_MARKER_MAX_WIDTH_PX = 56;
       const BUS_MARKER_BASE_ZOOM = 15;
-      const BUS_MARKER_OUTLINE_RATIO = 0.075;
-      const BUS_MARKER_RING_RATIO = 0.11;
-      const BUS_MARKER_MIN_OUTLINE_PX = 1.3;
-      const BUS_MARKER_MIN_RING_PX = 1.05;
-      const BUS_MARKER_SELECTION_DELTA_PX = 1.4;
-      const BUS_MARKER_HOVER_DELTA_PX = 0.85;
-      const BUS_MARKER_ROTATION_CENTER_X = 44.4;
-      const BUS_MARKER_ROTATION_CENTER_Y = BUS_MARKER_VIEWBOX_HEIGHT / 2;
-      const BUS_MARKER_ROTATION_CENTER_X_RATIO = BUS_MARKER_ROTATION_CENTER_X / BUS_MARKER_VIEWBOX_WIDTH;
-      const BUS_MARKER_ROTATION_CENTER_X_PERCENT = BUS_MARKER_ROTATION_CENTER_X_RATIO * 100;
-      const BUS_MARKER_ICON_ANCHOR_X_RATIO = 0.99;
-      const BUS_MARKER_ICON_ANCHOR_Y_RATIO = BUS_MARKER_ROTATION_CENTER_Y / BUS_MARKER_VIEWBOX_HEIGHT;
+      const BUS_MARKER_ANCHOR_X = 28;
+      const BUS_MARKER_ANCHOR_Y = 28;
+      const BUS_MARKER_ICON_ANCHOR_X_RATIO = BUS_MARKER_ANCHOR_X / BUS_MARKER_VIEWBOX_WIDTH;
+      const BUS_MARKER_ICON_ANCHOR_Y_RATIO = BUS_MARKER_ANCHOR_Y / BUS_MARKER_VIEWBOX_HEIGHT;
       const BUS_MARKER_DEFAULT_HEADING = 0;
-      const BUS_MARKER_OUTLINE_COLOR = 'rgba(0, 0, 0, 0.88)';
-      const BUS_MARKER_DARK_GLYPH_COLOR = 'rgba(15, 23, 42, 0.92)';
-      const BUS_MARKER_RING_RADIUS = 12.4;
-      const BUS_MARKER_RING_CENTER_X = BUS_MARKER_ROTATION_CENTER_X;
-      const BUS_MARKER_RING_CENTER_Y = BUS_MARKER_ROTATION_CENTER_Y;
+      const BUS_MARKER_DEFAULT_ROUTE_COLOR = '#0B7A26';
+      const BUS_MARKER_DEFAULT_CONTRAST_COLOR = '#FFFFFF';
+      const BUS_MARKER_BODY_PATH = 'M28,4c11.5,0,24,9.5,24,26,0,17.5-13.8,32.1-21.2,38-1.6,1.3-4,1.3-5.6,0-7.4-5.9-21.2-20.5-21.2-38C4,13.5,16.5,4,28,4Z';
+      const BUS_MARKER_HALO_PATH = 'M28.01,71.49c-1.56,0-3.11-.52-4.38-1.55-3.68-2.93-22.12-18.71-22.12-39.94C1.5,12.16,14.97,1.5,28,1.5s26.5,10.66,26.5,28.5c0,21.23-18.44,37.01-22.14,39.95-1.26,1.02-2.8,1.53-4.35,1.53ZM28,6.5c-10.57,0-21.5,8.79-21.5,23.5s10.91,28.59,20.26,36.04c.71.57,1.78.57,2.46.02C38.58,58.59,49.5,44.68,49.5,30S38.57,6.5,28,6.5Z';
+      const BUS_MARKER_RING_PATH = 'M28,43.5c-8.55,0-15.5-6.95-15.5-15.5S19.45,12.5,28,12.5S43.5,19.45,43.5,28S36.55,43.5,28,43.5ZM28,19c-4.97,0-9,4.03-9,9s4.03,9,9,9s9-4.03,9-9S32.97,19,28,19Z';
+      const BUS_MARKER_ARROW_PATH = 'M28,63 L18,45 Q28,51 38,45 Z';
+      const BUS_MARKER_INNER_ROTATE_X = BUS_MARKER_ANCHOR_X;
+      const BUS_MARKER_INNER_ROTATE_Y = 40;
+      const BUS_MARKER_INNER_ROTATE_DEGREES = 180;
       const MIN_HEADING_DISTANCE_METERS = 2;
       const MIN_POSITION_UPDATE_METERS = 0.5;
       const MIN_HEADING_SPEED_METERS_PER_SECOND = 1;
       const METERS_PER_SECOND_PER_MPH = 0.44704;
       const GPS_STALE_THRESHOLD_SECONDS = 60;
-
-      const BUS_MARKER_OUTER_PATH = 'M52 1 C66 1 82 5 92 16 C98 22 100 31 92 46 C82 57 66 61 52 61 C28 61 12 56 6 46 Q0 31 6 16 C12 6 28 1 52 1 Z';
-      const BUS_MARKER_RING_PATH = (() => {
-          const cx = BUS_MARKER_RING_CENTER_X;
-          const cy = BUS_MARKER_RING_CENTER_Y;
-          const r = BUS_MARKER_RING_RADIUS;
-          const startX = (cx + r).toFixed(3);
-          const radius = r.toFixed(3);
-          const diameter = (r * 2).toFixed(3);
-          const cyFixed = cy.toFixed(3);
-          return `M ${startX} ${cyFixed} a ${radius} ${radius} 0 1 1 -${diameter} 0 a ${radius} ${radius} 0 1 1 ${diameter} 0 Z`;
-      })();
-      const BUS_MARKER_CHEVRON_PATH = 'M78 23.6 Q78 23.2 78.6 23.5 L91.4 30.3 Q92 31 91.4 31.7 L78.6 38.5 Q78 38.8 78 38.4 Z';
+      let busMarkerContrastOverrideColor = null;
 
       let routeColors = {};
       let routeLayers = [];
@@ -3960,7 +3949,6 @@
                           state.busName = busName;
                           state.routeID = routeID;
                           state.fillColor = routeColor;
-                          state.outlineColor = BUS_MARKER_OUTLINE_COLOR;
                           state.glyphColor = glyphColor;
                           state.headingDeg = headingDeg;
                           state.accessibleLabel = accessibleLabel;
@@ -3977,7 +3965,6 @@
                               markers[vehicleID].routeID = routeID;
                               queueBusMarkerVisualUpdate(vehicleID, {
                                   fillColor: routeColor,
-                                  outlineColor: BUS_MARKER_OUTLINE_COLOR,
                                   glyphColor,
                                   headingDeg,
                                   stale: gpsIsStale,
@@ -4112,12 +4099,35 @@
       }
 
       function getContrastColor(hexColor) {
-          hexColor = hexColor.replace('#', '');
-          const r = parseInt(hexColor.substring(0, 2), 16);
-          const g = parseInt(hexColor.substring(2, 4), 16);
-          const b = parseInt(hexColor.substring(4, 6), 16);
-          const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-          return luminance > 0.565 ? 'black' : 'white';
+          if (typeof hexColor !== 'string') {
+              return BUS_MARKER_DEFAULT_CONTRAST_COLOR;
+          }
+          let normalized = hexColor.trim().replace(/^#/, '');
+          if (normalized.length === 3) {
+              normalized = normalized.split('').map(ch => ch + ch).join('');
+          }
+          if (normalized.length !== 6 || /[^0-9a-fA-F]/.test(normalized)) {
+              return BUS_MARKER_DEFAULT_CONTRAST_COLOR;
+          }
+          const r = parseInt(normalized.substring(0, 2), 16);
+          const g = parseInt(normalized.substring(2, 4), 16);
+          const b = parseInt(normalized.substring(4, 6), 16);
+          const luminance = computeRelativeLuminance(r, g, b);
+          const contrastWithWhite = (1.05) / (luminance + 0.05);
+          const contrastWithBlack = (luminance + 0.05) / 0.05;
+          return contrastWithWhite >= contrastWithBlack ? '#FFFFFF' : '#000000';
+      }
+
+      function computeRelativeLuminance(r, g, b) {
+          const rLinear = srgbChannelToLinear(r);
+          const gLinear = srgbChannelToLinear(g);
+          const bLinear = srgbChannelToLinear(b);
+          return 0.2126 * rLinear + 0.7152 * gLinear + 0.0722 * bLinear;
+      }
+
+      function srgbChannelToLinear(channelValue) {
+          const channel = Math.max(0, Math.min(255, channelValue)) / 255;
+          return channel <= 0.03928 ? channel / 12.92 : Math.pow((channel + 0.055) / 1.055, 2.4);
       }
 
       function clamp(value, min, max) {
@@ -4132,28 +4142,24 @@
               BUS_MARKER_MAX_WIDTH_PX
           );
           const height = width * BUS_MARKER_ASPECT_RATIO;
-          const outlineRatio = Math.max(BUS_MARKER_OUTLINE_RATIO, BUS_MARKER_MIN_OUTLINE_PX / height);
-          const ringRatio = Math.max(BUS_MARKER_RING_RATIO, BUS_MARKER_MIN_RING_PX / height);
-          return { widthPx: width, heightPx: height, outlineRatio, ringRatio };
+          return { widthPx: width, heightPx: height };
       }
 
       function ensureBusMarkerState(vehicleID) {
           if (!busMarkerStates[vehicleID]) {
+              const defaultRouteColor = BUS_MARKER_DEFAULT_ROUTE_COLOR;
               busMarkerStates[vehicleID] = {
                   vehicleID,
                   positionHistory: [],
                   headingDeg: BUS_MARKER_DEFAULT_HEADING,
-                  fillColor: BUS_MARKER_OUTLINE_COLOR,
-                  outlineColor: BUS_MARKER_OUTLINE_COLOR,
-                  glyphColor: BUS_MARKER_DARK_GLYPH_COLOR,
+                  fillColor: defaultRouteColor,
+                  glyphColor: computeBusMarkerGlyphColor(defaultRouteColor),
                   accessibleLabel: '',
                   isStale: false,
                   isSelected: false,
                   isHovered: false,
                   lastUpdateTimestamp: 0,
                   size: null,
-                  baseOutlineRatio: BUS_MARKER_OUTLINE_RATIO,
-                  baseRingRatio: BUS_MARKER_RING_RATIO,
                   elements: null,
                   marker: null,
                   markerEventsBound: false
@@ -4170,12 +4176,38 @@
               widthPx: metrics.widthPx,
               heightPx: metrics.heightPx
           };
-          state.baseOutlineRatio = metrics.outlineRatio;
-          state.baseRingRatio = metrics.ringRatio;
+      }
+ 
+      function computeBusMarkerGlyphColor(routeColor) {
+          if (typeof busMarkerContrastOverrideColor === 'string' && busMarkerContrastOverrideColor.trim().length > 0) {
+              return busMarkerContrastOverrideColor;
+          }
+          const fallback = BUS_MARKER_DEFAULT_CONTRAST_COLOR;
+          const candidate = typeof routeColor === 'string' && routeColor.trim().length > 0 ? routeColor : BUS_MARKER_DEFAULT_ROUTE_COLOR;
+          const contrast = getContrastColor(candidate);
+          return contrast || fallback;
       }
 
-      function computeBusMarkerGlyphColor() {
-          return BUS_MARKER_DARK_GLYPH_COLOR;
+      function setBusMarkerContrastOverrideColor(color) {
+          if (typeof color === 'string' && color.trim().length > 0) {
+              busMarkerContrastOverrideColor = color.trim();
+          } else {
+              busMarkerContrastOverrideColor = null;
+          }
+          Object.keys(busMarkerStates).forEach(vehicleID => {
+              const state = busMarkerStates[vehicleID];
+              if (!state) {
+                  return;
+              }
+              const routeColor = state.fillColor || BUS_MARKER_DEFAULT_ROUTE_COLOR;
+              const glyphColor = computeBusMarkerGlyphColor(routeColor);
+              state.glyphColor = glyphColor;
+              queueBusMarkerVisualUpdate(vehicleID, { glyphColor });
+          });
+      }
+
+      if (typeof window !== 'undefined') {
+          window.setBusMarkerContrastOverrideColor = setBusMarkerContrastOverrideColor;
       }
 
       function updateBusMarkerHeading(state, newPosition, fallbackHeading, groundSpeedMph) {
@@ -4292,24 +4324,13 @@
               .replace(/'/g, '&#39;');
       }
 
-      function computeMarkerTransformString(widthPx, headingDeg) {
+      function computeMarkerRotationTransform(headingDeg) {
           const normalizedHeading = normalizeHeadingDegrees(Number.isFinite(headingDeg) ? headingDeg : BUS_MARKER_DEFAULT_HEADING);
-          const rotationDeg = normalizedHeading - 90;
-          if (!Number.isFinite(widthPx) || widthPx <= 0) {
-              return `rotate(${rotationDeg.toFixed(2)}deg)`;
-          }
-          const radians = rotationDeg * Math.PI / 180;
-          const tipOffset = widthPx * (1 - BUS_MARKER_ROTATION_CENTER_X_RATIO);
-          const deltaX = tipOffset * (1 - Math.cos(radians));
-          const deltaY = -tipOffset * Math.sin(radians);
-          return `translate(${deltaX.toFixed(4)}px, ${deltaY.toFixed(4)}px) rotate(${rotationDeg.toFixed(2)}deg)`;
+          return `rotate(${normalizedHeading.toFixed(2)} ${BUS_MARKER_ANCHOR_X} ${BUS_MARKER_ANCHOR_Y})`;
       }
 
       function renderBusMarkerMarkup(vehicleID, state) {
-          const width = state?.size?.widthPx ?? BUS_MARKER_BASE_WIDTH_PX;
-          const height = state?.size?.heightPx ?? width * BUS_MARKER_ASPECT_RATIO;
-          const fillColor = state?.fillColor || BUS_MARKER_OUTLINE_COLOR;
-          const outlineColor = state?.outlineColor || BUS_MARKER_OUTLINE_COLOR;
+          const fillColor = state?.fillColor || BUS_MARKER_DEFAULT_ROUTE_COLOR;
           const glyphColor = state?.glyphColor || computeBusMarkerGlyphColor(fillColor);
           const headingDeg = Number.isFinite(state?.headingDeg) ? state.headingDeg : BUS_MARKER_DEFAULT_HEADING;
           const labelRaw = state?.accessibleLabel && state.accessibleLabel.trim().length > 0
@@ -4320,20 +4341,29 @@
           if (state?.isStale) rootClasses.push('is-stale');
           if (state?.isSelected) rootClasses.push('is-selected');
           if (state?.isHovered) rootClasses.push('is-hover');
-          const outlineRatio = state?.baseOutlineRatio ?? BUS_MARKER_OUTLINE_RATIO;
-          const ringRatio = state?.baseRingRatio ?? BUS_MARKER_RING_RATIO;
-          const outlineWidthViewBox = (outlineRatio * BUS_MARKER_VIEWBOX_HEIGHT).toFixed(3);
-          const ringWidthViewBox = (ringRatio * BUS_MARKER_VIEWBOX_HEIGHT).toFixed(3);
-          const transform = computeMarkerTransformString(width, headingDeg);
+          const rotationTransform = computeMarkerRotationTransform(headingDeg);
           const fillOpacity = state?.isStale ? '0.6' : '1';
           return `
       <div class="${rootClasses.join(' ')}" data-vehicle-id="${escapeHtml(`${vehicleID}`)}" tabindex="0" aria-label="${labelEscaped}" role="img">
         <svg class="bus-marker__svg" viewBox="0 0 ${BUS_MARKER_VIEWBOX_WIDTH} ${BUS_MARKER_VIEWBOX_HEIGHT}" preserveAspectRatio="xMidYMid meet" role="img" aria-label="${labelEscaped}" focusable="false">
           <title>${labelEscaped}</title>
-          <g class="bus-marker__rotator" style="transform-origin: ${BUS_MARKER_ROTATION_CENTER_X_PERCENT}% 50%; transform: ${transform};">
-            <path class="bus-marker__shell" d="${BUS_MARKER_OUTER_PATH}" fill="${fillColor}" stroke="${outlineColor}" stroke-width="${outlineWidthViewBox}" stroke-linecap="round" stroke-linejoin="round" fill-opacity="${fillOpacity}" />
-            <path class="bus-marker__ring" d="${BUS_MARKER_RING_PATH}" fill="none" stroke="${glyphColor}" stroke-width="${ringWidthViewBox}" stroke-linecap="round" stroke-linejoin="round" fill-rule="evenodd" />
-            <path class="bus-marker__glyph" d="${BUS_MARKER_CHEVRON_PATH}" fill="${glyphColor}" stroke="none" stroke-miterlimit="1.4" />
+          <defs>
+            <style>
+              /* st1 = body + centre (route color). st0 = ring + arrow + body halo (contrast color) */
+              .st0{fill:#fff;}
+              .st1{fill:#0b7a26;}
+            </style>
+          </defs>
+          <g class="bus-marker__rotator" transform="${rotationTransform}">
+            <!-- Wrap this whole SVG in an OUTER group at runtime to rotate by heading around (28,28).
+                 This INNER group is a fixed 180° rotate to make the arrow point up by default. -->
+            <g id="inner-up-rotate" transform="rotate(${BUS_MARKER_INNER_ROTATE_DEGREES} ${BUS_MARKER_INNER_ROTATE_X} ${BUS_MARKER_INNER_ROTATE_Y})">
+              <path class="st1 bus-marker__body" d="${BUS_MARKER_BODY_PATH}" fill="${fillColor}" style="fill: ${fillColor}; fill-opacity: ${fillOpacity};" fill-opacity="${fillOpacity}" />
+              <path class="st0 bus-marker__halo" d="${BUS_MARKER_HALO_PATH}" fill="#FFFFFF" style="fill: #FFFFFF;" />
+              <path class="st0 bus-marker__ring" d="${BUS_MARKER_RING_PATH}" fill="${glyphColor}" style="fill: ${glyphColor};" />
+              <circle class="st1 bus-marker__center" cx="${BUS_MARKER_ANCHOR_X}" cy="${BUS_MARKER_ANCHOR_Y}" r="8" fill="${fillColor}" style="fill: ${fillColor}; fill-opacity: ${fillOpacity};" fill-opacity="${fillOpacity}" />
+              <path class="st0 bus-marker__arrow" d="${BUS_MARKER_ARROW_PATH}" fill="${glyphColor}" style="fill: ${glyphColor};" />
+            </g>
           </g>
         </svg>
       </div>`;
@@ -4371,11 +4401,13 @@
           const root = iconElement.querySelector('.bus-marker__root');
           const svg = root ? root.querySelector('.bus-marker__svg') : null;
           const rotator = root ? root.querySelector('.bus-marker__rotator') : null;
-          const shell = root ? root.querySelector('.bus-marker__shell') : null;
+          const body = root ? root.querySelector('.bus-marker__body') : null;
+          const center = root ? root.querySelector('.bus-marker__center') : null;
           const ring = root ? root.querySelector('.bus-marker__ring') : null;
-          const glyph = root ? root.querySelector('.bus-marker__glyph') : null;
+          const arrow = root ? root.querySelector('.bus-marker__arrow') : null;
+          const halo = root ? root.querySelector('.bus-marker__halo') : null;
           const title = svg ? svg.querySelector('title') : null;
-          state.elements = { icon: iconElement, root, svg, rotator, shell, ring, glyph, title };
+          state.elements = { icon: iconElement, root, svg, rotator, body, center, ring, arrow, halo, title };
           if (root) {
               root.dataset.vehicleId = `${vehicleID}`;
           }
@@ -4417,9 +4449,6 @@
           if (update && update.fillColor) {
               state.fillColor = update.fillColor;
           }
-          if (update && update.outlineColor) {
-              state.outlineColor = update.outlineColor;
-          }
           if (update && update.glyphColor) {
               state.glyphColor = update.glyphColor;
           }
@@ -4432,20 +4461,29 @@
           if (update && Number.isFinite(update.headingDeg)) {
               state.headingDeg = normalizeHeadingDegrees(update.headingDeg);
           }
-          if (elements.shell && state.fillColor) {
-              elements.shell.setAttribute('fill', state.fillColor);
+          const routeColor = state.fillColor || BUS_MARKER_DEFAULT_ROUTE_COLOR;
+          const glyphColor = state.glyphColor || computeBusMarkerGlyphColor(routeColor);
+          state.glyphColor = glyphColor;
+          const fillOpacity = state.isStale ? '0.6' : '1';
+          if (elements.body) {
+              elements.body.setAttribute('fill', routeColor);
+              elements.body.style.fill = routeColor;
+              elements.body.setAttribute('fill-opacity', fillOpacity);
+              elements.body.style.fillOpacity = fillOpacity;
           }
-          if (elements.shell && state.outlineColor) {
-              elements.shell.setAttribute('stroke', state.outlineColor);
+          if (elements.center) {
+              elements.center.setAttribute('fill', routeColor);
+              elements.center.style.fill = routeColor;
+              elements.center.setAttribute('fill-opacity', fillOpacity);
+              elements.center.style.fillOpacity = fillOpacity;
           }
-          if (elements.ring && state.glyphColor) {
-              elements.ring.setAttribute('stroke', state.glyphColor);
+          if (elements.ring) {
+              elements.ring.setAttribute('fill', glyphColor);
+              elements.ring.style.fill = glyphColor;
           }
-          if (elements.glyph && state.glyphColor) {
-              elements.glyph.setAttribute('fill', state.glyphColor);
-          }
-          if (elements.shell) {
-              elements.shell.setAttribute('fill-opacity', state.isStale ? '0.6' : '1');
+          if (elements.arrow) {
+              elements.arrow.setAttribute('fill', glyphColor);
+              elements.arrow.style.fill = glyphColor;
           }
           if (elements.svg && state.accessibleLabel) {
               elements.svg.setAttribute('aria-label', state.accessibleLabel);
@@ -4454,9 +4492,7 @@
               elements.title.textContent = state.accessibleLabel;
           }
           if (elements.rotator) {
-              elements.rotator.style.transformOrigin = `${BUS_MARKER_ROTATION_CENTER_X_PERCENT}% 50%`;
-              const widthForTransform = state.size?.widthPx;
-              elements.rotator.style.transform = computeMarkerTransformString(widthForTransform, state.headingDeg);
+              elements.rotator.setAttribute('transform', computeMarkerRotationTransform(state.headingDeg));
           }
           updateBusMarkerRootClasses(state);
           updateBusMarkerZIndex(state);
@@ -4464,24 +4500,18 @@
       }
 
       function applyBusMarkerOutlineWidth(state) {
-          if (!state?.elements?.shell || !state?.size) {
+          if (!state?.elements) {
               return;
           }
-          const heightPx = state.size.heightPx;
-          if (!(heightPx > 0)) {
-              return;
+          const fillOpacity = state.isStale ? '0.6' : '1';
+          if (state.elements.body) {
+              state.elements.body.setAttribute('fill-opacity', fillOpacity);
+              state.elements.body.style.fillOpacity = fillOpacity;
           }
-          const baseRatio = state.baseOutlineRatio ?? BUS_MARKER_OUTLINE_RATIO;
-          let widthPx = Math.max(baseRatio * heightPx, BUS_MARKER_MIN_OUTLINE_PX);
-          if (state.isSelected) {
-              widthPx += BUS_MARKER_SELECTION_DELTA_PX;
+          if (state.elements.center) {
+              state.elements.center.setAttribute('fill-opacity', fillOpacity);
+              state.elements.center.style.fillOpacity = fillOpacity;
           }
-          if (state.isHovered) {
-              widthPx += BUS_MARKER_HOVER_DELTA_PX;
-          }
-          const ratio = widthPx / heightPx;
-          const viewBoxWidth = ratio * BUS_MARKER_VIEWBOX_HEIGHT;
-          state.elements.shell.setAttribute('stroke-width', viewBoxWidth.toFixed(3));
       }
 
       function updateBusMarkerRootClasses(state) {


### PR DESCRIPTION
## Summary
- replace the bus marker geometry with the supplied SVG anchored at (28,28) and update the marker CSS classes
- compute WCAG relative luminance contrast to choose black/white ring and expose an override hook for special themes
- render the new SVG structure with heading rotation around the anchor and update elements for route/stale states

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d0398c13488333b84fef137e905669