### PR TITLE
Serve bus marker asset via FastAPI

### DIFF
--- a/app.py
+++ b/app.py
@@ -1510,6 +1510,12 @@ async def stream_api_calls():
 async def fgdc_font():
     return FileResponse(BASE_DIR / "FGDC.ttf", media_type="font/ttf")
 
+
+@app.get("/busmarker.svg", include_in_schema=False)
+async def busmarker_svg():
+    return FileResponse(BASE_DIR / "busmarker.svg", media_type="image/svg+xml")
+
+
 @app.get("/vehicle_log/{log_name}", include_in_schema=False)
 async def vehicle_log_file(log_name: str):
     if not re.fullmatch(r"\d{8}_\d{2}\.jsonl", log_name):


### PR DESCRIPTION
## Summary
- add a FastAPI route to serve the bus marker SVG used by the test map

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68d06aae8b7c8333948bc047e470fb75