### PR TITLE
Ensure fetchTrains resolves when trains hidden

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -10199,7 +10199,7 @@
               return trainFetchPromise;
           }
           if (!trainsVisible) {
-              return;
+              return Promise.resolve();
           }
           const fetchTask = (async () => {
               if (!trainsVisible) {


### PR DESCRIPTION
## Summary
- return a resolved promise from fetchTrains when trains are hidden so callers can still chain promise handlers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d31584d15483338257ccddea6c60a5