### PR TITLE
Reduce stopped vehicle indicator size

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -923,7 +923,7 @@
       const BUS_MARKER_DEFAULT_CONTRAST_COLOR = '#FFFFFF';
       const BUS_MARKER_CENTER_RING_CENTER_X = 26.5;
       const BUS_MARKER_CENTER_RING_CENTER_Y = 43.49;
-      const BUS_MARKER_STOPPED_SQUARE_SIZE_PX = 26;
+      const BUS_MARKER_STOPPED_SQUARE_SIZE_PX = 20;
       const BUS_MARKER_STOPPED_SQUARE_ID = 'center_square';
       const BUS_MARKER_CENTER_RING_ID = 'center_ring';
       let BUS_MARKER_SVG_TEXT = null;


### PR DESCRIPTION
## Summary
- shrink the stopped vehicle indicator square to 20px for a more compact display

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d08e8c49e08333a80866b178f93b85