### PR TITLE
Refine service alerts styling on test map

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -536,12 +536,16 @@
       .selector-panel .selector-section.service-alerts {
         border-radius: 16px;
         border: 1px solid rgba(35, 45, 75, 0.14);
-        background: rgba(248, 250, 252, 0.92);
-        box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(241, 245, 249, 0.9));
+        box-shadow: 0 18px 38px rgba(15, 23, 42, 0.12);
         display: flex;
         flex-direction: column;
         gap: 0;
         transition: box-shadow 0.2s ease, border-color 0.2s ease;
+        backdrop-filter: blur(6px);
+      }
+      .selector-panel .selector-section.service-alerts.is-expanded {
+        box-shadow: 0 22px 44px rgba(15, 23, 42, 0.16);
       }
       .service-alerts.is-collapsed.has-active-alerts {
         border-color: rgba(220, 38, 38, 0.45);
@@ -550,31 +554,45 @@
       .service-alerts__header {
         appearance: none;
         border: none;
-        background: transparent;
-        border-radius: 0;
-        padding: 16px 18px;
+        background: linear-gradient(135deg, rgba(35, 45, 75, 0.08), rgba(35, 45, 75, 0.02));
+        border-radius: 16px;
+        border-bottom: 1px solid transparent;
+        padding: 18px 20px;
         display: flex;
         align-items: center;
-        gap: 14px;
+        gap: 16px;
         width: 100%;
         text-align: left;
         cursor: pointer;
         font: inherit;
         color: inherit;
-        transition: color 0.2s ease, border-color 0.2s ease;
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.55);
+        position: relative;
+        transition: color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
       }
       .service-alerts__header:hover,
       .service-alerts__header:focus-visible {
         text-decoration: none;
+        background: linear-gradient(135deg, rgba(35, 45, 75, 0.16), rgba(35, 45, 75, 0.05));
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65), 0 12px 24px rgba(15, 23, 42, 0.12);
       }
       .service-alerts__header:focus-visible {
-        box-shadow: none;
+        outline: none;
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65), 0 0 0 3px var(--accent-soft), 0 18px 32px rgba(15, 23, 42, 0.16);
       }
       .service-alerts.is-expanded .service-alerts__header {
-        border-bottom: 1px solid rgba(148, 163, 184, 0.32);
+        border-bottom-color: rgba(148, 163, 184, 0.26);
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+      }
+      .service-alerts.is-collapsed .service-alerts__header {
+        border-bottom-color: transparent;
       }
       .service-alerts.is-collapsed.has-active-alerts .service-alerts__header {
         color: rgba(127, 29, 29, 0.95);
+        background: linear-gradient(135deg, rgba(220, 38, 38, 0.12), rgba(220, 38, 38, 0.04));
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7), 0 14px 30px rgba(220, 38, 38, 0.18);
       }
       .service-alerts__header-main {
         display: flex;
@@ -624,23 +642,45 @@
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        color: rgba(35, 45, 75, 0.72);
-        font-size: 16px;
+        width: 34px;
+        height: 34px;
+        border-radius: 50%;
+        background: linear-gradient(135deg, rgba(35, 45, 75, 0.95), rgba(35, 45, 75, 0.7));
+        color: #f8fafc;
+        font-size: 18px;
+        font-weight: 700;
         line-height: 1;
-        transition: transform 0.2s ease, color 0.2s ease;
+        box-shadow: 0 12px 24px rgba(35, 45, 75, 0.25);
+        transition: transform 0.25s ease, background 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
+        flex-shrink: 0;
       }
       .service-alerts__header:hover .service-alerts__chevron,
       .service-alerts__header:focus-visible .service-alerts__chevron {
-        color: rgba(35, 45, 75, 0.92);
+        background: linear-gradient(135deg, rgba(35, 45, 75, 0.85), rgba(35, 45, 75, 0.65));
+        box-shadow: 0 14px 28px rgba(35, 45, 75, 0.28);
+      }
+      .service-alerts.is-collapsed.has-active-alerts .service-alerts__chevron {
+        background: linear-gradient(135deg, #dc2626, #ef4444);
+        box-shadow: 0 16px 30px rgba(220, 38, 38, 0.32);
+        color: #fef2f2;
       }
       .service-alerts.is-expanded .service-alerts__chevron {
         transform: rotate(90deg);
+        background: linear-gradient(135deg, rgba(35, 45, 75, 0.88), rgba(35, 45, 75, 0.68));
       }
       .service-alerts__content {
-        padding: 18px 18px 20px;
+        padding: 20px 20px 22px;
         display: flex;
         flex-direction: column;
         gap: 16px;
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(241, 245, 249, 0.94));
+        border-top: 1px solid rgba(148, 163, 184, 0.24);
+        border-bottom-left-radius: 16px;
+        border-bottom-right-radius: 16px;
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+      }
+      .service-alerts.is-expanded .service-alerts__content {
+        animation: service-alerts-fade-in 180ms ease;
       }
       .service-alerts.is-collapsed .service-alerts__content {
         display: none;
@@ -654,14 +694,14 @@
         gap: 16px;
       }
       .service-alerts__item {
-        background: rgba(255, 255, 255, 0.92);
+        background: linear-gradient(135deg, rgba(255, 255, 255, 0.98), rgba(241, 245, 249, 0.92));
         border: 1px solid rgba(148, 163, 184, 0.32);
         border-radius: 14px;
-        padding: 14px 16px;
+        padding: 16px 18px;
         display: flex;
         flex-direction: column;
         gap: 10px;
-        box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+        box-shadow: 0 16px 30px rgba(15, 23, 42, 0.12);
       }
       .service-alerts__item-title {
         font-size: 15px;
@@ -700,9 +740,14 @@
       .service-alerts__state {
         display: flex;
         align-items: center;
-        gap: 10px;
+        gap: 12px;
         font-size: 14px;
-        color: rgba(30, 41, 59, 0.75);
+        color: rgba(30, 41, 59, 0.8);
+        padding: 16px 18px;
+        border-radius: 14px;
+        background: linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(237, 242, 247, 0.92));
+        border: 1px solid rgba(148, 163, 184, 0.28);
+        box-shadow: 0 12px 22px rgba(15, 23, 42, 0.1);
       }
       .service-alerts__spinner {
         width: 18px;
@@ -715,10 +760,28 @@
       .service-alerts__state--error {
         color: rgba(153, 27, 27, 0.9);
         font-weight: 600;
+        border-color: rgba(220, 38, 38, 0.3);
+        box-shadow: 0 16px 32px rgba(220, 38, 38, 0.18);
       }
       .service-alerts__state--empty {
         color: rgba(30, 41, 59, 0.6);
         font-style: italic;
+        border-style: dashed;
+      }
+      @keyframes service-alerts-fade-in {
+        from {
+          opacity: 0;
+          transform: translateY(-6px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .service-alerts.is-expanded .service-alerts__content {
+          animation: none;
+        }
       }
       .selector-panel .incident-alert-block {
         background: linear-gradient(135deg, rgba(254, 226, 226, 0.92), rgba(254, 202, 202, 0.78));


### PR DESCRIPTION
## Summary
- Refresh the service alerts panel container, header button, and chevron so they reuse the gradients, shadows, and focus treatments seen elsewhere on the map UI.
- Restyle the expanded panel body, alert cards, and empty/error states with cohesive surfaces plus a subtle open animation that respects reduced-motion preferences.

## Testing
- Not run (HTML/CSS change only)


------
https://chatgpt.com/codex/tasks/task_e_68d2300dcce4833395dc9a75ca93585d