### PR TITLE
Show CAT routes 7 and 12 in kiosk mode when active

### DIFF
--- a/cattestmap.html
+++ b/cattestmap.html
@@ -2215,6 +2215,7 @@
       if (adminParam !== null) {
         adminMode = adminParam.toLowerCase() === 'true';
       }
+      const autoEnableCatOverlay = kioskMode || adminKioskMode;
 
       const showRadarParam = params.get('showRadar');
       if (showRadarParam !== null) {
@@ -4408,6 +4409,8 @@
       let activeRoutes = new Set();
       // Tracks which routes the API designates as public-facing.
       let routeVisibility = {};
+      // Routes that should be forced visible in kiosk mode when they have vehicles.
+      const kioskModeAlwaysVisibleRoutes = new Set([7, 12]);
 
       // Routes default to visible if they currently have vehicles unless the user
       // overrides the selection via the route selector.
@@ -4473,7 +4476,12 @@
           return adminKioskMode || (!kioskMode && adminMode);
         }
         if (adminKioskMode) return true;
-        if (kioskMode) return isRoutePublicById(id);
+        if (kioskMode) {
+          if (kioskModeAlwaysVisibleRoutes.has(id) && routeHasActiveVehicles(id)) {
+            return true;
+          }
+          return isRoutePublicById(id);
+        }
         if (adminMode) return true;
         return isRoutePublicById(id);
       }
@@ -12581,6 +12589,9 @@
         loadAgencies()
           .then(() => {
             initMap();
+            if (autoEnableCatOverlay && !catOverlayEnabled) {
+              enableCatOverlay();
+            }
             showCookieBanner();
             enforceIncidentVisibilityForCurrentAgency();
             return loadAgencyData()


### PR DESCRIPTION
## Summary
- ensure kiosk mode treats CAT routes 7 and 12 as visible when they have active vehicles
- automatically enable the CAT overlay in kiosk and admin kiosk modes so the forced routes appear without manual interaction

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4d23fa86083338e74ce043f0441bc