### PR TITLE
Adjust vehicle label spacing around markers

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -936,7 +936,7 @@
       const SPEED_BUBBLE_MIN_WIDTH = 60;
       const SPEED_BUBBLE_MIN_HEIGHT = 20;
       const SPEED_BUBBLE_CORNER_RADIUS = 10;
-      const LABEL_VERTICAL_CLEARANCE_PX = 4; // ensures labels clear the bus marker even when rotated
+      const LABEL_VERTICAL_CLEARANCE_PX = 0; // bring labels flush with the marker's bounding circle while rotation safety still comes from the half-diagonal
       const LABEL_TEXT_VERTICAL_ADJUSTMENT_RATIO = 0.06;
       const NAME_BUBBLE_BASE_FONT_PX = 14;
       const NAME_BUBBLE_HORIZONTAL_PADDING = 14;


### PR DESCRIPTION
## Summary
- remove the extra clearance so vehicle name, speed, and block bubbles sit tightly against the bus marker while still respecting its rotation-safe bounds

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d07d620618833383c87a8acc4c8abb