### PR TITLE
Increase incident incident route proximity threshold to 90m

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -1344,7 +1344,7 @@
         : null;
       let isFetchingIncidents = false;
 
-      const INCIDENT_ROUTE_PROXIMITY_THRESHOLD_METERS = 75;
+      const INCIDENT_ROUTE_PROXIMITY_THRESHOLD_METERS = 90;
       const INCIDENT_TIME_ZONE = 'America/New_York';
       const INCIDENT_LIST_ICON_BASE_URL = 'https://web.pulsepoint.org/images/respond_icons/';
       const INCIDENT_TYPE_LABELS = Object.freeze({


### PR DESCRIPTION
## Summary
- increase the incident-to-route proximity threshold to 90 meters so more nearby incidents are flagged

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1c218e6fc8333b318aa3afa08eb74