### PR TITLE
Hide incident icon image to remove translucent background

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -505,6 +505,12 @@
         pointer-events: none;
         contain: layout style paint;
       }
+      .incident-marker-icon {
+        opacity: 0;
+        background: transparent !important;
+        border: none !important;
+        box-shadow: none !important;
+      }
       .incident-marker-pulse-container .incident-marker-pulse {
         position: absolute;
         inset: 0;


### PR DESCRIPTION
## Summary
- hide the PulsePoint incident icon element so the semi-transparent rectangle no longer shows
- retain tooltip interaction while leaving only the animated pulse halo visible

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1103ea3a88333a5e3cba89b522b1d