### PR TITLE
Adjust map label spacing for east/west headings

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -940,6 +940,7 @@
       const LABEL_VERTICAL_CLEARANCE_PX = -7; // pull labels ~7px closer to the vehicle while relying on the half-diagonal for rotation safety
       const LABEL_VERTICAL_ALIGNMENT_BONUS_PX = 6; // push labels a little farther away when the vehicle is nearly north/south
       const LABEL_VERTICAL_ALIGNMENT_EXPONENT = 4; // emphasize the bonus for headings close to due north/south
+      const LABEL_HORIZONTAL_ALIGNMENT_BONUS_PX = 10; // give east/west headings extra breathing room
       const LABEL_TEXT_VERTICAL_ADJUSTMENT_RATIO = 0.06;
       const NAME_BUBBLE_BASE_FONT_PX = 14;
       const NAME_BUBBLE_HORIZONTAL_PADDING = 14;
@@ -4563,10 +4564,11 @@
               LABEL_VERTICAL_ALIGNMENT_EXPONENT
           );
           const verticalAlignmentBonus = LABEL_VERTICAL_ALIGNMENT_BONUS_PX * safeScale * verticality;
+          const horizontalAlignmentBonus = LABEL_HORIZONTAL_ALIGNMENT_BONUS_PX * safeScale * (1 - verticality);
 
           const verticalExtents = computeBusMarkerVerticalExtentsForHeading(normalizedHeading);
           if (!verticalExtents) {
-              return Math.max(0, fallbackHalfDiagonal + clearance + verticalAlignmentBonus);
+              return Math.max(0, fallbackHalfDiagonal + clearance + verticalAlignmentBonus + horizontalAlignmentBonus);
           }
 
           let extentSvgUnits;
@@ -4579,11 +4581,11 @@
           }
 
           if (!Number.isFinite(extentSvgUnits)) {
-              return Math.max(0, fallbackHalfDiagonal + clearance + verticalAlignmentBonus);
+              return Math.max(0, fallbackHalfDiagonal + clearance + verticalAlignmentBonus + horizontalAlignmentBonus);
           }
 
           const extentPx = extentSvgUnits * conversionFactor;
-          const totalOffset = extentPx + clearance + verticalAlignmentBonus;
+          const totalOffset = extentPx + clearance + verticalAlignmentBonus + horizontalAlignmentBonus;
           return totalOffset > 0 ? totalOffset : 0;
       }
 


### PR DESCRIPTION
## Summary
- add a horizontal alignment bonus so name/speed/block labels stay farther from buses when heading east or west
- apply the same horizontal bonus in the fallback label offset logic

## Testing
- echo "No automated tests were run (not requested)."

------
https://chatgpt.com/codex/tasks/task_e_68d0888d7c8883338039950309092b7b