### PR TITLE
Add incident detail popup for map markers

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -58,6 +58,126 @@
         transform: translateY(-1px);
         box-shadow: 0 12px 24px rgba(229, 114, 0, 0.4);
       }
+      .incident-popup {
+        min-width: 280px;
+        max-width: 340px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        color: #f8fafc;
+        text-transform: none;
+        font-family: 'FGDC', sans-serif;
+        letter-spacing: 0.3px;
+        white-space: normal;
+      }
+      .incident-popup__header {
+        display: flex;
+        align-items: flex-start;
+        gap: 14px;
+      }
+      .incident-popup__details {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+      .incident-popup__icon {
+        width: 60px;
+        height: 60px;
+        border-radius: 16px;
+        background: rgba(15, 23, 42, 0.45);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        overflow: hidden;
+        box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12), 0 12px 24px rgba(15, 23, 42, 0.45);
+        flex-shrink: 0;
+      }
+      .incident-popup__icon img {
+        width: 100%;
+        height: 100%;
+        object-fit: contain;
+        display: block;
+      }
+      .incident-popup__icon-fallback {
+        font-size: 24px;
+        font-weight: 800;
+        letter-spacing: 2px;
+        color: rgba(255, 255, 255, 0.85);
+      }
+      .incident-popup__title {
+        font-size: 18px;
+        font-weight: 800;
+        text-transform: uppercase;
+        letter-spacing: 1.4px;
+        margin-bottom: 4px;
+      }
+      .incident-popup__meta {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        font-size: 13px;
+        opacity: 0.92;
+      }
+      .incident-popup__meta-line {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        line-height: 1.3;
+      }
+      .incident-popup__section {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+      .incident-popup__section-title {
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 1.1px;
+        font-weight: 700;
+        color: rgba(255, 255, 255, 0.78);
+      }
+      .incident-popup__routes-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        font-size: 13px;
+        font-weight: 600;
+        color: rgba(255, 255, 255, 0.92);
+        overflow-wrap: anywhere;
+      }
+      .incident-popup__route {
+        display: inline-flex;
+        align-items: center;
+        padding: 2px 10px;
+        border-radius: 999px;
+        background: rgba(15, 23, 42, 0.55);
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        color: rgba(248, 250, 252, 0.92);
+        font-weight: 600;
+        letter-spacing: 0.4px;
+      }
+      .incident-popup__units {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+      .incident-popup__unit-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+      }
+      .incident-popup .incident-unit {
+        display: inline-flex;
+        align-items: center;
+        font-size: 12px;
+        font-weight: 700;
+        padding: 4px 10px;
+        border-radius: 999px;
+        border: 1px solid rgba(148, 163, 184, 0.4);
+        background: rgba(15, 23, 42, 0.55);
+        color: rgba(248, 250, 252, 0.92);
+        letter-spacing: 0.35px;
+      }
       .route-pill {
         display: inline-block;
         padding: 5px 12px;
@@ -2192,6 +2312,7 @@
         incidentsNearRoutesLookup = lookup;
         incidentRouteAlertSignature = typeof signature === 'string' ? signature : '';
         applyIncidentHaloStates();
+        refreshOpenIncidentPopups();
       }
 
       function applyIncidentMarkers(incidents) {
@@ -2229,6 +2350,7 @@
             }
             updateIncidentMarkerTooltip(existing.marker, incident);
             existing.data = incident;
+            refreshIncidentPopup(id);
           } else {
             const marker = L.marker([lat, lon], {
               pane: 'incidentsPane',
@@ -2245,6 +2367,13 @@
               haloMarker: null,
               haloAnimated: false
             });
+            marker.on('click', () => {
+              const config = buildIncidentPopupConfig(id);
+              if (config) {
+                createCustomPopup(config);
+              }
+            });
+            refreshIncidentPopup(id);
           }
         });
         const idsToRemove = [];
@@ -2263,6 +2392,7 @@
             map.removeLayer(entry.marker);
           }
           removeIncidentHalo(entry);
+          removeIncidentPopupById(id);
           incidentMarkers.delete(id);
         });
         applyIncidentHaloStates();
@@ -2501,6 +2631,7 @@
           } else {
             resetIncidentAlertState();
           }
+          removeAllIncidentPopups();
           updateIncidentToggleButton();
           return;
         }
