### PR TITLE
Fix incident decryption return to restore table data

### DIFF
--- a/incidents.html
+++ b/incidents.html
@@ -128,7 +128,7 @@ function decryptPayload(encryptedObj) {
   if (typeof parsed === "string")
     throw new Error("Decrypted payload is still a string after parsing attempts.");
 
-  return parsed; // e.g. { incidents: { active:[], recent:[...] } }
+  return { parsed, rawText }; // e.g. { incidents: { active:[], recent:[...] } }
 }
 
 


### PR DESCRIPTION
## Summary
- return both the parsed payload and raw text from `decryptPayload` so the loader receives incident data

## Testing
- not run (front-end only change)


------
https://chatgpt.com/codex/tasks/task_e_68d0b2f38f308333b624852e8139e5fe