### PR TITLE
Prevent service alerts panel from collapsing

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -544,6 +544,7 @@
         box-shadow: 0 22px 45px rgba(15, 23, 42, 0.16);
         display: flex;
         flex-direction: column;
+        flex: 0 0 auto;
         overflow: hidden;
         transition: box-shadow 0.25s ease, border-color 0.25s ease, transform 0.25s ease;
         isolation: isolate;


### PR DESCRIPTION
## Summary
- prevent the service alert section in the control panel from shrinking within the flex column layout
- keep the panel content scrollable instead of collapsing when incident alerts render alongside service alerts

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d23af442ec8333a5267747cd087b6c