### PR TITLE
Prevent service alerts panel expansion without active alerts

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -4448,6 +4448,9 @@
       }
 
       function refreshServiceAlertsUI() {
+        if (serviceAlertsExpanded && serviceAlertsHasLoaded && !serviceAlertsLoading && !serviceAlertsError && getActiveServiceAlertCount() === 0) {
+          serviceAlertsExpanded = false;
+        }
         updateServiceAlertsButtonState();
         updateServiceAlertsPanelContent();
         updateServiceAlertsPanelVisibility();
@@ -4558,6 +4561,10 @@
       function toggleServiceAlertsPanel(event) {
         if (event && typeof event.preventDefault === 'function') {
           event.preventDefault();
+        }
+        const hasActiveAlerts = getActiveServiceAlertCount() > 0;
+        if (!serviceAlertsExpanded && serviceAlertsHasLoaded && !serviceAlertsLoading && !serviceAlertsError && !hasActiveAlerts) {
+          return;
         }
         serviceAlertsExpanded = !serviceAlertsExpanded;
         refreshServiceAlertsUI();


### PR DESCRIPTION
## Summary
- block manual expansion of the service alerts panel when there are no active alerts
- automatically collapse the panel after updates when all service alerts are inactive

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d25f725b4c83339982ec48cd291316