### PR TITLE
Align replay map visuals with live map

### DIFF
--- a/replay.html
+++ b/replay.html
@@ -2688,6 +2688,12 @@
         const endPos = hasArrayPosition ? L.latLng(newPosition) : L.latLng(newPosition?.lat, newPosition?.lng);
         if (!endPos || Number.isNaN(endPos.lat) || Number.isNaN(endPos.lng)) return;
 
+        const existingHandle = marker.__activeAnimationHandle;
+        if (typeof existingHandle === 'number') {
+          cancelAnimationFrame(existingHandle);
+        }
+        marker.__activeAnimationHandle = null;
+
         const startPos = marker.getLatLng();
         if (!startPos) {
           marker.setLatLng(endPos);
@@ -2713,9 +2719,14 @@
             startPos.lng + t * (endPos.lng - startPos.lng)
           );
           marker.setLatLng(currentPos);
-          if (t < 1) requestAnimationFrame(animate);
+          if (t < 1) {
+            marker.__activeAnimationHandle = requestAnimationFrame(animate);
+          } else {
+            marker.__activeAnimationHandle = null;
+            marker.setLatLng(endPos);
+          }
         }
-        requestAnimationFrame(animate);
+        marker.__activeAnimationHandle = requestAnimationFrame(animate);
       }
 
     function initializeMap() {


### PR DESCRIPTION
## Summary
- ported the testmap route-overlap renderer and bus marker styling/logic into replay.html, including the RBush dependency, SVG templating, and label bubble utilities
- updated route drawing, playback frame rendering, and selector handling so the replay view uses the same stacked vehicle markers, speed/name/block bubbles, and overlap striping as the live map
- refreshed initialization and range-loading flows to reset state, keep the playback controls responsive, and sync overlays with current selections
- cancel any in-flight requestAnimationFrame loops before animating a marker to a new position so only the latest target updates the marker

## Testing
- not run (HTML/JS change)


------
https://chatgpt.com/codex/tasks/task_e_68d0a2379b8c8333aa7d4849973b3d11