### PR TITLE
Persist vehicle heading cache for test map

### DIFF
--- a/app.py
+++ b/app.py
@@ -704,7 +704,6 @@ def save_device_stops() -> None:
     propagate_file(DEVICE_STOP_NAME, payload)
 
 load_device_stops()
-load_vehicle_headings()
 
 API_CALL_LOG = deque(maxlen=100)
 API_CALL_SUBS: set[asyncio.Queue] = set()
@@ -892,6 +891,9 @@ def save_vehicle_headings() -> None:
         except Exception as e:
             print(f"[vehicle_headings] error writing {path}: {e}")
     propagate_file(VEHICLE_HEADINGS_NAME, payload_json)
+
+
+load_vehicle_headings()
 
 def load_bus_days() -> None:
     for base in DATA_DIRS:


### PR DESCRIPTION
## Summary
- persist the stabilised vehicle heading cache on disk and expose it through `/v1/vehicle_headings`
- reuse cached bearings during the updater cycle while clearing out stale vehicle entries
- preload headings in `testmap.html`, storing updates client-side with graceful fallback when the API is unavailable
- defer calling `load_vehicle_headings()` until after its definition so the module imports cleanly

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68d1a407eb1483338c3fc42434082024