### PR TITLE
Start incidents layer hidden by default

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -932,8 +932,8 @@
       let agencies = [];
       let baseURL = '';
 
-      let incidentsVisible = true;
-      let incidentsVisibilityPreference = true;
+      let incidentsVisible = false;
+      let incidentsVisibilityPreference = false;
       let incidentLayerGroup = null;
       const incidentMarkers = new Map();
       const incidentIconCache = new Map();


### PR DESCRIPTION
## Summary
- initialize `incidentsVisible` and `incidentsVisibilityPreference` to `false` so the incidents layer starts hidden

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0e37a92088333ad0466744b626b44