### PR TITLE
Add service alerts panel to control panel

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -533,6 +533,193 @@
         flex-direction: column;
         gap: 18px;
       }
+      .selector-panel .service-alerts {
+        border-radius: 16px;
+        border: 1px solid rgba(35, 45, 75, 0.14);
+        background: rgba(248, 250, 252, 0.92);
+        box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+        transition: box-shadow 0.2s ease, border-color 0.2s ease;
+      }
+      .service-alerts.is-collapsed.has-active-alerts {
+        border-color: rgba(220, 38, 38, 0.45);
+        box-shadow: 0 16px 32px rgba(220, 38, 38, 0.18);
+      }
+      .service-alerts__header {
+        appearance: none;
+        border: none;
+        border-bottom: 1px solid rgba(35, 45, 75, 0.12);
+        background: rgba(35, 45, 75, 0.05);
+        padding: 16px 18px;
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        width: 100%;
+        text-align: left;
+        cursor: pointer;
+        font: inherit;
+        color: inherit;
+        transition: background 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+      }
+      .service-alerts__header:hover,
+      .service-alerts__header:focus-visible {
+        background: rgba(35, 45, 75, 0.12);
+        outline: none;
+        box-shadow: 0 8px 18px rgba(35, 45, 75, 0.18);
+      }
+      .service-alerts.is-collapsed.has-active-alerts .service-alerts__header {
+        background: linear-gradient(135deg, rgba(220, 38, 38, 0.16), rgba(248, 113, 113, 0.28));
+        border-color: rgba(220, 38, 38, 0.45);
+        color: rgba(127, 29, 29, 0.95);
+        box-shadow: 0 16px 32px rgba(220, 38, 38, 0.22);
+      }
+      .service-alerts__header-main {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        flex: 1;
+        min-width: 0;
+      }
+      .service-alerts__title {
+        font-size: 16px;
+        font-weight: 700;
+        letter-spacing: 0.4px;
+      }
+      .service-alerts__status {
+        font-size: 13px;
+        letter-spacing: 0.3px;
+        color: rgba(35, 45, 75, 0.65);
+        text-transform: uppercase;
+      }
+      .service-alerts.is-collapsed.has-active-alerts .service-alerts__status {
+        color: rgba(127, 29, 29, 0.78);
+      }
+      .service-alerts__badge,
+      .panel-toggle__badge {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 26px;
+        height: 26px;
+        padding: 0 6px;
+        border-radius: 999px;
+        background: linear-gradient(135deg, #dc2626, #ef4444);
+        color: #fef2f2;
+        font-weight: 700;
+        font-size: 13px;
+        letter-spacing: 0.4px;
+        box-shadow: 0 8px 18px rgba(220, 38, 38, 0.25);
+      }
+      .service-alerts__badge[hidden],
+      .panel-toggle__badge[hidden] {
+        display: none !important;
+      }
+      .service-alerts__chevron {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 24px;
+        height: 24px;
+        border-radius: 50%;
+        background: rgba(35, 45, 75, 0.12);
+        color: rgba(35, 45, 75, 0.72);
+        font-size: 16px;
+        transition: transform 0.2s ease, background 0.2s ease;
+      }
+      .service-alerts__header:hover .service-alerts__chevron,
+      .service-alerts__header:focus-visible .service-alerts__chevron {
+        background: rgba(35, 45, 75, 0.18);
+      }
+      .service-alerts.is-expanded .service-alerts__chevron {
+        transform: rotate(90deg);
+      }
+      .service-alerts__content {
+        padding: 18px 18px 20px;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        background: rgba(248, 250, 252, 0.88);
+      }
+      .service-alerts.is-collapsed .service-alerts__content {
+        display: none;
+      }
+      .service-alerts__list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+      .service-alerts__item {
+        background: rgba(255, 255, 255, 0.92);
+        border: 1px solid rgba(148, 163, 184, 0.32);
+        border-radius: 14px;
+        padding: 14px 16px;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+        box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+      }
+      .service-alerts__item-title {
+        font-size: 15px;
+        font-weight: 700;
+        letter-spacing: 0.3px;
+        color: rgba(35, 45, 75, 0.92);
+      }
+      .service-alerts__item-message {
+        font-size: 14px;
+        line-height: 1.45;
+        color: rgba(15, 23, 42, 0.85);
+        white-space: pre-wrap;
+      }
+      .service-alerts__meta {
+        display: grid;
+        gap: 6px;
+        font-size: 13px;
+        color: rgba(55, 65, 81, 0.88);
+      }
+      .service-alerts__meta-row {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 8px;
+        align-items: baseline;
+      }
+      .service-alerts__meta-row dt {
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.6px;
+        color: rgba(30, 41, 59, 0.72);
+      }
+      .service-alerts__meta-row dd {
+        margin: 0;
+        overflow-wrap: anywhere;
+      }
+      .service-alerts__state {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        font-size: 14px;
+        color: rgba(30, 41, 59, 0.75);
+      }
+      .service-alerts__spinner {
+        width: 18px;
+        height: 18px;
+        border-radius: 50%;
+        border: 2px solid rgba(30, 64, 175, 0.2);
+        border-top-color: rgba(30, 64, 175, 0.7);
+        animation: loading-overlay-spin 1s linear infinite;
+      }
+      .service-alerts__state--error {
+        color: rgba(153, 27, 27, 0.9);
+        font-weight: 600;
+      }
+      .service-alerts__state--empty {
+        color: rgba(30, 41, 59, 0.6);
+        font-style: italic;
+      }
       .selector-panel .incident-alert-block {
         background: linear-gradient(135deg, rgba(254, 226, 226, 0.92), rgba(254, 202, 202, 0.78));
         border: 1px solid rgba(220, 38, 38, 0.35);
@@ -1025,6 +1212,7 @@
         box-shadow: 0 12px 28px rgba(15, 23, 42, 0.25);
         border: 1px solid rgba(255, 255, 255, 0.1);
         backdrop-filter: blur(10px);
+        padding: 0 4px;
       }
       .panel-toggle.is-hidden-mobile {
         display: none;
@@ -1046,6 +1234,22 @@
       .panel-toggle:focus-visible {
         outline: none;
         box-shadow: 0 0 0 3px var(--accent-soft), 0 16px 32px rgba(15, 23, 42, 0.3);
+      }
+      .panel-toggle__arrow {
+        pointer-events: none;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+      }
+      .panel-toggle__badge {
+        position: absolute;
+        top: 8px;
+        right: 6px;
+      }
+      .panel-toggle--right .panel-toggle__badge {
+        left: 6px;
+        right: auto;
       }
       #routeLegend {
         position: fixed;
@@ -1410,6 +1614,65 @@
 
       let agencies = [];
       let baseURL = '';
+
+      const SERVICE_ALERT_REFRESH_INTERVAL_MS = 60000;
+      const SERVICE_ALERT_START_FIELDS = Object.freeze([
+        'StartDateText',
+        'StartDateDisplay',
+        'StartDateLocalText',
+        'StartDateLocal',
+        'StartDate',
+        'StartDateUtc',
+        'StartDateTime',
+        'StartDateISO',
+        'StartTimestamp',
+        'StartTime',
+        'Start',
+        'BeginDateText',
+        'BeginDate',
+        'BeginDateUtc',
+        'BeginTime',
+        'EffectiveStart',
+        'EffectiveStartDate',
+        'EffectiveStartUtc'
+      ]);
+      const SERVICE_ALERT_END_FIELDS = Object.freeze([
+        'EndDateText',
+        'EndDateDisplay',
+        'EndDateLocalText',
+        'EndDateLocal',
+        'EndDate',
+        'EndDateUtc',
+        'EndDateTime',
+        'EndDateISO',
+        'EndTimestamp',
+        'EndTime',
+        'End',
+        'StopDateText',
+        'StopDate',
+        'StopDateUtc',
+        'StopTime',
+        'ExpirationDate',
+        'ExpirationDateUtc',
+        'ExpireDate',
+        'ExpireDateUtc',
+        'EffectiveEnd',
+        'EffectiveEndDate',
+        'EffectiveEndUtc'
+      ]);
+      const SERVICE_ALERT_EMPTY_MESSAGE = 'No active service alerts.';
+      const SERVICE_ALERT_UNAVAILABLE_MESSAGE = 'Service alerts unavailable.';
+      const SERVICE_ALERT_STATUS_NO_ALERTS = 'No active alerts';
+      const SERVICE_ALERT_STATUS_LOADING = 'Loading…';
+      const SERVICE_ALERT_STATUS_ERROR = 'Unavailable';
+      const SERVICE_ALERT_BADGE_MAX = 99;
+      const SERVICE_ALERT_DATE_FORMATTER = (typeof Intl !== 'undefined' && typeof Intl.DateTimeFormat === 'function')
+        ? new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short', timeZoneName: 'short' })
+        : null;
+      let serviceAlerts = [];
+      let serviceAlertsLoading = false;
+      let serviceAlertsError = null;
+      let serviceAlertsExpanded = false;
 
       let incidentsVisible = false;
       let incidentsVisibilityPreference = false;
@@ -3229,9 +3492,11 @@
           } else {
             baseURL = agencies[0]?.url || '';
           }
+          resetServiceAlertsState();
           updateControlPanel();
           enforceIncidentVisibilityForCurrentAgency();
           updateRouteSelector(activeRoutes, true);
+          fetchServiceAlerts();
         } catch (e) {
           console.error('Failed to load agencies', e);
         }