@@ -2527,6 +2658,9 @@
         }
         updateIncidentToggleButton();
         applyIncidentHaloStates();
+        if (!incidentsVisible) {
+          removeAllIncidentPopups();
+        }
       }
 
       async function activateDemoIncidentPreview() {
@@ -4535,11 +4669,23 @@
           }).join('');
       }
 
-      function setPopupContent(popupElement, groupInfo) {
+      function attachPopupCloseHandler(popupElement) {
+          const closeButton = popupElement.querySelector('.custom-popup-close');
+          if (!closeButton) {
+              return;
+          }
+          closeButton.addEventListener('click', () => {
+              popupElement.remove();
+              customPopups = customPopups.filter(popup => popup !== popupElement);
+          });
+      }
+
+      function setStopPopupContent(popupElement, groupInfo) {
           if (!popupElement || !groupInfo) {
               return;
           }
 
+          popupElement.dataset.popupType = 'stop';
           const stopEntries = Array.isArray(groupInfo.stopEntries) ? groupInfo.stopEntries : [];
           const aggregatedRouteStopIds = Array.isArray(groupInfo.aggregatedRouteStopIds)
               ? groupInfo.aggregatedRouteStopIds
@@ -4581,9 +4727,227 @@
             <div class="custom-popup-arrow"></div>
           `;
 
-          popupElement.querySelector('.custom-popup-close').addEventListener('click', () => {
+          attachPopupCloseHandler(popupElement);
+      }
+
+      function getIncidentLocationText(incident) {
+          if (!incident) return '';
+          const candidates = [
+              incident.FullDisplayAddress,
+              incident.DisplayAddress,
+              incident.Address,
+              incident.AddressName,
+              incident.IncidentAddress,
+              incident.LocationDescription,
+              incident.Location,
+              incident.CrossStreet,
+              incident.Intersection,
+              incident.NearestIntersection,
+              incident.CommonName,
+              incident.CommonLocation
+          ];
+          for (const value of candidates) {
+              if (typeof value !== 'string') continue;
+              const trimmed = value.trim();
+              if (trimmed) {
+                  return trimmed;
+              }
+          }
+          return '';
+      }
+
+      function setIncidentPopupContent(popupElement, config) {
+          if (!popupElement) {
+              return;
+          }
+
+          popupElement.dataset.popupType = 'incident';
+          const incident = config && config.incident ? config.incident : null;
+          const idValue = typeof config?.id === 'string'
+              ? config.id
+              : (typeof config?.incidentId === 'string' ? config.incidentId : '');
+          if (idValue) {
+              popupElement.dataset.incidentId = idValue;
+          } else {
+              delete popupElement.dataset.incidentId;
+          }
+
+          if (!incident) {
+              popupElement.innerHTML = `
+                <button class="custom-popup-close">&times;</button>
+                <div class="incident-popup">
+                  <div>Incident information is unavailable.</div>
+                </div>
+                <div class="custom-popup-arrow"></div>
+              `;
+              attachPopupCloseHandler(popupElement);
+              return;
+          }
+
+          const typeLabel = getIncidentTypeLabel(incident) || 'Incident';
+          const safeTypeLabel = escapeHtml(typeLabel);
+          const iconUrl = buildPulsePointListIconUrl(getIncidentTypeCode(incident));
+          const iconAlt = typeLabel ? `${typeLabel} icon` : 'Incident icon';
+          const iconHtml = iconUrl
+              ? `<div class="incident-popup__icon"><img src="${escapeAttribute(iconUrl)}" alt="${escapeAttribute(iconAlt)}" onerror="this.style.display='none';"></div>`
+              : `<div class="incident-popup__icon"><span class="incident-popup__icon-fallback">${escapeHtml((typeLabel || 'I').charAt(0))}</span></div>`;
+
+          const timeInfo = getIncidentReceivedTimeInfo(incident);
+          const receivedLine = timeInfo
+              ? `<div class="incident-popup__meta-line" title="${escapeAttribute(timeInfo.full)}">Received ${escapeHtml(timeInfo.display)}</div>`
+              : '';
+          const statusCandidates = [incident.Status, incident.IncidentStatus, incident.Stage];
+          let statusText = '';
+          for (const value of statusCandidates) {
+              if (typeof value !== 'string') continue;
+              const trimmed = value.trim();
+              if (trimmed) {
+                  statusText = trimmed;
+                  break;
+              }
+          }
+          const statusLine = statusText
+              ? `<div class="incident-popup__meta-line">Status: ${escapeHtml(statusText)}</div>`
+              : '';
+          const locationText = getIncidentLocationText(incident);
+          const locationLine = locationText
+              ? `<div class="incident-popup__meta-line">Location: ${escapeHtml(locationText)}</div>`
+              : '';
+          const metaLines = [receivedLine, statusLine, locationLine].filter(Boolean).join('');
+          const metaHtml = metaLines ? `<div class="incident-popup__meta">${metaLines}</div>` : '';
+
+          const routes = Array.isArray(config?.routes) ? config.routes : [];
+          const routeNames = routes
+              .map(route => {
+                  if (!route) return '';
+                  if (typeof route === 'string') return route.trim();
+                  if (typeof route.name === 'string') return route.name.trim();
+                  if (typeof route.RouteName === 'string') return route.RouteName.trim();
+                  if (typeof route.Description === 'string') return route.Description.trim();
+                  return '';
+              })
+              .filter(Boolean);
+          const routesHtml = routeNames.length
+              ? `<div class="incident-popup__section"><div class="incident-popup__section-title">Routes Nearby</div><div class="incident-popup__routes-list">${routeNames.map(name => `<span class="incident-popup__route">${escapeHtml(name)}</span>`).join('')}</div></div>`
+              : '';
+
+          const units = extractIncidentUnits(incident);
+          const unitsContent = Array.isArray(units)
+              ? units.map(renderIncidentUnit).filter(Boolean).join('')
+              : '';
+          const unitsHtml = unitsContent
+              ? `<div class="incident-popup__section incident-popup__units"><div class="incident-popup__section-title">Units</div><div class="incident-popup__unit-list">${unitsContent}</div></div>`
+              : '';
+
+          popupElement.innerHTML = `
+            <button class="custom-popup-close">&times;</button>
+            <div class="incident-popup">
+              <div class="incident-popup__header">
+                ${iconHtml}
+                <div class="incident-popup__details">
+                  <div class="incident-popup__title">${safeTypeLabel}</div>
+                  ${metaHtml}
+                </div>
+              </div>
+              ${routesHtml}
+              ${unitsHtml}
+            </div>
+            <div class="custom-popup-arrow"></div>
+          `;
+
+          attachPopupCloseHandler(popupElement);
+      }
+
+      function getIncidentPopupElementById(id) {
+          const normalizedId = getNormalizedIncidentId(id);
+          if (!normalizedId) {
+              return null;
+          }
+          for (const popupElement of customPopups) {
+              if (!popupElement) continue;
+              if (popupElement.dataset.popupType !== 'incident') continue;
+              const popupId = popupElement.dataset.incidentId || '';
+              if (popupId && getNormalizedIncidentId(popupId) === normalizedId) {
+                  return popupElement;
+              }
+          }
+          return null;
+      }
+
+      function buildIncidentPopupConfig(id) {
+          const normalizedId = getNormalizedIncidentId(id);
+          if (!normalizedId) {
+              return null;
+          }
+          const entry = incidentMarkers.get(normalizedId);
+          if (!entry || !entry.marker || typeof entry.marker.getLatLng !== 'function') {
+              return null;
+          }
+          const latLng = entry.marker.getLatLng();
+          if (!latLng) {
+              return null;
+          }
+          const lat = Number(latLng.lat);
+          const lng = Number(latLng.lng);
+          if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+              return null;
+          }
+          const routesEntry = incidentsNearRoutesLookup.get(normalizedId);
+          const routes = routesEntry && Array.isArray(routesEntry.routes) ? routesEntry.routes : [];
+          return {
+              popupType: 'incident',
+              position: [lat, lng],
+              incident: entry.data || null,
+              id: normalizedId,
+              routes
+          };
+      }
+
+      function refreshIncidentPopup(id) {
+          const popupElement = getIncidentPopupElementById(id);
+          if (!popupElement) {
+              return;
+          }
+          const config = buildIncidentPopupConfig(id);
+          if (!config) {
               popupElement.remove();
               customPopups = customPopups.filter(popup => popup !== popupElement);
+              return;
+          }
+          popupElement.dataset.position = `${config.position[0]},${config.position[1]}`;
+          setIncidentPopupContent(popupElement, config);
+          updatePopupPosition(popupElement, config.position);
+      }
+
+      function refreshOpenIncidentPopups() {
+          const ids = customPopups
+              .filter(popupElement => popupElement && popupElement.dataset.popupType === 'incident')
+              .map(popupElement => popupElement.dataset.incidentId || '')
+              .filter(Boolean);
+          ids.forEach(id => {
+              refreshIncidentPopup(id);
+          });
+      }
+
+      function removeIncidentPopupById(id) {
+          const popupElement = getIncidentPopupElementById(id);
+          if (!popupElement) {
+              return;
+          }
+          popupElement.remove();
+          customPopups = customPopups.filter(popup => popup !== popupElement);
+      }
+
+      function removeAllIncidentPopups() {
+          customPopups = customPopups.filter(popupElement => {
+              if (!popupElement) {
+                  return false;
+              }
+              if (popupElement.dataset.popupType === 'incident') {
+                  popupElement.remove();
+                  return false;
+              }
+              return true;
           });
       }
 
@@ -4689,7 +5053,7 @@
               }).addTo(map);
 
               stopMarker.on('click', () => {
-                  createCustomPopup(groupInfo);
+                  createCustomPopup(Object.assign({ popupType: 'stop' }, groupInfo));
               });
 
               stopMarkers.push(stopMarker);
@@ -4714,6 +5078,12 @@
               });
 
               customPopups = customPopups.filter(popupElement => {
+                  if (!popupElement) {
+                      return false;
+                  }
+                  if (popupElement.dataset.popupType === 'incident') {
+                      return true;
+                  }
                   let parsedRouteStopIds = [];
                   try {
                       parsedRouteStopIds = JSON.parse(popupElement.dataset.routeStopIds || '[]');
@@ -4725,7 +5095,7 @@
                   const matchingGroup = groupByKey.get(key);
                   if (matchingGroup) {
                       popupElement.dataset.position = `${matchingGroup.position[0]},${matchingGroup.position[1]}`;
-                      setPopupContent(popupElement, matchingGroup);
+                      setStopPopupContent(popupElement, matchingGroup);
                       updatePopupPosition(popupElement, matchingGroup.position);
                       return true;
                   }
@@ -4735,18 +5105,24 @@
           }
       }
 
-      function createCustomPopup(groupInfo) {
-          if (!groupInfo || !Array.isArray(groupInfo.position) || groupInfo.position.length !== 2) {
+      function createCustomPopup(config) {
+          if (!config || !Array.isArray(config.position) || config.position.length !== 2) {
               return;
           }
-          const position = groupInfo.position;
+          const popupType = typeof config.popupType === 'string' ? config.popupType : 'stop';
+          const position = config.position;
           customPopups.forEach(popup => popup.remove());
           customPopups = [];
           const popupElement = document.createElement('div');
           popupElement.className = 'custom-popup';
           document.body.appendChild(popupElement);
           popupElement.dataset.position = `${position[0]},${position[1]}`;
-          setPopupContent(popupElement, groupInfo);
+          popupElement.dataset.popupType = popupType;
+          if (popupType === 'incident') {
+              setIncidentPopupContent(popupElement, config);
+          } else {
+              setStopPopupContent(popupElement, config);
+          }
           updatePopupPosition(popupElement, position);
           customPopups.push(popupElement);
           if (typeof requestAnimationFrame === 'function') {
@@ -4809,6 +5185,16 @@
 
       function updateCustomPopups() {
           customPopups.forEach(popupElement => {
+              if (!popupElement) {
+                  return;
+              }
+              if (popupElement.dataset.popupType === 'incident') {
+                  const popupId = popupElement.dataset.incidentId || '';
+                  if (popupId) {
+                      refreshIncidentPopup(popupId);
+                  }
+                  return;
+              }
               const position = popupElement.dataset.position;
               if (position) {
                   let routeStopIds = [];
@@ -4834,7 +5220,7 @@
                       aggregatedRouteStopIds: routeStopIds,
                       groupKey
                   };
-                  setPopupContent(popupElement, groupInfo);
+                  setStopPopupContent(popupElement, groupInfo);
               }
           });
       }


### PR DESCRIPTION
## Summary
- add reusable custom popup logic so incident markers open rich detail panels similar to stop ETAs
- include incident icon, type, received time, location, nearby routes, and units in the popup and keep it updated with live data

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d1a611dc8883339da0c9e470dc48bd