### PR TITLE
Flatten service alerts card header styling

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -551,7 +551,8 @@
         appearance: none;
         border: none;
         border-bottom: 1px solid transparent;
-        background: none;
+        background: transparent;
+        border-radius: 0;
         padding: 16px 18px;
         display: flex;
         align-items: center;
@@ -570,7 +571,7 @@
         background: rgba(35, 45, 75, 0.06);
       }
       .service-alerts__header:focus-visible {
-        box-shadow: inset 0 0 0 2px rgba(56, 189, 248, 0.45);
+        box-shadow: none;
       }
       .service-alerts.is-expanded .service-alerts__header {
         border-bottom-color: rgba(148, 163, 184, 0.32);
@@ -619,21 +620,21 @@
       .panel-toggle__badge[hidden] {
         display: none !important;
       }
+      .service-alerts__badge {
+        box-shadow: none;
+      }
       .service-alerts__chevron {
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        width: 24px;
-        height: 24px;
-        border-radius: 50%;
-        background: rgba(35, 45, 75, 0.12);
         color: rgba(35, 45, 75, 0.72);
         font-size: 16px;
-        transition: transform 0.2s ease, background 0.2s ease;
+        line-height: 1;
+        transition: transform 0.2s ease, color 0.2s ease;
       }
       .service-alerts__header:hover .service-alerts__chevron,
       .service-alerts__header:focus-visible .service-alerts__chevron {
-        background: rgba(35, 45, 75, 0.18);
+        color: rgba(35, 45, 75, 0.92);
       }
       .service-alerts.is-expanded .service-alerts__chevron {
         transform: rotate(90deg);


### PR DESCRIPTION
## Summary
- flatten the service alerts card header so the outer container owns the chrome
- remove the chevron button styling and badge drop shadow for an inline header layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d224576fb483339b93229ba84640e2