### PR TITLE
Adjust label clearance on test map

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -936,7 +936,7 @@
       const SPEED_BUBBLE_MIN_WIDTH = 60;
       const SPEED_BUBBLE_MIN_HEIGHT = 20;
       const SPEED_BUBBLE_CORNER_RADIUS = 10;
-      const LABEL_VERTICAL_CLEARANCE_PX = 0; // bring labels flush with the marker's bounding circle while rotation safety still comes from the half-diagonal
+      const LABEL_VERTICAL_CLEARANCE_PX = -7; // pull labels ~7px closer to the vehicle while relying on the half-diagonal for rotation safety
       const LABEL_TEXT_VERTICAL_ADJUSTMENT_RATIO = 0.06;
       const NAME_BUBBLE_BASE_FONT_PX = 14;
       const NAME_BUBBLE_HORIZONTAL_PADDING = 14;


### PR DESCRIPTION
## Summary
- reduce the label clearance offset so speed, name, and block bubbles render closer to each vehicle marker

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d07f754e5c8333bfeae69025412f75