### PR TITLE
Use external bus marker SVG for map vehicles

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -146,23 +146,16 @@
         transform-origin: 26.5px 43.49px;
         will-change: transform;
       }
-      .bus-marker__body {
+      .bus-marker__svg .st1 {
         paint-order: stroke fill;
         transition: fill 0.2s ease, fill-opacity 0.2s ease;
-      }
-      .bus-marker__ring,
-      .bus-marker__arrow {
-        transition: fill 0.2s ease;
-      }
-      .bus-marker__ring,
-      .bus-marker__arrow,
-      .bus-marker__body {
         pointer-events: auto;
       }
-      .bus-marker__halo {
-        pointer-events: none;
+      .bus-marker__svg .st0 {
+        transition: fill 0.2s ease;
+        pointer-events: auto;
       }
-      .bus-marker__anchor {
+      .bus-marker__svg #halo {
         pointer-events: none;
       }
       .bus-marker__root.is-stale .bus-marker__body {
@@ -909,13 +902,15 @@
       let pendingMarkerScaleMetrics = null;
       let textMeasurementCanvas = null;
 
-      const BUS_MARKER_VIEWBOX_WIDTH = 52.99;
-      const BUS_MARKER_VIEWBOX_HEIGHT = 69.99;
-      const BUS_MARKER_RING_CENTER_FALLBACK = Object.freeze({ x: 26.5, y: 43.49 });
+      const BUS_MARKER_SVG_URL = 'busmarker.svg';
+
+      let BUS_MARKER_VIEWBOX_WIDTH = 56;
+      let BUS_MARKER_VIEWBOX_HEIGHT = 80;
+      const BUS_MARKER_RING_CENTER_FALLBACK = Object.freeze({ x: 28, y: 28 });
       let BUS_MARKER_RING_CENTER_X = BUS_MARKER_RING_CENTER_FALLBACK.x;
       let BUS_MARKER_RING_CENTER_Y = BUS_MARKER_RING_CENTER_FALLBACK.y;
       let BUS_MARKER_RING_CENTER = Object.freeze({ x: BUS_MARKER_RING_CENTER_X, y: BUS_MARKER_RING_CENTER_Y });
-      const BUS_MARKER_ASPECT_RATIO = BUS_MARKER_VIEWBOX_HEIGHT / BUS_MARKER_VIEWBOX_WIDTH;
+      let BUS_MARKER_ASPECT_RATIO = BUS_MARKER_VIEWBOX_HEIGHT / BUS_MARKER_VIEWBOX_WIDTH;
       const BUS_MARKER_BASE_WIDTH_PX = 26;
       const BUS_MARKER_MIN_WIDTH_PX = 18;
       const BUS_MARKER_MAX_WIDTH_PX = 48;
@@ -932,10 +927,8 @@
       const BUS_MARKER_DEFAULT_HEADING = 0;
       const BUS_MARKER_DEFAULT_ROUTE_COLOR = '#0B7A26';
       const BUS_MARKER_DEFAULT_CONTRAST_COLOR = '#FFFFFF';
-      const BUS_MARKER_BODY_PATH = 'M26.5,67.49c-11.5,0-24-9.5-24-26C2.5,23.99,16.3,9.39,23.7,3.49c1.6-1.3,4-1.3,5.6,0,7.4,5.9,21.2,20.5,21.2,38,0,16.5-12.5,26-24,26Z';
-      const BUS_MARKER_HALO_PATH = 'M26.49,0c1.56,0,3.11.52,4.38,1.55,3.68,2.93,22.12,18.71,22.12,39.94.01,17.84-13.46,28.5-26.49,28.5S0,59.33,0,41.49C0,20.26,18.44,4.48,22.14,1.54,23.4.52,24.94.01,26.49.01h0Z';
-      const BUS_MARKER_RING_PATH = 'M26.5,27.99c8.55,0,15.5,6.95,15.5,15.5s-6.95,15.5-15.5,15.5-15.5-6.95-15.5-15.5,6.95-15.5,15.5-15.5ZM26.5,52.49c4.97,0,9-4.03,9-9s-4.03-9-9-9-9,4.03-9,9,4.03,9,9,9Z';
-      const BUS_MARKER_ARROW_PATH = 'M26.5,8.49l10,18c-6.67-4-13.33-4-20,0l10-18Z';
+      let BUS_MARKER_SVG_TEXT = null;
+      let BUS_MARKER_SVG_LOAD_PROMISE = null;
       const BUS_MARKER_LABEL_FONT_FAMILY = 'FGDC, sans-serif';
       const BUS_MARKER_LABEL_MIN_FONT_PX = 10;
       const SPEED_BUBBLE_BASE_FONT_PX = 12;
@@ -3924,193 +3917,206 @@
               .catch(error => console.error("Error fetching block assignments:", error));
       }
 
-      function fetchBusLocations() {
+      async function fetchBusLocations() {
           const currentBaseURL = baseURL;
           const apiUrl = `${currentBaseURL}/Services/JSONPRelay.svc/GetMapVehiclePoints?APIKey=8882812681&returnVehiclesNotAssignedToRoute=true`;
-          return fetch(apiUrl)
-              .then(response => {
-                  if (!response.ok) throw new Error("Network response was not ok: " + response.statusText);
-                  return response.json();
-              })
-              .then(data => {
-                  if (currentBaseURL !== baseURL) return;
-                  if (Array.isArray(data)) {
-                      let currentBusData = {};
-                      let activeRoutesSet = new Set();
-                      let vehicles = [];
+          try {
+              await loadBusSVG();
+          } catch (error) {
+              console.error('Failed to load bus marker SVG before fetching locations:', error);
+          }
+          try {
+              const response = await fetch(apiUrl);
+              if (!response.ok) {
+                  throw new Error(`Network response was not ok: ${response.statusText}`);
+              }
+              const data = await response.json();
+              if (currentBaseURL !== baseURL || !Array.isArray(data)) {
+                  return;
+              }
+              const currentBusData = {};
+              const activeRoutesSet = new Set();
+              const vehicles = [];
 
-                      // First pass: gather vehicles and determine active routes.
-                      data.forEach(vehicle => {
-                          const vehicleID = vehicle.VehicleID;
-                          const newPosition = [vehicle.Latitude, vehicle.Longitude];
-                          const isMoving = vehicle.GroundSpeed > 0;
-                          const busName = vehicle.Name;
-                          let routeID = vehicle.RouteID;
-                          if (!routeID && adminMode) {
-                              routeID = 0;
-                          } else if (!routeID) {
-                              return;
-                          }
-                          const numericRouteId = Number(routeID);
-                          const effectiveRouteId = Number.isNaN(numericRouteId) ? routeID : numericRouteId;
-                          if (!canDisplayRoute(effectiveRouteId)) return;
-                          if (!adminMode && !routeColors.hasOwnProperty(effectiveRouteId)) return;
-                          activeRoutesSet.add(effectiveRouteId);
-                          vehicles.push({
-                              vehicleID,
-                              newPosition,
-                              isMoving,
-                              busName,
-                              routeID: effectiveRouteId,
-                              heading: vehicle.Heading,
-                              groundSpeed: vehicle.GroundSpeed
-                          });
-                      });
-
-                      // Update global activeRoutes and rebuild selector before rendering.
-                      activeRoutes = activeRoutesSet;
-                      updateRouteSelector(activeRoutesSet);
-
-                      const markerMetricsForZoom = computeBusMarkerMetrics(map && typeof map?.getZoom === 'function' ? map.getZoom() : BUS_MARKER_BASE_ZOOM);
-
-                      // Second pass: render only selected routes.
-                      vehicles.forEach(v => {
-                          const { vehicleID, newPosition, busName, routeID, heading, groundSpeed } = v;
-                          if (!isRouteSelected(routeID)) return;
-                          currentBusData[vehicleID] = true;
-                          const state = ensureBusMarkerState(vehicleID);
-                          const routeColor = getRouteColor(routeID) || outOfServiceRouteColor;
-                          const glyphColor = computeBusMarkerGlyphColor(routeColor);
-                          const headingDeg = updateBusMarkerHeading(state, newPosition, heading, groundSpeed);
-                          const accessibleLabel = buildBusMarkerAccessibleLabel(busName, headingDeg, groundSpeed);
-                          const gpsIsStale = isVehicleGpsStale(v);
-
-                          state.busName = busName;
-                          state.routeID = routeID;
-                          state.fillColor = routeColor;
-                          state.glyphColor = glyphColor;
-                          state.headingDeg = headingDeg;
-                          state.accessibleLabel = accessibleLabel;
-                          state.isStale = gpsIsStale;
-                          state.groundSpeed = groundSpeed;
-                          state.lastUpdateTimestamp = Date.now();
-
-                          if (!state.size) {
-                              setBusMarkerSize(state, markerMetricsForZoom);
-                          }
-
-                          if (markers[vehicleID]) {
-                              animateMarkerTo(markers[vehicleID], newPosition);
-                              markers[vehicleID].routeID = routeID;
-                              queueBusMarkerVisualUpdate(vehicleID, {
-                                  fillColor: routeColor,
-                                  glyphColor,
-                                  headingDeg,
-                                  stale: gpsIsStale,
-                                  accessibleLabel
-                              });
-                          } else {
-                              const icon = createBusMarkerDivIcon(vehicleID, state);
-                              const marker = L.marker(newPosition, { icon, pane: 'busesPane', interactive: true });
-                              marker.routeID = routeID;
-                              marker.addTo(map);
-                              markers[vehicleID] = marker;
-                              state.marker = marker;
-                              registerBusMarkerElements(vehicleID);
-                              attachBusMarkerInteractions(vehicleID);
-                              updateBusMarkerRootClasses(state);
-                              updateBusMarkerZIndex(state);
-                              applyBusMarkerOutlineWidth(state);
-                          }
-                          if (adminMode && displayMode === DISPLAY_MODES.SPEED && !kioskMode) {
-                              const speedIcon = createSpeedBubbleDivIcon(routeColor, groundSpeed, markerMetricsForZoom.scale);
-                              if (speedIcon) {
-                                  nameBubbles[vehicleID] = nameBubbles[vehicleID] || {};
-                                  if (nameBubbles[vehicleID].speedMarker) {
-                                      animateMarkerTo(nameBubbles[vehicleID].speedMarker, newPosition);
-                                      nameBubbles[vehicleID].speedMarker.setIcon(speedIcon);
-                                  } else {
-                                      nameBubbles[vehicleID].speedMarker = L.marker(newPosition, { icon: speedIcon, interactive: false, pane: 'busesPane' }).addTo(map);
-                                  }
-                              } else if (nameBubbles[vehicleID] && nameBubbles[vehicleID].speedMarker) {
-                                  map.removeLayer(nameBubbles[vehicleID].speedMarker);
-                                  delete nameBubbles[vehicleID].speedMarker;
-                              }
-                          } else if (nameBubbles[vehicleID] && nameBubbles[vehicleID].speedMarker) {
-                              map.removeLayer(nameBubbles[vehicleID].speedMarker);
-                              delete nameBubbles[vehicleID].speedMarker;
-                          }
-                          if (adminMode && !kioskMode) {
-                              const nameIcon = createNameBubbleDivIcon(busName, routeColor, markerMetricsForZoom.scale);
-                              if (nameIcon) {
-                                  nameBubbles[vehicleID] = nameBubbles[vehicleID] || {};
-                                  if (nameBubbles[vehicleID].nameMarker) {
-                                      animateMarkerTo(nameBubbles[vehicleID].nameMarker, newPosition);
-                                      nameBubbles[vehicleID].nameMarker.setIcon(nameIcon);
-                                  } else {
-                                      nameBubbles[vehicleID].nameMarker = L.marker(newPosition, { icon: nameIcon, interactive: false, pane: 'busesPane' }).addTo(map);
-                                  }
-                              } else if (nameBubbles[vehicleID] && nameBubbles[vehicleID].nameMarker) {
-                                  map.removeLayer(nameBubbles[vehicleID].nameMarker);
-                                  delete nameBubbles[vehicleID].nameMarker;
-                              }
-
-                              const blockName = busBlocks[vehicleID];
-                              if (displayMode === DISPLAY_MODES.BLOCK && blockName && blockName.includes('[')) {
-                                  const blockIcon = createBlockBubbleDivIcon(blockName, routeColor, markerMetricsForZoom.scale);
-                                  if (blockIcon) {
-                                      nameBubbles[vehicleID] = nameBubbles[vehicleID] || {};
-                                      if (nameBubbles[vehicleID].blockMarker) {
-                                          animateMarkerTo(nameBubbles[vehicleID].blockMarker, newPosition);
-                                          nameBubbles[vehicleID].blockMarker.setIcon(blockIcon);
-                                      } else {
-                                          nameBubbles[vehicleID].blockMarker = L.marker(newPosition, { icon: blockIcon, interactive: false, pane: 'busesPane' }).addTo(map);
-                                      }
-                                  } else if (nameBubbles[vehicleID] && nameBubbles[vehicleID].blockMarker) {
-                                      map.removeLayer(nameBubbles[vehicleID].blockMarker);
-                                      delete nameBubbles[vehicleID].blockMarker;
-                                  }
-                              } else if (nameBubbles[vehicleID] && nameBubbles[vehicleID].blockMarker) {
-                                  map.removeLayer(nameBubbles[vehicleID].blockMarker);
-                                  delete nameBubbles[vehicleID].blockMarker;
-                              }
-                          } else {
-                              if (nameBubbles[vehicleID] && nameBubbles[vehicleID].nameMarker) {
-                                  map.removeLayer(nameBubbles[vehicleID].nameMarker);
-                                  delete nameBubbles[vehicleID].nameMarker;
-                              }
-                              if (nameBubbles[vehicleID] && nameBubbles[vehicleID].blockMarker) {
-                                  map.removeLayer(nameBubbles[vehicleID].blockMarker);
-                                  delete nameBubbles[vehicleID].blockMarker;
-                              }
-                          }
-                          if (nameBubbles[vehicleID]) {
-                              const hasMarkers = Boolean(nameBubbles[vehicleID].speedMarker || nameBubbles[vehicleID].nameMarker || nameBubbles[vehicleID].blockMarker);
-                              if (hasMarkers) {
-                                  nameBubbles[vehicleID].lastScale = markerMetricsForZoom.scale;
-                              } else {
-                                  delete nameBubbles[vehicleID];
-                              }
-                          }
-                      });
-
-                      Object.keys(markers).forEach(vehicleID => {
-                          if (!currentBusData[vehicleID] || !isRouteSelected(markers[vehicleID].routeID)) {
-                              map.removeLayer(markers[vehicleID]);
-                              delete markers[vehicleID];
-                              clearBusMarkerState(vehicleID);
-                              if (nameBubbles[vehicleID]) {
-                                  if (nameBubbles[vehicleID].speedMarker) map.removeLayer(nameBubbles[vehicleID].speedMarker);
-                                  if (nameBubbles[vehicleID].nameMarker) map.removeLayer(nameBubbles[vehicleID].nameMarker);
-                                  if (nameBubbles[vehicleID].blockMarker) map.removeLayer(nameBubbles[vehicleID].blockMarker);
-                                  delete nameBubbles[vehicleID];
-                              }
-                          }
-                      });
-                      previousBusData = currentBusData;
+              data.forEach(vehicle => {
+                  const vehicleID = vehicle.VehicleID;
+                  const newPosition = [vehicle.Latitude, vehicle.Longitude];
+                  const isMoving = vehicle.GroundSpeed > 0;
+                  const busName = vehicle.Name;
+                  let routeID = vehicle.RouteID;
+                  if (!routeID && adminMode) {
+                      routeID = 0;
+                  } else if (!routeID) {
+                      return;
                   }
-              })
-              .catch(error => console.error("Error fetching bus locations:", error));
+                  const numericRouteId = Number(routeID);
+                  const effectiveRouteId = Number.isNaN(numericRouteId) ? routeID : numericRouteId;
+                  if (!canDisplayRoute(effectiveRouteId)) return;
+                  if (!adminMode && !routeColors.hasOwnProperty(effectiveRouteId)) return;
+                  activeRoutesSet.add(effectiveRouteId);
+                  vehicles.push({
+                      vehicleID,
+                      newPosition,
+                      isMoving,
+                      busName,
+                      routeID: effectiveRouteId,
+                      heading: vehicle.Heading,
+                      groundSpeed: vehicle.GroundSpeed
+                  });
+              });
+
+              activeRoutes = activeRoutesSet;
+              updateRouteSelector(activeRoutesSet);
+
+              const markerMetricsForZoom = computeBusMarkerMetrics(map && typeof map?.getZoom === 'function' ? map.getZoom() : BUS_MARKER_BASE_ZOOM);
+
+              for (const v of vehicles) {
+                  const { vehicleID, newPosition, busName, routeID, heading, groundSpeed } = v;
+                  if (!isRouteSelected(routeID)) continue;
+                  currentBusData[vehicleID] = true;
+                  const state = ensureBusMarkerState(vehicleID);
+                  const routeColor = getRouteColor(routeID) || outOfServiceRouteColor;
+                  const glyphColor = computeBusMarkerGlyphColor(routeColor);
+                  const headingDeg = updateBusMarkerHeading(state, newPosition, heading, groundSpeed);
+                  const accessibleLabel = buildBusMarkerAccessibleLabel(busName, headingDeg, groundSpeed);
+                  const gpsIsStale = isVehicleGpsStale(v);
+
+                  state.busName = busName;
+                  state.routeID = routeID;
+                  state.fillColor = routeColor;
+                  state.glyphColor = glyphColor;
+                  state.headingDeg = headingDeg;
+                  state.accessibleLabel = accessibleLabel;
+                  state.isStale = gpsIsStale;
+                  state.groundSpeed = groundSpeed;
+                  state.lastUpdateTimestamp = Date.now();
+
+                  if (!state.size) {
+                      setBusMarkerSize(state, markerMetricsForZoom);
+                  }
+
+                  if (markers[vehicleID]) {
+                      animateMarkerTo(markers[vehicleID], newPosition);
+                      markers[vehicleID].routeID = routeID;
+                      queueBusMarkerVisualUpdate(vehicleID, {
+                          fillColor: routeColor,
+                          glyphColor,
+                          headingDeg,
+                          stale: gpsIsStale,
+                          accessibleLabel
+                      });
+                  } else {
+                      try {
+                          const icon = await createBusMarkerDivIcon(vehicleID, state);
+                          if (!icon) {
+                              continue;
+                          }
+                          const marker = L.marker(newPosition, { icon, pane: 'busesPane', interactive: true });
+                          marker.routeID = routeID;
+                          marker.addTo(map);
+                          markers[vehicleID] = marker;
+                          state.marker = marker;
+                          registerBusMarkerElements(vehicleID);
+                          attachBusMarkerInteractions(vehicleID);
+                          updateBusMarkerRootClasses(state);
+                          updateBusMarkerZIndex(state);
+                          applyBusMarkerOutlineWidth(state);
+                      } catch (error) {
+                          console.error(`Failed to create bus marker icon for vehicle ${vehicleID}:`, error);
+                      }
+                  }
+
+                  if (adminMode && displayMode === DISPLAY_MODES.SPEED && !kioskMode) {
+                      const speedIcon = createSpeedBubbleDivIcon(routeColor, groundSpeed, markerMetricsForZoom.scale);
+                      if (speedIcon) {
+                          nameBubbles[vehicleID] = nameBubbles[vehicleID] || {};
+                          if (nameBubbles[vehicleID].speedMarker) {
+                              animateMarkerTo(nameBubbles[vehicleID].speedMarker, newPosition);
+                              nameBubbles[vehicleID].speedMarker.setIcon(speedIcon);
+                          } else {
+                              nameBubbles[vehicleID].speedMarker = L.marker(newPosition, { icon: speedIcon, interactive: false, pane: 'busesPane' }).addTo(map);
+                          }
+                      } else if (nameBubbles[vehicleID] && nameBubbles[vehicleID].speedMarker) {
+                          map.removeLayer(nameBubbles[vehicleID].speedMarker);
+                          delete nameBubbles[vehicleID].speedMarker;
+                      }
+                  } else if (nameBubbles[vehicleID] && nameBubbles[vehicleID].speedMarker) {
+                      map.removeLayer(nameBubbles[vehicleID].speedMarker);
+                      delete nameBubbles[vehicleID].speedMarker;
+                  }
+
+                  if (adminMode && !kioskMode) {
+                      const nameIcon = createNameBubbleDivIcon(busName, routeColor, markerMetricsForZoom.scale);
+                      if (nameIcon) {
+                          nameBubbles[vehicleID] = nameBubbles[vehicleID] || {};
+                          if (nameBubbles[vehicleID].nameMarker) {
+                              animateMarkerTo(nameBubbles[vehicleID].nameMarker, newPosition);
+                              nameBubbles[vehicleID].nameMarker.setIcon(nameIcon);
+                          } else {
+                              nameBubbles[vehicleID].nameMarker = L.marker(newPosition, { icon: nameIcon, interactive: false, pane: 'busesPane' }).addTo(map);
+                          }
+                      } else if (nameBubbles[vehicleID] && nameBubbles[vehicleID].nameMarker) {
+                          map.removeLayer(nameBubbles[vehicleID].nameMarker);
+                          delete nameBubbles[vehicleID].nameMarker;
+                      }
+
+                      const blockName = busBlocks[vehicleID];
+                      if (displayMode === DISPLAY_MODES.BLOCK && blockName && blockName.includes('[')) {
+                          const blockIcon = createBlockBubbleDivIcon(blockName, routeColor, markerMetricsForZoom.scale);
+                          if (blockIcon) {
+                              nameBubbles[vehicleID] = nameBubbles[vehicleID] || {};
+                              if (nameBubbles[vehicleID].blockMarker) {
+                                  animateMarkerTo(nameBubbles[vehicleID].blockMarker, newPosition);
+                                  nameBubbles[vehicleID].blockMarker.setIcon(blockIcon);
+                              } else {
+                                  nameBubbles[vehicleID].blockMarker = L.marker(newPosition, { icon: blockIcon, interactive: false, pane: 'busesPane' }).addTo(map);
+                              }
+                          } else if (nameBubbles[vehicleID] && nameBubbles[vehicleID].blockMarker) {
+                              map.removeLayer(nameBubbles[vehicleID].blockMarker);
+                              delete nameBubbles[vehicleID].blockMarker;
+                          }
+                      } else if (nameBubbles[vehicleID] && nameBubbles[vehicleID].blockMarker) {
+                          map.removeLayer(nameBubbles[vehicleID].blockMarker);
+                          delete nameBubbles[vehicleID].blockMarker;
+                      }
+                  } else {
+                      if (nameBubbles[vehicleID] && nameBubbles[vehicleID].nameMarker) {
+                          map.removeLayer(nameBubbles[vehicleID].nameMarker);
+                          delete nameBubbles[vehicleID].nameMarker;
+                      }
+                      if (nameBubbles[vehicleID] && nameBubbles[vehicleID].blockMarker) {
+                          map.removeLayer(nameBubbles[vehicleID].blockMarker);
+                          delete nameBubbles[vehicleID].blockMarker;
+                      }
+                  }
+
+                  if (nameBubbles[vehicleID]) {
+                      const hasMarkers = Boolean(nameBubbles[vehicleID].speedMarker || nameBubbles[vehicleID].nameMarker || nameBubbles[vehicleID].blockMarker);
+                      if (hasMarkers) {
+                          nameBubbles[vehicleID].lastScale = markerMetricsForZoom.scale;
+                      } else {
+                          delete nameBubbles[vehicleID];
+                      }
+                  }
+              }
+
+              Object.keys(markers).forEach(vehicleID => {
+                  if (!currentBusData[vehicleID] || !isRouteSelected(markers[vehicleID].routeID)) {
+                      map.removeLayer(markers[vehicleID]);
+                      delete markers[vehicleID];
+                      clearBusMarkerState(vehicleID);
+                      if (nameBubbles[vehicleID]) {
+                          if (nameBubbles[vehicleID].speedMarker) map.removeLayer(nameBubbles[vehicleID].speedMarker);
+                          if (nameBubbles[vehicleID].nameMarker) map.removeLayer(nameBubbles[vehicleID].nameMarker);
+                          if (nameBubbles[vehicleID].blockMarker) map.removeLayer(nameBubbles[vehicleID].blockMarker);
+                          delete nameBubbles[vehicleID];
+                      }
+                  }
+              });
+              previousBusData = currentBusData;
+          } catch (error) {
+              console.error("Error fetching bus locations:", error);
+          }
       }
 
       function getContrastColor(hexColor) {
@@ -4175,26 +4181,38 @@
           BUS_MARKER_ICON_ANCHOR_Y_RATIO = BUS_MARKER_ANCHOR_Y / BUS_MARKER_VIEWBOX_HEIGHT;
       }
 
-      function refreshBusMarkerIconsForRingCenterChange() {
+      async function refreshBusMarkerIconsForRingCenterChange() {
           if (busMarkerIconRefreshInProgress) {
               return;
           }
           busMarkerIconRefreshInProgress = true;
           try {
-              Object.keys(markers).forEach(vehicleID => {
+              try {
+                  await loadBusSVG();
+              } catch (error) {
+                  console.error('Failed to load bus marker SVG while refreshing icons:', error);
+              }
+              for (const vehicleID of Object.keys(markers)) {
                   const marker = markers[vehicleID];
                   const state = busMarkerStates[vehicleID];
                   if (!marker || !state) {
-                      return;
+                      continue;
                   }
-                  const icon = createBusMarkerDivIcon(vehicleID, state);
-                  marker.setIcon(icon);
-                  registerBusMarkerElements(vehicleID);
-                  attachBusMarkerInteractions(vehicleID);
-                  updateBusMarkerRootClasses(state);
-                  updateBusMarkerZIndex(state);
-                  applyBusMarkerOutlineWidth(state);
-              });
+                  try {
+                      const icon = await createBusMarkerDivIcon(vehicleID, state);
+                      if (!icon) {
+                          continue;
+                      }
+                      marker.setIcon(icon);
+                      registerBusMarkerElements(vehicleID);
+                      attachBusMarkerInteractions(vehicleID);
+                      updateBusMarkerRootClasses(state);
+                      updateBusMarkerZIndex(state);
+                      applyBusMarkerOutlineWidth(state);
+                  } catch (error) {
+                      console.error(`Failed to refresh bus marker icon for vehicle ${vehicleID}:`, error);
+                  }
+              }
           } finally {
               busMarkerIconRefreshInProgress = false;
           }
@@ -4289,7 +4307,7 @@
           }
           const fallback = BUS_MARKER_DEFAULT_CONTRAST_COLOR;
           const candidate = typeof routeColor === 'string' && routeColor.trim().length > 0 ? routeColor : BUS_MARKER_DEFAULT_ROUTE_COLOR;
-          const contrast = getContrastColor(candidate);
+          const contrast = contrastBW(candidate);
           return contrast || fallback;
       }
 
@@ -4565,6 +4583,168 @@
               .replace(/'/g, '&#39;');
       }
 
+      function updateBusMarkerGeometryFromSvg(svgEl) {
+          if (!svgEl || typeof svgEl.getAttribute !== 'function') {
+              return;
+          }
+          let width = BUS_MARKER_VIEWBOX_WIDTH;
+          let height = BUS_MARKER_VIEWBOX_HEIGHT;
+          const viewBoxAttr = svgEl.getAttribute('viewBox');
+          if (typeof viewBoxAttr === 'string') {
+              const parts = viewBoxAttr.trim().split(/\s+/);
+              if (parts.length === 4) {
+                  const parsedWidth = Number(parts[2]);
+                  const parsedHeight = Number(parts[3]);
+                  if (Number.isFinite(parsedWidth) && parsedWidth > 0) {
+                      width = parsedWidth;
+                  }
+                  if (Number.isFinite(parsedHeight) && parsedHeight > 0) {
+                      height = parsedHeight;
+                  }
+              }
+          } else {
+              const widthAttr = Number(svgEl.getAttribute('width'));
+              const heightAttr = Number(svgEl.getAttribute('height'));
+              if (Number.isFinite(widthAttr) && widthAttr > 0) {
+                  width = widthAttr;
+              }
+              if (Number.isFinite(heightAttr) && heightAttr > 0) {
+                  height = heightAttr;
+              }
+          }
+          BUS_MARKER_VIEWBOX_WIDTH = width;
+          BUS_MARKER_VIEWBOX_HEIGHT = height;
+          BUS_MARKER_ASPECT_RATIO = BUS_MARKER_VIEWBOX_HEIGHT / BUS_MARKER_VIEWBOX_WIDTH;
+
+          let centerX = BUS_MARKER_RING_CENTER_FALLBACK.x;
+          let centerY = BUS_MARKER_RING_CENTER_FALLBACK.y;
+          const ringSelectors = ['#center_ring', '[data-marker-segment="center_ring"]'];
+          let ringElement = null;
+          for (let i = 0; i < ringSelectors.length && !ringElement; i += 1) {
+              ringElement = svgEl.querySelector(ringSelectors[i]);
+          }
+          if (ringElement && typeof ringElement.getBBox === 'function' && document?.body) {
+              const tempContainer = document.createElement('div');
+              tempContainer.style.position = 'absolute';
+              tempContainer.style.width = '0';
+              tempContainer.style.height = '0';
+              tempContainer.style.overflow = 'hidden';
+              tempContainer.style.visibility = 'hidden';
+              const tempSvg = svgEl.cloneNode(true);
+              tempSvg.style.position = 'absolute';
+              tempSvg.style.pointerEvents = 'none';
+              tempSvg.style.visibility = 'hidden';
+              tempContainer.appendChild(tempSvg);
+              document.body.appendChild(tempContainer);
+              try {
+                  let candidate = null;
+                  for (let i = 0; i < ringSelectors.length && !candidate; i += 1) {
+                      candidate = tempSvg.querySelector(ringSelectors[i]);
+                  }
+                  if (candidate) {
+                      const bbox = candidate.getBBox();
+                      if (bbox && Number.isFinite(bbox.x) && Number.isFinite(bbox.width) && Number.isFinite(bbox.y) && Number.isFinite(bbox.height)) {
+                          centerX = bbox.x + bbox.width / 2;
+                          centerY = bbox.y + bbox.height / 2;
+                      }
+                  }
+              } catch (error) {
+                  console.warn('Unable to measure bus marker ring center from SVG:', error);
+              } finally {
+                  if (tempContainer.parentNode) {
+                      tempContainer.parentNode.removeChild(tempContainer);
+                  }
+              }
+          }
+          setBusMarkerRingCenterCoordinates(centerX, centerY);
+      }
+
+      function contrastBW(hex) {
+          if (typeof hex !== 'string' || hex.trim().length === 0) {
+              return '#FFFFFF';
+          }
+          let normalized = hex.trim().replace(/^#/, '');
+          if (normalized.length === 3) {
+              normalized = normalized.split('').map(ch => ch + ch).join('');
+          }
+          if (normalized.length !== 6 || /[^0-9a-fA-F]/.test(normalized)) {
+              return '#FFFFFF';
+          }
+          const r = parseInt(normalized.substring(0, 2), 16) / 255;
+          const g = parseInt(normalized.substring(2, 4), 16) / 255;
+          const b = parseInt(normalized.substring(4, 6), 16) / 255;
+          const L = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+          return L > 0.55 ? '#000000' : '#FFFFFF';
+      }
+
+      function applyMarkerColors(svgEl, routeHex, glyphOverride = null, fillOpacity = '1') {
+          if (!svgEl) {
+              return;
+          }
+          const routeColor = typeof routeHex === 'string' && routeHex.trim().length > 0 ? routeHex.trim() : BUS_MARKER_DEFAULT_ROUTE_COLOR;
+          const glyphColor = typeof glyphOverride === 'string' && glyphOverride.trim().length > 0 ? glyphOverride.trim() : contrastBW(routeColor);
+          const safeOpacity = typeof fillOpacity === 'string' ? fillOpacity : `${fillOpacity}`;
+          const routeSegments = Array.from(svgEl.querySelectorAll('.st1'));
+          routeSegments.forEach(segment => {
+              segment.setAttribute('fill', routeColor);
+              segment.style.fill = routeColor;
+              segment.setAttribute('fill-opacity', safeOpacity);
+              segment.style.fillOpacity = safeOpacity;
+          });
+          const ringAndArrowSegments = [];
+          const ring = svgEl.querySelector('#center_ring');
+          if (ring) {
+              ringAndArrowSegments.push(ring);
+          }
+          const arrow = svgEl.querySelector('#heading_arrow');
+          if (arrow) {
+              ringAndArrowSegments.push(arrow);
+          }
+          if (ringAndArrowSegments.length === 0) {
+              ringAndArrowSegments.push(...svgEl.querySelectorAll('.st0'));
+          }
+          ringAndArrowSegments.forEach(segment => {
+              segment.setAttribute('fill', glyphColor);
+              segment.style.fill = glyphColor;
+          });
+          const halo = svgEl.querySelector('#halo');
+          if (halo) {
+              halo.setAttribute('fill', '#FFFFFF');
+              halo.style.fill = '#FFFFFF';
+          }
+      }
+
+      async function loadBusSVG() {
+          if (BUS_MARKER_SVG_TEXT) {
+              return BUS_MARKER_SVG_TEXT;
+          }
+          if (!BUS_MARKER_SVG_LOAD_PROMISE) {
+              BUS_MARKER_SVG_LOAD_PROMISE = fetch(BUS_MARKER_SVG_URL)
+                  .then(response => {
+                      if (!response.ok) {
+                          throw new Error(`Failed to load bus marker SVG: ${response.status} ${response.statusText}`);
+                      }
+                      return response.text();
+                  })
+                  .then(text => {
+                      const template = document.createElement('template');
+                      template.innerHTML = text.trim();
+                      const parsedSvg = template.content.firstElementChild;
+                      if (parsedSvg && parsedSvg.tagName && parsedSvg.tagName.toLowerCase() === 'svg') {
+                          updateBusMarkerGeometryFromSvg(parsedSvg);
+                      }
+                      BUS_MARKER_SVG_TEXT = text;
+                      BUS_MARKER_SVG_LOAD_PROMISE = null;
+                      return BUS_MARKER_SVG_TEXT;
+                  })
+                  .catch(error => {
+                      BUS_MARKER_SVG_LOAD_PROMISE = null;
+                      throw error;
+                  });
+          }
+          return BUS_MARKER_SVG_LOAD_PROMISE;
+      }
+
       function computeMarkerRotationTransform(headingDeg) {
           const normalizedHeading = normalizeHeadingDegrees(Number.isFinite(headingDeg) ? headingDeg : BUS_MARKER_DEFAULT_HEADING);
           const pivotX = BUS_MARKER_RING_CENTER_X;
@@ -4573,49 +4753,89 @@
           return `rotate(${rotation} ${pivotX} ${pivotY})`;
       }
 
-      function renderBusMarkerMarkup(vehicleID, state) {
-          const fillColor = state?.fillColor || BUS_MARKER_DEFAULT_ROUTE_COLOR;
-          const glyphColor = state?.glyphColor || computeBusMarkerGlyphColor(fillColor);
-          const headingDeg = Number.isFinite(state?.headingDeg) ? state.headingDeg : BUS_MARKER_DEFAULT_HEADING;
-          const labelRaw = state?.accessibleLabel && state.accessibleLabel.trim().length > 0
-              ? state.accessibleLabel.trim()
-              : `Vehicle ${vehicleID}`;
-          const labelEscaped = escapeHtml(labelRaw);
-          const rootClasses = ['bus-marker__root'];
-          if (state?.isStale) rootClasses.push('is-stale');
-          if (state?.isSelected) rootClasses.push('is-selected');
-          if (state?.isHovered) rootClasses.push('is-hover');
-          const rotationTransform = computeMarkerRotationTransform(headingDeg);
-          const fillOpacity = state?.isStale ? '0.6' : '1';
-          return `
-      <div class="${rootClasses.join(' ')}" data-vehicle-id="${escapeHtml(`${vehicleID}`)}" tabindex="0" aria-label="${labelEscaped}" role="img">
-        <svg class="bus-marker__svg" viewBox="0 0 ${BUS_MARKER_VIEWBOX_WIDTH} ${BUS_MARKER_VIEWBOX_HEIGHT}" preserveAspectRatio="xMidYMid meet" role="img" aria-label="${labelEscaped}" focusable="false">
-          <title>${labelEscaped}</title>
-          <g class="bus-marker__rotator" transform="${rotationTransform}">
-            <path data-marker-segment="halo" class="bus-marker__halo" d="${BUS_MARKER_HALO_PATH}" fill="#FFFFFF" style="fill: #FFFFFF;" />
-            <path data-marker-segment="route_color" class="bus-marker__route bus-marker__body" d="${BUS_MARKER_BODY_PATH}" fill="${fillColor}" style="fill: ${fillColor}; fill-opacity: ${fillOpacity};" fill-opacity="${fillOpacity}" />
-            <circle data-marker-segment="anchor_point" class="bus-marker__anchor" cx="${BUS_MARKER_RING_CENTER_X}" cy="${BUS_MARKER_RING_CENTER_Y}" r="0" />
-            <path data-marker-segment="center_ring" class="bus-marker__ring" d="${BUS_MARKER_RING_PATH}" fill="${glyphColor}" style="fill: ${glyphColor};" fill-rule="evenodd" clip-rule="evenodd" />
-            <path data-marker-segment="heading_arrow" class="bus-marker__arrow" d="${BUS_MARKER_ARROW_PATH}" fill="${glyphColor}" style="fill: ${glyphColor};" />
-          </g>
-        </svg>
-      </div>`;
-      }
-
-      function createBusMarkerDivIcon(vehicleID, state) {
+      async function createBusMarkerDivIcon(vehicleID, state) {
           if (!state) {
               return null;
           }
+          try {
+              await loadBusSVG();
+          } catch (error) {
+              console.error('Failed to load bus marker SVG:', error);
+              return null;
+          }
+          if (!BUS_MARKER_SVG_TEXT) {
+              return null;
+          }
           if (!state.size) {
-              setBusMarkerSize(state, computeBusMarkerMetrics(map && typeof map?.getZoom === 'function' ? map.getZoom() : BUS_MARKER_BASE_ZOOM));
+              const zoom = map && typeof map?.getZoom === 'function' ? map.getZoom() : BUS_MARKER_BASE_ZOOM;
+              setBusMarkerSize(state, computeBusMarkerMetrics(zoom));
           }
           const width = state.size?.widthPx ?? BUS_MARKER_BASE_WIDTH_PX;
           const height = state.size?.heightPx ?? width * BUS_MARKER_ASPECT_RATIO;
           const anchorX = width * BUS_MARKER_ICON_ANCHOR_X_RATIO;
           const anchorY = height * BUS_MARKER_ICON_ANCHOR_Y_RATIO;
+          const routeColor = state?.fillColor || BUS_MARKER_DEFAULT_ROUTE_COLOR;
+          const glyphColor = state?.glyphColor || computeBusMarkerGlyphColor(routeColor);
+          const headingDeg = Number.isFinite(state?.headingDeg) ? state.headingDeg : BUS_MARKER_DEFAULT_HEADING;
+          const fillOpacity = state?.isStale ? '0.6' : '1';
+          const label = state?.accessibleLabel && state.accessibleLabel.trim().length > 0
+              ? state.accessibleLabel.trim()
+              : `Vehicle ${vehicleID}`;
+          const template = document.createElement('template');
+          template.innerHTML = BUS_MARKER_SVG_TEXT.trim();
+          const svgEl = template.content.firstElementChild;
+          if (!svgEl || svgEl.tagName.toLowerCase() !== 'svg') {
+              return null;
+          }
+          svgEl.querySelectorAll('style').forEach(styleNode => styleNode.remove());
+          svgEl.classList.add('bus-marker__svg');
+          svgEl.setAttribute('viewBox', `0 0 ${BUS_MARKER_VIEWBOX_WIDTH} ${BUS_MARKER_VIEWBOX_HEIGHT}`);
+          svgEl.setAttribute('preserveAspectRatio', 'xMidYMid meet');
+          svgEl.setAttribute('focusable', 'false');
+          svgEl.setAttribute('role', 'img');
+          svgEl.setAttribute('aria-label', label);
+          svgEl.setAttribute('overflow', 'visible');
+
+          const existingTitle = svgEl.querySelector('title');
+          if (existingTitle) {
+              existingTitle.remove();
+          }
+          const title = document.createElementNS('http://www.w3.org/2000/svg', 'title');
+          title.textContent = label;
+          svgEl.insertBefore(title, svgEl.firstChild);
+
+          const rotator = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+          rotator.classList.add('bus-marker__rotator');
+          rotator.setAttribute('transform', computeMarkerRotationTransform(headingDeg));
+          const nodesToWrap = [];
+          for (let child = svgEl.firstChild; child; child = child.nextSibling) {
+              if (child !== title) {
+                  nodesToWrap.push(child);
+              }
+          }
+          nodesToWrap.forEach(node => rotator.appendChild(node));
+          svgEl.appendChild(rotator);
+
+          applyMarkerColors(svgEl, routeColor, glyphColor, fillOpacity);
+
+          const rootClasses = ['bus-marker__root'];
+          if (state?.isStale) rootClasses.push('is-stale');
+          if (state?.isSelected) rootClasses.push('is-selected');
+          if (state?.isHovered) rootClasses.push('is-hover');
+          const root = document.createElement('div');
+          root.className = rootClasses.join(' ');
+          root.dataset.vehicleId = `${vehicleID}`;
+          root.setAttribute('tabindex', '0');
+          root.setAttribute('role', 'img');
+          root.setAttribute('aria-label', label);
+          root.appendChild(svgEl);
+
+          const wrapper = document.createElement('div');
+          wrapper.appendChild(root);
+
           return L.divIcon({
-              html: renderBusMarkerMarkup(vehicleID, state),
-              className: 'bus-marker',
+              html: wrapper.innerHTML,
+              className: 'leaflet-div-icon bus-marker',
               iconSize: [width, height],
               iconAnchor: [anchorX, anchorY]
           });
@@ -4633,21 +4853,25 @@
           }
           const root = iconElement.querySelector('.bus-marker__root');
           const svg = root ? root.querySelector('.bus-marker__svg') : null;
-          const rotators = root ? Array.from(root.querySelectorAll('.bus-marker__rotator')) : [];
+          const rotators = svg ? Array.from(svg.querySelectorAll('.bus-marker__rotator')) : [];
           const rotator = rotators.length > 0 ? rotators[0] : null;
-          const body = root ? root.querySelector('.bus-marker__body') : null;
-          const ring = root ? root.querySelector('.bus-marker__ring') : null;
-          const arrow = root ? root.querySelector('.bus-marker__arrow') : null;
-          const halo = root ? root.querySelector('.bus-marker__halo') : null;
-          const anchor = root ? root.querySelector('.bus-marker__anchor') : null;
+          const routeSegments = svg ? Array.from(svg.querySelectorAll('.st1')) : [];
+          const ringSegments = svg ? Array.from(svg.querySelectorAll('#center_ring')) : [];
+          const arrowSegments = svg ? Array.from(svg.querySelectorAll('#heading_arrow')) : [];
+          const contrastSegments = [...ringSegments, ...arrowSegments];
+          const halo = svg ? svg.querySelector('#halo') : null;
           const title = svg ? svg.querySelector('title') : null;
-          if (anchor) {
-              updateBusMarkerAnchorPointFromElement(anchor);
-          }
-          if (ring) {
-              updateBusMarkerRingCenterFromElement(ring);
-          }
-          state.elements = { icon: iconElement, root, svg, rotator, rotators, body, ring, arrow, halo, anchor, title };
+          state.elements = {
+              icon: iconElement,
+              root,
+              svg,
+              rotator,
+              rotators,
+              routeSegments,
+              contrastSegments,
+              halo,
+              title
+          };
           if (root) {
               root.dataset.vehicleId = `${vehicleID}`;
           }
@@ -4705,26 +4929,14 @@
           const glyphColor = state.glyphColor || computeBusMarkerGlyphColor(routeColor);
           state.glyphColor = glyphColor;
           const fillOpacity = state.isStale ? '0.6' : '1';
-          if (elements.halo) {
-              elements.halo.setAttribute('fill', '#FFFFFF');
-              elements.halo.style.fill = '#FFFFFF';
+          if (elements.svg) {
+              applyMarkerColors(elements.svg, routeColor, glyphColor, fillOpacity);
+              if (state.accessibleLabel) {
+                  elements.svg.setAttribute('aria-label', state.accessibleLabel);
+              }
           }
-          if (elements.body) {
-              elements.body.setAttribute('fill', routeColor);
-              elements.body.style.fill = routeColor;
-              elements.body.setAttribute('fill-opacity', fillOpacity);
-              elements.body.style.fillOpacity = fillOpacity;
-          }
-          if (elements.ring) {
-              elements.ring.setAttribute('fill', glyphColor);
-              elements.ring.style.fill = glyphColor;
-          }
-          if (elements.arrow) {
-              elements.arrow.setAttribute('fill', glyphColor);
-              elements.arrow.style.fill = glyphColor;
-          }
-          if (elements.svg && state.accessibleLabel) {
-              elements.svg.setAttribute('aria-label', state.accessibleLabel);
+          if (elements.root && state.accessibleLabel) {
+              elements.root.setAttribute('aria-label', state.accessibleLabel);
           }
           if (elements.title && state.accessibleLabel) {
               elements.title.textContent = state.accessibleLabel;
@@ -4749,9 +4961,11 @@
               return;
           }
           const fillOpacity = state.isStale ? '0.6' : '1';
-          if (state.elements.body) {
-              state.elements.body.setAttribute('fill-opacity', fillOpacity);
-              state.elements.body.style.fillOpacity = fillOpacity;
+          if (Array.isArray(state.elements.routeSegments)) {
+              state.elements.routeSegments.forEach(segment => {
+                  segment.setAttribute('fill-opacity', fillOpacity);
+                  segment.style.fillOpacity = fillOpacity;
+              });
           }
       }
 
@@ -4837,31 +5051,43 @@
           }
       }
 
-      function updateBusMarkerSizes(metricsOverride = null) {
+      async function updateBusMarkerSizes(metricsOverride = null) {
           if (!map) {
               return;
           }
           const zoom = typeof map.getZoom === 'function' ? map.getZoom() : BUS_MARKER_BASE_ZOOM;
           const metrics = metricsOverride || computeBusMarkerMetrics(zoom);
-          Object.keys(markers).forEach(vehicleID => {
+          try {
+              await loadBusSVG();
+          } catch (error) {
+              console.error('Failed to load bus marker SVG while updating sizes:', error);
+          }
+          for (const vehicleID of Object.keys(markers)) {
               const marker = markers[vehicleID];
               const state = busMarkerStates[vehicleID];
               if (!marker || !state) {
-                  return;
+                  continue;
               }
               const currentWidth = state.size?.widthPx;
               if (currentWidth && Math.abs(currentWidth - metrics.widthPx) < 0.1) {
-                  return;
+                  continue;
               }
               setBusMarkerSize(state, metrics);
-              const icon = createBusMarkerDivIcon(vehicleID, state);
-              marker.setIcon(icon);
-              registerBusMarkerElements(vehicleID);
-              attachBusMarkerInteractions(vehicleID);
-              updateBusMarkerRootClasses(state);
-              updateBusMarkerZIndex(state);
-              applyBusMarkerOutlineWidth(state);
-          });
+              try {
+                  const icon = await createBusMarkerDivIcon(vehicleID, state);
+                  if (!icon) {
+                      continue;
+                  }
+                  marker.setIcon(icon);
+                  registerBusMarkerElements(vehicleID);
+                  attachBusMarkerInteractions(vehicleID);
+                  updateBusMarkerRootClasses(state);
+                  updateBusMarkerZIndex(state);
+                  applyBusMarkerOutlineWidth(state);
+              } catch (error) {
+                  console.error(`Failed to resize bus marker for vehicle ${vehicleID}:`, error);
+              }
+          }
           updateLabelIconsForMetrics(metrics);
       }
 
@@ -4947,14 +5173,18 @@
           if (markerScaleUpdateFrame !== null) {
               return;
           }
-          markerScaleUpdateFrame = requestAnimationFrame(() => {
+          markerScaleUpdateFrame = requestAnimationFrame(async () => {
               markerScaleUpdateFrame = null;
               const metricsToApply = pendingMarkerScaleMetrics;
               pendingMarkerScaleMetrics = null;
               if (!metricsToApply) {
                   return;
               }
-              updateBusMarkerSizes(metricsToApply);
+              try {
+                  await updateBusMarkerSizes(metricsToApply);
+              } catch (error) {
+                  console.error('Failed to update bus marker sizes:', error);
+              }
           });
       }
 


### PR DESCRIPTION
## Summary
- load and cache the external `busmarker.svg` so icons reuse a single template
- inline the SVG at runtime, recolor `.st1`/`.st0` elements, and rotate about the measured ring centre
- update vehicle marker creation, refresh, and resize flows to await the asynchronous SVG icon builder

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d061aedc348333887b7152b572d039