### PR TITLE
Fix plane rotation using track heading (follow-up)

### DIFF
--- a/planes_integration.js
+++ b/planes_integration.js
@@ -508,7 +508,7 @@
       icon.style.transformOrigin = '50% 50%';
       const rotationTransform = `rotate(${degrees}deg)`;
       if (typeof icon.style.rotate !== 'undefined') {
-        icon.style.rotate = rotationTransform;
+        icon.style.rotate = `${degrees}deg`;
         if (icon.style.transform && icon.style.transform.includes('rotate(')) {
           const cleaned = icon.style.transform.replace(/rotate\([^)]*\)/g, '').trim();
           icon.style.transform = cleaned;


### PR DESCRIPTION
## Summary
- ensure Leaflet plane markers always rotate using the track heading from the ADS-B feed
- preserve marker translation transforms and refresh rotations after map interactions to keep headings accurate
- correct standalone CSS rotate assignment so browsers honoring style.rotate receive valid values

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d370eb0e5083338a4752486f0dd590