### PR TITLE
Prevent incident display in kiosk admin mode

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -935,7 +935,7 @@
       let isFetchingIncidents = false;
 
       function incidentsAreAvailable() {
-        return adminMode || adminKioskMode;
+        return (adminMode && !kioskMode) || adminKioskMode;
       }
 
       if (!incidentsAreAvailable()) {


### PR DESCRIPTION
## Summary
- prevent PulsePoint incident overlays from appearing when kiosk mode is enabled even if admin mode is active

## Testing
- not run (HTML-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d0c2bdb4c48333b8290d295703a42b