### PR TITLE
Remove background from vehicle label icons

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -138,6 +138,10 @@
       }
       .bus-label-icon {
         pointer-events: none !important;
+        background: transparent !important;
+        border: none !important;
+        box-shadow: none !important;
+        padding: 0 !important;
       }
       .bus-marker__svg {
         display: block;


### PR DESCRIPTION
## Summary
- ensure Leaflet vehicle label icons render with a transparent background by overriding the default div-icon styles

## Testing
- not run (html/css change)


------
https://chatgpt.com/codex/tasks/task_e_68d0f2ef61948333ac35cc305aca0b84