### PR TITLE
Increase incident route proximity threshold to 100 meters

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -1360,7 +1360,7 @@
         : null;
       let isFetchingIncidents = false;
 
-      const INCIDENT_ROUTE_PROXIMITY_THRESHOLD_METERS = 90;
+      const INCIDENT_ROUTE_PROXIMITY_THRESHOLD_METERS = 100;
       const INCIDENT_TIME_ZONE = 'America/New_York';
       const INCIDENT_LIST_ICON_BASE_URL = 'https://web.pulsepoint.org/images/respond_icons/';
       const INCIDENT_TYPE_LABELS = Object.freeze({


### PR DESCRIPTION
## Summary
- increase the incident route proximity threshold to 100 meters so nearby alerts cover a wider radius

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1c8dd2c8083338494be5258c38817