@@ -3348,6 +3613,7 @@
         positionPanelTab('routeSelector', 'routeSelectorTab', 'right');
         positionPanelTab('controlPanel', 'controlPanelTab', 'left');
         updatePanelTabVisibility();
+        syncServiceAlertsBadge();
       }
 
       window.addEventListener("load", positionAllPanelTabs);
@@ -3777,12 +4043,478 @@
           .replace(/>/g, '&gt;');
       }
 
+
+      function sanitizeBaseUrl(url) {
+        if (typeof url !== 'string') return '';
+        return url.trim().replace(/\/+$/, '');
+      }
+
+      function formatServiceAlertsBadgeText(count) {
+        const numeric = Number(count);
+        if (!Number.isFinite(numeric) || numeric <= 0) {
+          return '';
+        }
+        if (numeric > SERVICE_ALERT_BADGE_MAX) {
+          return `${SERVICE_ALERT_BADGE_MAX}+`;
+        }
+        return `${Math.round(numeric)}`;
+      }
+
+      function getActiveServiceAlertCount() {
+        if (!Array.isArray(serviceAlerts) || serviceAlerts.length === 0) {
+          return 0;
+        }
+        return serviceAlerts.reduce((total, alert) => {
+          if (!alert) return total;
+          return total + (alert.isActive === false ? 0 : 1);
+        }, 0);
+      }
+
+      function resetServiceAlertsState() {
+        serviceAlerts = [];
+        serviceAlertsLoading = false;
+        serviceAlertsError = null;
+        serviceAlertsExpanded = false;
+        updateServiceAlertsUI();
+      }
+
+      function formatServiceAlertDate(date) {
+        if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+          return '';
+        }
+        if (SERVICE_ALERT_DATE_FORMATTER) {
+          try {
+            return SERVICE_ALERT_DATE_FORMATTER.format(date);
+          } catch (error) {
+            // ignore formatting errors and fall back
+          }
+        }
+        try {
+          return date.toLocaleString();
+        } catch (error) {
+          return date.toString();
+        }
+      }
+
+      function formatServiceAlertTimeValue(value) {
+        if (value === null || value === undefined) {
+          return { display: '', raw: '' };
+        }
+        if (value instanceof Date && !Number.isNaN(value.getTime())) {
+          return {
+            display: formatServiceAlertDate(value),
+            raw: value.toISOString()
+          };
+        }
+        if (typeof value === 'number' && Number.isFinite(value)) {
+          const date = new Date(value);
+          if (!Number.isNaN(date.getTime())) {
+            return {
+              display: formatServiceAlertDate(date),
+              raw: String(value)
+            };
+          }
+          return { display: String(value), raw: String(value) };
+        }
+        if (typeof value === 'string') {
+          const trimmed = value.trim();
+          if (!trimmed) {
+            return { display: '', raw: '' };
+          }
+          const unixMatch = trimmed.match(/\/Date\((\d+)\)\/?/i);
+          if (unixMatch && unixMatch[1]) {
+            const millis = Number(unixMatch[1]);
+            if (Number.isFinite(millis)) {
+              const date = new Date(millis);
+              if (!Number.isNaN(date.getTime())) {
+                return {
+                  display: formatServiceAlertDate(date),
+                  raw: trimmed
+                };
+              }
+            }
+          }
+          const parsed = new Date(trimmed);
+          if (!Number.isNaN(parsed.getTime())) {
+            return {
+              display: formatServiceAlertDate(parsed),
+              raw: trimmed
+            };
+          }
+          return { display: trimmed, raw: trimmed };
+        }
+        if (typeof value === 'object') {
+          const stringValue = String(value);
+          if (stringValue && stringValue !== '[object Object]') {
+            return formatServiceAlertTimeValue(stringValue);
+          }
+        }
+        return { display: '', raw: '' };
+      }
+
+      function extractServiceAlertTime(record, type) {
+        if (!record || typeof record !== 'object') {
+          return { display: '', raw: '' };
+        }
+        const fields = type === 'end' ? SERVICE_ALERT_END_FIELDS : SERVICE_ALERT_START_FIELDS;
+        for (const field of fields) {
+          if (Object.prototype.hasOwnProperty.call(record, field)) {
+            const info = formatServiceAlertTimeValue(record[field]);
+            if (info.display) {
+              return info;
+            }
+          }
+        }
+        const lowerKeyMap = Object.keys(record).reduce((acc, key) => {
+          acc[key.toLowerCase()] = key;
+          return acc;
+        }, {});
+        for (const field of fields) {
+          const originalKey = lowerKeyMap[field.toLowerCase()];
+          if (originalKey && Object.prototype.hasOwnProperty.call(record, originalKey)) {
+            const info = formatServiceAlertTimeValue(record[originalKey]);
+            if (info.display) {
+              return info;
+            }
+          }
+        }
+        return { display: '', raw: '' };
+      }
+
+      function normalizeServiceAlertRoutes(record) {
+        const collected = [];
+        const candidateKeys = ['Routes', 'routes', 'RoutesAffected', 'routesAffected', 'AffectedRoutes', 'affectedRoutes', 'RouteNames', 'routeNames'];
+        for (const key of candidateKeys) {
+          if (!Object.prototype.hasOwnProperty.call(record, key)) continue;
+          const value = record[key];
+          if (Array.isArray(value)) {
+            value.forEach(entry => {
+              if (!entry) return;
+              if (typeof entry === 'string') {
+                const trimmed = entry.trim();
+                if (trimmed) collected.push(trimmed);
+                return;
+              }
+              if (typeof entry === 'object') {
+                const nameCandidates = [
+                  typeof entry.Name === 'string' ? entry.Name.trim() : '',
+                  typeof entry.RouteName === 'string' ? entry.RouteName.trim() : '',
+                  typeof entry.Description === 'string' ? entry.Description.trim() : '',
+                  typeof entry.Title === 'string' ? entry.Title.trim() : '',
+                  typeof entry.label === 'string' ? entry.label.trim() : ''
+                ];
+                const label = nameCandidates.find(candidate => candidate);
+                if (label) collected.push(label);
+              }
+            });
+          } else if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (trimmed) {
+              trimmed.split(/[,;]+/).map(part => part.trim()).filter(Boolean).forEach(part => collected.push(part));
+            }
+          }
+          if (collected.length) break;
+        }
+        if (!collected.length) {
+          return [];
+        }
+        const seen = new Set();
+        return collected.filter(route => {
+          const key = route.toLowerCase();
+          if (seen.has(key)) return false;
+          seen.add(key);
+          return true;
+        });
+      }
+
+      function normalizeServiceAlertRow(row) {
+        if (!row || typeof row !== 'object') return null;
+        const titleCandidates = [
+          typeof row.MessageTitle === 'string' ? row.MessageTitle.trim() : '',
+          typeof row.Title === 'string' ? row.Title.trim() : '',
+          typeof row.Subject === 'string' ? row.Subject.trim() : ''
+        ];
+        const messageCandidates = [
+          typeof row.MessageText === 'string' ? row.MessageText.trim() : '',
+          typeof row.MessageBody === 'string' ? row.MessageBody.trim() : '',
+          typeof row.Text === 'string' ? row.Text.trim() : '',
+          typeof row.Description === 'string' ? row.Description.trim() : '',
+          typeof row.Details === 'string' ? row.Details.trim() : '',
+          typeof row.Body === 'string' ? row.Body.trim() : ''
+        ];
+        const title = titleCandidates.find(candidate => candidate) || '';
+        const message = messageCandidates.find(candidate => candidate) || '';
+        const startInfo = extractServiceAlertTime(row, 'start');
+        const endInfo = extractServiceAlertTime(row, 'end');
+        const idCandidates = [
+          row.MessageID,
+          row.MessageId,
+          row.MessageGuid,
+          row.Guid,
+          row.ID,
+          row.Id,
+          row.AlertId,
+          row.AlertID,
+          row.RecordId,
+          row.RecordID
+        ];
+        const rawId = idCandidates.find(value => value !== null && value !== undefined);
+        const statusValue = typeof row.Status === 'string' ? row.Status.trim().toLowerCase() : '';
+        let isActive = true;
+        if (Object.prototype.hasOwnProperty.call(row, 'IsActive')) {
+          isActive = !!row.IsActive;
+        } else if (Object.prototype.hasOwnProperty.call(row, 'Active')) {
+          isActive = !!row.Active;
+        } else if (Object.prototype.hasOwnProperty.call(row, 'Visible')) {
+          isActive = !!row.Visible;
+        } else if (statusValue) {
+          isActive = !(statusValue === 'inactive' || statusValue === 'expired' || statusValue === 'inactive alert');
+        }
+        const routes = normalizeServiceAlertRoutes(row);
+        return {
+          id: rawId !== undefined && rawId !== null ? String(rawId) : (title || message || null),
+          title,
+          message,
+          startDisplay: startInfo.display,
+          startRaw: startInfo.raw,
+          endDisplay: endInfo.display,
+          endRaw: endInfo.raw,
+          isActive,
+          routes
+        };
+      }
+
+      function extractServiceAlertRows(data) {
+        if (!data) return [];
+        if (Array.isArray(data)) return data;
+        if (Array.isArray(data.Rows)) return data.Rows;
+        if (Array.isArray(data.rows)) return data.rows;
+        if (Array.isArray(data.Result?.Rows)) return data.Result.Rows;
+        if (Array.isArray(data.Result)) return data.Result;
+        if (Array.isArray(data.Data)) return data.Data;
+        if (Array.isArray(data.data)) return data.data;
+        if (Array.isArray(data.Messages)) return data.Messages;
+        if (Array.isArray(data.messages)) return data.messages;
+        if (data.d) return extractServiceAlertRows(data.d);
+        return [];
+      }
+
+      function buildServiceAlertsStatusText() {
+        if (serviceAlertsLoading) {
+          return SERVICE_ALERT_STATUS_LOADING;
+        }
+        if (serviceAlertsError) {
+          return SERVICE_ALERT_STATUS_ERROR;
+        }
+        const count = getActiveServiceAlertCount();
+        if (count > 0) {
+          const badgeText = formatServiceAlertsBadgeText(count);
+          const labelCount = badgeText || `${count}`;
+          return count === 1 ? '1 active alert' : `${labelCount} active alerts`;
+        }
+        return SERVICE_ALERT_STATUS_NO_ALERTS;
+      }
+
+      function renderServiceAlertItem(alert) {
+        if (!alert) return '';
+        const idAttr = alert.id ? ` data-alert-id="${escapeAttribute(alert.id)}"` : '';
+        const title = typeof alert.title === 'string' ? alert.title : '';
+        const message = typeof alert.message === 'string' ? alert.message : '';
+        const titleHtml = title ? `<div class="service-alerts__item-title">${escapeHtml(title)}</div>` : '';
+        const messageHtml = message ? `<div class="service-alerts__item-message">${escapeHtml(message)}</div>` : '';
+        const metaRows = [];
+        if (alert.startDisplay) {
+          const titleAttr = alert.startRaw ? ` title="${escapeAttribute(alert.startRaw)}"` : '';
+          metaRows.push(`<div class="service-alerts__meta-row"><dt>Start</dt><dd${titleAttr}>${escapeHtml(alert.startDisplay)}</dd></div>`);
+        }
+        if (alert.endDisplay) {
+          const titleAttr = alert.endRaw ? ` title="${escapeAttribute(alert.endRaw)}"` : '';
+          metaRows.push(`<div class="service-alerts__meta-row"><dt>End</dt><dd${titleAttr}>${escapeHtml(alert.endDisplay)}</dd></div>`);
+        }
+        if (Array.isArray(alert.routes) && alert.routes.length > 0) {
+          const routesHtml = alert.routes.map(route => escapeHtml(route)).join(', ');
+          metaRows.push(`<div class="service-alerts__meta-row"><dt>Routes</dt><dd>${routesHtml}</dd></div>`);
+        }
+        const metaHtml = metaRows.length ? `<dl class="service-alerts__meta">${metaRows.join('')}</dl>` : '';
+        if (!titleHtml && !messageHtml && !metaHtml) {
+          return '';
+        }
+        return `<li class="service-alerts__item"${idAttr}>${titleHtml}${messageHtml}${metaHtml}</li>`;
+      }
+
+      function renderServiceAlertsContent() {
+        const container = document.getElementById('serviceAlertsContent');
+        const statusEl = document.getElementById('serviceAlertsStatus');
+        if (statusEl) {
+          statusEl.textContent = buildServiceAlertsStatusText();
+        }
+        if (!container) {
+          return;
+        }
+        if (serviceAlertsLoading) {
+          container.innerHTML = `<div class="service-alerts__state service-alerts__state--loading"><span class="service-alerts__spinner" aria-hidden="true"></span><span>Loading service alerts…</span></div>`;
+          return;
+        }
+        if (serviceAlertsError) {
+          container.innerHTML = `<div class="service-alerts__state service-alerts__state--error">${escapeHtml(serviceAlertsError)}</div>`;
+          return;
+        }
+        if (!Array.isArray(serviceAlerts) || serviceAlerts.length === 0) {
+          container.innerHTML = `<div class="service-alerts__state service-alerts__state--empty">${escapeHtml(SERVICE_ALERT_EMPTY_MESSAGE)}</div>`;
+          return;
+        }
+        const itemsHtml = serviceAlerts.map(renderServiceAlertItem).filter(Boolean).join('');
+        if (!itemsHtml) {
+          container.innerHTML = `<div class="service-alerts__state service-alerts__state--empty">${escapeHtml(SERVICE_ALERT_EMPTY_MESSAGE)}</div>`;
+          return;
+        }
+        container.innerHTML = `<ul class="service-alerts__list">${itemsHtml}</ul>`;
+      }
+
+      function updateServiceAlertsSectionState() {
+        const section = document.getElementById('serviceAlertsSection');
+        if (!section) return;
+        section.classList.toggle('is-expanded', serviceAlertsExpanded);
+        section.classList.toggle('is-collapsed', !serviceAlertsExpanded);
+        section.classList.toggle('is-loading', !!serviceAlertsLoading);
+        section.classList.toggle('has-error', !!serviceAlertsError);
+        const hasAlerts = getActiveServiceAlertCount() > 0;
+        section.classList.toggle('has-alerts', hasAlerts);
+        section.classList.toggle('has-active-alerts', hasAlerts && !serviceAlertsExpanded);
+      }
+
+      function syncServiceAlertsBadge() {
+        const headerBadge = document.getElementById('serviceAlertsBadge');
+        const toggleBadge = document.getElementById('controlPanelAlertBadge');
+        const controlPanelElement = document.getElementById('controlPanel');
+        const controlPanelTab = document.getElementById('controlPanelTab');
+        const badgeText = formatServiceAlertsBadgeText(getActiveServiceAlertCount());
+        const panelHidden = controlPanelElement ? controlPanelElement.classList.contains('hidden') : false;
+        const panelDisplayNone = controlPanelElement ? controlPanelElement.style.display === 'none' : false;
+        const toggleHidden = controlPanelTab
+          ? (controlPanelTab.style.display === 'none' || controlPanelTab.classList.contains('is-hidden-mobile'))
+          : false;
+        if (headerBadge) {
+          const shouldShowHeader = !!badgeText && !panelHidden && !panelDisplayNone;
+          headerBadge.hidden = !shouldShowHeader;
+          headerBadge.textContent = shouldShowHeader ? badgeText : '';
+        }
+        if (toggleBadge) {
+          const shouldShowToggle = !!badgeText && panelHidden && !panelDisplayNone && !toggleHidden;
+          toggleBadge.hidden = !shouldShowToggle;
+          toggleBadge.textContent = shouldShowToggle ? badgeText : '';
+        }
+      }
+
+      function applyServiceAlertsExpandedState() {
+        const toggle = document.getElementById('serviceAlertsToggle');
+        const content = document.getElementById('serviceAlertsContent');
+        if (toggle) {
+          toggle.setAttribute('aria-expanded', serviceAlertsExpanded ? 'true' : 'false');
+        }
+        if (content) {
+          if (serviceAlertsExpanded) {
+            content.removeAttribute('hidden');
+          } else {
+            content.setAttribute('hidden', '');
+          }
+        }
+        updateServiceAlertsSectionState();
+        syncServiceAlertsBadge();
+      }
+
+      function updateServiceAlertsUI() {
+        renderServiceAlertsContent();
+        applyServiceAlertsExpandedState();
+      }
+
+      function toggleServiceAlertsSection(event) {
+        if (event && typeof event.preventDefault === 'function') {
+          event.preventDefault();
+        }
+        serviceAlertsExpanded = !serviceAlertsExpanded;
+        applyServiceAlertsExpandedState();
+      }
+
+      function initializeServiceAlertsSection() {
+        const toggle = document.getElementById('serviceAlertsToggle');
+        if (toggle) {
+          toggle.addEventListener('click', toggleServiceAlertsSection);
+        }
+        updateServiceAlertsUI();
+      }
+
+      async function fetchServiceAlerts() {
+        const currentBaseUrl = baseURL;
+        const sanitizedBase = sanitizeBaseUrl(currentBaseUrl);
+        if (!sanitizedBase) {
+          serviceAlerts = [];
+          serviceAlertsError = null;
+          serviceAlertsLoading = false;
+          updateServiceAlertsUI();
+          return [];
+        }
+        serviceAlertsLoading = true;
+        serviceAlertsError = null;
+        updateServiceAlertsUI();
+        const query = new URLSearchParams({
+          showInactive: 'false',
+          includeDeleted: 'false',
+          messageTypeId: '1',
+          search: 'false',
+          rows: '10',
+          page: '1',
+          sortIndex: 'StartDateUtc',
+          sortOrder: 'asc'
+        });
+        const endpoint = `${sanitizedBase}/Secure/Services/RoutesService.svc/GetMessagesPaged?${query.toString()}`;
+        try {
+          const response = await fetch(endpoint, { cache: 'no-store' });
+          if (!response.ok) {
+            throw new Error(`Service alerts request failed: ${response.status}`);
+          }
+          const text = await response.text();
+          let payload = {};
+          if (text) {
+            try {
+              payload = JSON.parse(text);
+            } catch (parseError) {
+              console.error('Failed to parse service alerts response:', parseError);
+              throw parseError;
+            }
+          }
+          let rows = extractServiceAlertRows(payload);
+          if (!rows.length && payload && typeof payload === 'object' && payload.d) {
+            rows = extractServiceAlertRows(payload.d);
+          }
+          const normalized = rows.map(normalizeServiceAlertRow).filter(Boolean);
+          if (currentBaseUrl !== baseURL) {
+            return normalized;
+          }
+          serviceAlerts = normalized;
+          serviceAlertsError = null;
+          serviceAlertsLoading = false;
+          updateServiceAlertsUI();
+          return normalized;
+        } catch (error) {
+          console.error('Failed to fetch service alerts:', error);
+          if (currentBaseUrl !== baseURL) {
+            return [];
+          }
+          serviceAlerts = [];
+          serviceAlertsError = SERVICE_ALERT_UNAVAILABLE_MESSAGE;
+          serviceAlertsLoading = false;
+          updateServiceAlertsUI();
+          return [];
+        }
+      }
+
       function updateControlPanel() {
         const panel = document.getElementById('controlPanel');
         if (!panel) return;
 
         const selectedAgency = agencies.find(a => a.url === baseURL);
-        const sanitizedBaseURL = typeof baseURL === 'string' ? baseURL.trim().replace(/\/+$/, '') : '';
+        const sanitizedBaseURL = sanitizeBaseUrl(baseURL);
         let logoHtml = '';
         if (sanitizedBaseURL) {
           const agencyLogoUrl = `${sanitizedBaseURL}/Images/clientLogo.jpg`;
@@ -3822,6 +4554,24 @@
             </button>
           </div>
         ` : '';
+        const serviceAlertsExpandedClass = serviceAlertsExpanded ? 'is-expanded' : 'is-collapsed';
+        const serviceAlertsStatusText = buildServiceAlertsStatusText();
+        const serviceAlertsBadgeText = formatServiceAlertsBadgeText(getActiveServiceAlertCount());
+        const serviceAlertsBadgeAttr = serviceAlertsBadgeText ? '' : ' hidden';
+        const serviceAlertsContentHiddenAttr = serviceAlertsExpanded ? '' : ' hidden';
+        const serviceAlertsSectionHtml = `
+          <div class="selector-section service-alerts ${serviceAlertsExpandedClass}" id="serviceAlertsSection">
+            <button type="button" class="service-alerts__header" id="serviceAlertsToggle" aria-expanded="${serviceAlertsExpanded ? 'true' : 'false'}" aria-controls="serviceAlertsContent">
+              <span class="service-alerts__header-main">
+                <span class="service-alerts__title">Service Alerts</span>
+                <span class="service-alerts__status" id="serviceAlertsStatus">${escapeHtml(serviceAlertsStatusText)}</span>
+              </span>
+              <span class="service-alerts__badge" id="serviceAlertsBadge"${serviceAlertsBadgeAttr}>${escapeHtml(serviceAlertsBadgeText)}</span>
+              <span class="service-alerts__chevron" aria-hidden="true">&#8250;</span>
+            </button>
+            <div class="service-alerts__content" id="serviceAlertsContent"${serviceAlertsContentHiddenAttr}></div>
+          </div>
+        `;
         let html = `
           <div class="selector-header">
             <div class="selector-header-text">
@@ -3844,6 +4594,7 @@
               </div>
             </div>
         `;
+        html += serviceAlertsSectionHtml;
 
         if (adminMode) {
           html += `
@@ -3872,6 +4623,7 @@
         `;
 
         panel.innerHTML = html;
+        initializeServiceAlertsSection();
         updateDisplayModeButtons();
         updateIncidentToggleButton();
         positionAllPanelTabs();
@@ -4146,14 +4898,25 @@
         refreshMap();
       }
 
+      function setPanelToggleArrow(tab, arrowHtml) {
+        if (!tab) return;
+        const arrowElement = tab.querySelector('.panel-toggle__arrow');
+        if (arrowElement) {
+          arrowElement.innerHTML = arrowHtml;
+        } else {
+          tab.innerHTML = arrowHtml;
+        }
+      }
+
       // togglePanelVisibility toggles the provided panel's visibility and updates its tab arrow.
       function togglePanelVisibility(panelId, tabId, expandedArrow, collapsedArrow) {
         const panel = document.getElementById(panelId);
         const tab = document.getElementById(tabId);
         if (!panel || !tab) return;
         const isHidden = panel.classList.toggle('hidden');
-        tab.innerHTML = isHidden ? collapsedArrow : expandedArrow;
+        setPanelToggleArrow(tab, isHidden ? collapsedArrow : expandedArrow);
         positionAllPanelTabs();
+        syncServiceAlertsBadge();
       }
 
       function toggleRoutePanel() {
@@ -4180,17 +4943,18 @@
           controlPanel.classList.add('hidden');
         }
         if (controlTab) {
-          controlTab.innerHTML = '&#9664;';
+          setPanelToggleArrow(controlTab, '&#9664;');
         }
 
         if (routePanel && !routePanel.classList.contains('hidden')) {
           routePanel.classList.add('hidden');
         }
         if (routeTab) {
-          routeTab.innerHTML = '&#9654;';
+          setPanelToggleArrow(routeTab, '&#9654;');
         }
 
         positionAllPanelTabs();
+        syncServiceAlertsBadge();
       }
 
       function renderRouteLegendContent(legendElement, routes) {
@@ -4523,6 +5287,7 @@
           });
         }, 15000));
         refreshIntervals.push(setInterval(fetchRoutePaths, 15000));
+        refreshIntervals.push(setInterval(fetchServiceAlerts, SERVICE_ALERT_REFRESH_INTERVAL_MS));
         if (incidentsAreAvailable()) {
           refreshIntervals.push(setInterval(refreshIncidents, INCIDENT_REFRESH_INTERVAL_MS));
           refreshIncidents();
@@ -4572,8 +5337,10 @@
         clearRefreshIntervals();
         baseURL = url;
         resetIncidentAlertState();
+        resetServiceAlertsState();
         updateControlPanel();
         enforceIncidentVisibilityForCurrentAgency();
+        fetchServiceAlerts();
         Object.values(markers).forEach(m => map.removeLayer(m));
         markers = {};
         Object.values(nameBubbles).forEach(b => {
@@ -4720,6 +5487,7 @@
             if (controlPanelTab) {
               controlPanelTab.style.display = "none";
             }
+            syncServiceAlertsBadge();
           }
           map.on('zoom', () => {
               scheduleMarkerScaleUpdate();
@@ -8402,8 +9170,13 @@
     <div id="routeLegend" aria-live="polite"></div>
     <div id="controlPanel" class="selector-panel"></div>
     <div id="routeSelector" class="selector-panel"></div>
-    <div id="controlPanelTab" class="panel-toggle panel-toggle--left" onclick="toggleControlPanel()" title="Toggle system controls">&#9654;</div>
-    <div id="routeSelectorTab" class="panel-toggle panel-toggle--right" onclick="toggleRoutePanel()" title="Toggle route selector">&#9664;</div>
+    <div id="controlPanelTab" class="panel-toggle panel-toggle--left" onclick="toggleControlPanel()" title="Toggle system controls">
+      <span class="panel-toggle__arrow" aria-hidden="true">&#9654;</span>
+      <span id="controlPanelAlertBadge" class="panel-toggle__badge" hidden></span>
+    </div>
+    <div id="routeSelectorTab" class="panel-toggle panel-toggle--right" onclick="toggleRoutePanel()" title="Toggle route selector">
+      <span class="panel-toggle__arrow" aria-hidden="true">&#9664;</span>
+    </div>
     <div class="credit">proof of concept created by pat cox • phc6j@virginia.edu</div>
     <div id="cookieBanner" class="cookie-banner" style="display:none;">
       This site stores your selected transit agency on your device to remember your preference.


### PR DESCRIPTION
## Summary
- add a collapsible Service Alerts section with styling and badges in the system controls panel
- fetch, normalize, and render service alerts for the selected agency while syncing badge counts on panel/toggle state changes
- update panel toggle markup and helper logic to support the new badge indicator

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1ef3b5bac83338d62baa9ad758e3f