### PR TITLE
Fix service alerts panel collapsing

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -540,7 +540,6 @@
         box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
         display: flex;
         flex-direction: column;
-        overflow: hidden;
         transition: box-shadow 0.2s ease, border-color 0.2s ease;
       }
       .service-alerts.is-collapsed.has-active-alerts {


### PR DESCRIPTION
## Summary
- remove the overflow clipping from the service alerts card so the header stays visible when collapsed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d205ccd5bc83339f49024d18da56bc