### PR TITLE
Handle stop marker bringToFront availability

### DIFF
--- a/cattestmap.html
+++ b/cattestmap.html
@@ -8615,7 +8615,18 @@
                       }
                       evaluateIncidentRouteAlerts();
                       updateRouteSelector(activeRoutes);
-                      stopMarkers.forEach(stopMarker => stopMarker.bringToFront());
+                      stopMarkers.forEach(stopMarker => {
+                          if (!stopMarker) {
+                              return;
+                          }
+                          if (typeof stopMarker.bringToFront === 'function') {
+                              stopMarker.bringToFront();
+                              return;
+                          }
+                          if (typeof stopMarker.setZIndexOffset === 'function') {
+                              stopMarker.setZIndexOffset(1000);
+                          }
+                      });
                   }
                   updateRouteLegend(Array.from(displayedRoutes.values()), { preserveOnEmpty: true });
               })


### PR DESCRIPTION
## Summary
- guard stop marker bringToFront usage so non-marker entries do not crash rendering
- fall back to setZIndexOffset when bringToFront is unavailable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4ae6d100083339627b5e82901ceb2