### PR TITLE
Disable ATC marker style on test map

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -10423,6 +10423,13 @@
       window.ADSB_PROXY_ENDPOINT = '/adsb';
     </script>
     <script src="plane_globals.js"></script>
+    <script>
+      if (typeof window.setPlaneStyleOptions === 'function') {
+        window.setPlaneStyleOptions({ atcStyle: false });
+      } else {
+        window.atcStyle = false;
+      }
+    </script>
     <script src="markers.js"></script>
     <script src="planeObject.js"></script>
     <script src="planes_integration.js"></script>


### PR DESCRIPTION
## Summary
- disable the ATC asterisk marker style on the test map so planes render with aircraft silhouettes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d367e44e38833381a79748a945eae8