### PR TITLE
Fix bus marker pivot around ring centre

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -143,7 +143,7 @@
       }
       .bus-marker__rotator {
         transform-box: fill-box;
-        transform-origin: 50% 65%;
+        transform-origin: 50% 35%;
         will-change: transform;
       }
       .bus-marker__body {
@@ -909,9 +909,9 @@
       const BUS_MARKER_MAX_WIDTH_PX = 56;
       const BUS_MARKER_BASE_ZOOM = 15;
       const BUS_MARKER_ANCHOR_X = 28;
-      const BUS_MARKER_ANCHOR_Y = 52; // final screen-space pivot aligned with the ring centre
+      const BUS_MARKER_ANCHOR_Y = 28; // final screen-space pivot at the ring centre
       const BUS_MARKER_RING_CENTER_X = BUS_MARKER_ANCHOR_X;
-      const BUS_MARKER_RING_CENTER_Y = 28; // pre-rotation ring centre inside the SVG artwork
+      const BUS_MARKER_RING_CENTER_Y = BUS_MARKER_ANCHOR_Y; // ring centre inside the SVG artwork
       const BUS_MARKER_ICON_ANCHOR_X_RATIO = BUS_MARKER_ANCHOR_X / BUS_MARKER_VIEWBOX_WIDTH;
       const BUS_MARKER_ICON_ANCHOR_Y_RATIO = BUS_MARKER_ANCHOR_Y / BUS_MARKER_VIEWBOX_HEIGHT;
       const BUS_MARKER_DEFAULT_HEADING = 0;
@@ -4328,7 +4328,7 @@
 
       function computeMarkerRotationTransform(headingDeg) {
           const normalizedHeading = normalizeHeadingDegrees(Number.isFinite(headingDeg) ? headingDeg : BUS_MARKER_DEFAULT_HEADING);
-          return `rotate(${normalizedHeading.toFixed(2)} ${BUS_MARKER_ANCHOR_X} ${BUS_MARKER_ANCHOR_Y})`;
+          return `rotate(${normalizedHeading.toFixed(2)} ${BUS_MARKER_RING_CENTER_X} ${BUS_MARKER_RING_CENTER_Y})`;
       }
 
       function renderBusMarkerMarkup(vehicleID, state) {
@@ -4357,7 +4357,7 @@
             </style>
           </defs>
           <g class="bus-marker__rotator" transform="${rotationTransform}">
-            <!-- Wrap this whole SVG in an OUTER group at runtime to rotate by heading around (28,52).
+            <!-- Rotate the marker around the ring centre so it stays anchored to the vehicle location.
                  This INNER group is a fixed 180° rotate to make the arrow point up by default. -->
             <g id="inner-up-rotate" transform="rotate(${BUS_MARKER_INNER_ROTATE_DEGREES} ${BUS_MARKER_INNER_ROTATE_X} ${BUS_MARKER_INNER_ROTATE_Y})">
               <path class="st1 bus-marker__body" d="${BUS_MARKER_BODY_PATH}" fill="${fillColor}" style="fill: ${fillColor}; fill-opacity: ${fillOpacity};" fill-opacity="${fillOpacity}" />


### PR DESCRIPTION
## Summary
- align the bus marker icon anchor with the circular ring so the marker plots at the correct map location
- rotate the SVG around the ring centre and update CSS transform origin so heading changes spin about the right point

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d040131a8c8333adcce8cb23d5c36d