### PR TITLE
Use CAT API heading field

### DIFF
--- a/cattestmap.html
+++ b/cattestmap.html
@@ -10156,7 +10156,7 @@
           if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
               return null;
           }
-          const heading = toNumberOrNull(getFirstDefined(entry, ['Heading', 'heading', 'Direction', 'direction']));
+          const heading = toNumberOrNull(getFirstDefined(entry, ['h', 'H', 'Heading', 'heading', 'Direction', 'direction']));
           const speed = toNumberOrNull(getFirstDefined(entry, ['Speed', 'speed', 'Velocity', 'velocity', 'GpsSpeed', 'GPSSpeed', 'GroundSpeed', 'groundSpeed']));
           const rawRouteId = getFirstDefined(entry, ['RouteID', 'routeID', 'RouteId', 'routeId', 'Route', 'route']);
           const routeKey = catRouteKey(rawRouteId);


### PR DESCRIPTION
## Summary
- read the CAT vehicle heading directly from the API's `h` property when normalizing vehicle data
- ensure CAT vehicle markers reuse the feed-provided heading without relying on calculated fallbacks

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d4cc99ef708333a8a182fb362de0cd