### PR TITLE
Increase incident incident proximity threshold

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -1360,7 +1360,7 @@
         : null;
       let isFetchingIncidents = false;
 
-      const INCIDENT_ROUTE_PROXIMITY_THRESHOLD_METERS = 100;
+      const INCIDENT_ROUTE_PROXIMITY_THRESHOLD_METERS = 150;
       const INCIDENT_TIME_ZONE = 'America/New_York';
       const INCIDENT_LIST_ICON_BASE_URL = 'https://web.pulsepoint.org/images/respond_icons/';
       const INCIDENT_TYPE_LABELS = Object.freeze({


### PR DESCRIPTION
## Summary
- raise the incident route proximity threshold constant to 150 meters so incidents remain visible at greater distances

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1cf6ab5388333b95d2db0ea40759e