### PR TITLE
Refresh CAT stops when active routes change

### DIFF
--- a/cattestmap.html
+++ b/cattestmap.html
@@ -10355,6 +10355,9 @@
           });
           catActiveRouteKeys = activeKeys;
           renderCatRoutes();
+          if (catOverlayEnabled) {
+              renderBusStops(stopDataCache);
+          }
       }
 
       function renderCatVehiclesUsingCache() {


### PR DESCRIPTION
## Summary
- trigger a bus stop re-render after CAT active route keys update so CAT stops appear immediately

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4cffc09c083338cc08a8e10021b5d