### PR TITLE
Make incident popup icon background white

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -84,12 +84,12 @@
         width: 60px;
         height: 60px;
         border-radius: 16px;
-        background: rgba(15, 23, 42, 0.45);
+        background: #ffffff;
         display: flex;
         align-items: center;
         justify-content: center;
         overflow: hidden;
-        box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12), 0 12px 24px rgba(15, 23, 42, 0.45);
+        box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.08), 0 12px 24px rgba(15, 23, 42, 0.35);
         flex-shrink: 0;
       }
       .incident-popup__icon img {
@@ -102,7 +102,7 @@
         font-size: 24px;
         font-weight: 800;
         letter-spacing: 2px;
-        color: rgba(255, 255, 255, 0.85);
+        color: rgba(15, 23, 42, 0.75);
       }
       .incident-popup__title {
         font-size: 18px;


### PR DESCRIPTION
## Summary
- update the incident popup icon styling to use a solid white background for better contrast
- adjust the fallback text color so it remains legible on the lighter background

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1b6ce9cc083338647fb416c34a6b8