### PR TITLE
Extend incident proximity alerts to CAT routes

### DIFF
--- a/cattestmap.html
+++ b/cattestmap.html
@@ -3732,6 +3732,19 @@
         return entry.projectedPath;
       }
 
+      function ensureCatProjectedPath(geometry) {
+        if (!geometry) return null;
+        const latLngs = Array.isArray(geometry.latLngs) ? geometry.latLngs : null;
+        if (!latLngs || latLngs.length < 2) return null;
+        const existing = Array.isArray(geometry.projectedPath) ? geometry.projectedPath : null;
+        if (existing && existing.length === latLngs.length && existing.length >= 2) {
+          return existing;
+        }
+        if (typeof L === 'undefined' || !L.Projection || !L.Projection.SphericalMercator) return null;
+        geometry.projectedPath = latLngs.map(point => L.Projection.SphericalMercator.project(point));
+        return geometry.projectedPath;
+      }
+
       function computeDistanceFromProjectedPointToSegmentMeters(point, a, b) {
         if (!point || !a || !b) return Infinity;
         const ax = a.x;
@@ -3837,8 +3850,59 @@
           if (!Number.isFinite(numericRouteId) || numericRouteId === 0) return;
           const projectedPath = ensureRouteProjectedPath(entry);
           if (!projectedPath || projectedPath.length < 2) return;
-          routeEntries.push({ routeId: numericRouteId, projectedPath });
+          routeEntries.push({
+            routeId: numericRouteId,
+            rawRouteId: numericRouteId,
+            projectedPath,
+            source: 'transloc'
+          });
         });
+        if (catOverlayEnabled) {
+          catRoutePatternGeometries.forEach(geometry => {
+            if (!geometry || !Array.isArray(geometry.latLngs) || geometry.latLngs.length < 2) {
+              return;
+            }
+            const routeKey = catRouteKey(geometry.routeKey);
+            if (!routeKey || routeKey === CAT_OUT_OF_SERVICE_ROUTE_KEY) {
+              return;
+            }
+            if (!isCatRouteVisible(routeKey)) {
+              return;
+            }
+            const projectedPath = ensureCatProjectedPath(geometry);
+            if (!projectedPath || projectedPath.length < 2) {
+              return;
+            }
+            const color = sanitizeCssColor(geometry.color)
+              || sanitizeCssColor(getCatRouteColor(routeKey))
+              || '';
+            const info = getCatRouteInfo(routeKey) || null;
+            const nameCandidates = [
+              info?.displayName,
+              info?.shortName,
+              info?.longName,
+              routeKey ? `Route ${routeKey}` : ''
+            ];
+            let displayName = '';
+            for (const candidate of nameCandidates) {
+              if (typeof candidate !== 'string') continue;
+              const trimmed = candidate.trim();
+              if (trimmed) {
+                displayName = trimmed;
+                break;
+              }
+            }
+            routeEntries.push({
+              routeId: `cat:${routeKey}`,
+              rawRouteId: routeKey,
+              projectedPath,
+              source: 'cat',
+              routeKey,
+              color,
+              name: displayName
+            });
+          });
+        }
         if (routeEntries.length === 0) {
           if (hadAlerts) {
             resetIncidentAlertState();
@@ -3861,7 +3925,17 @@
           const matchedRoutes = [];
           const seenRoutes = new Set();
           let closestDistance = Infinity;
-          routeEntries.forEach(({ routeId, projectedPath }) => {
+          routeEntries.forEach(entry => {
+            if (!entry || !Array.isArray(entry.projectedPath) || entry.projectedPath.length < 2) {
+              return;
+            }
+            const routeId = entry.routeId;
+            const rawRouteId = entry.rawRouteId;
+            const projectedPath = entry.projectedPath;
+            const source = entry.source;
+            const routeKey = entry.routeKey;
+            const presetColor = entry.color;
+            const presetName = entry.name;
             const distance = computeDistanceFromProjectedPointToPathMeters(projectedPoint, projectedPath);
             if (!Number.isFinite(distance)) return;
             if (distance < closestDistance) {
@@ -3870,16 +3944,47 @@
             if (distance <= threshold && !seenRoutes.has(routeId)) {
               seenRoutes.add(routeId);
               const colorCandidates = [];
-              if (routeColors && typeof routeColors[routeId] === 'string') {
-                colorCandidates.push(routeColors[routeId]);
-              }
-              const storedRoute = allRoutes ? (allRoutes[routeId] || allRoutes[`${routeId}`] || null) : null;
-              if (storedRoute) {
-                const storedColorCandidates = [storedRoute.MapLineColor, storedRoute.RouteColor, storedRoute.Color, storedRoute.color];
-                storedColorCandidates.forEach(value => {
-                  if (typeof value === 'string') {
-                    colorCandidates.push(value);
+              if (source === 'cat') {
+                if (presetColor) {
+                  colorCandidates.push(presetColor);
+                }
+                const fallbackCatColor = sanitizeCssColor(getCatRouteColor(routeKey || rawRouteId));
+                if (fallbackCatColor) {
+                  colorCandidates.push(fallbackCatColor);
+                }
+              } else {
+                const lookupCandidates = [];
+                if (rawRouteId !== undefined && rawRouteId !== null) {
+                  lookupCandidates.push(rawRouteId);
+                }
+                if (routeId !== undefined && routeId !== null && routeId !== rawRouteId) {
+                  lookupCandidates.push(routeId);
+                }
+                lookupCandidates.forEach(idCandidate => {
+                  if (routeColors && typeof routeColors[idCandidate] === 'string') {
+                    colorCandidates.push(routeColors[idCandidate]);
                   }
+                  const numericCandidate = Number(idCandidate);
+                  if (Number.isFinite(numericCandidate) && routeColors && typeof routeColors[numericCandidate] === 'string') {
+                    colorCandidates.push(routeColors[numericCandidate]);
+                  }
+                });
+                const numericRouteId = Number(rawRouteId);
+                const storedRouteCandidates = [];
+                if (Number.isFinite(numericRouteId) && allRoutes) {
+                  storedRouteCandidates.push(allRoutes[numericRouteId], allRoutes[`${numericRouteId}`]);
+                }
+                if (rawRouteId !== undefined && rawRouteId !== null && allRoutes && Object.prototype.hasOwnProperty.call(allRoutes, rawRouteId)) {
+                  storedRouteCandidates.push(allRoutes[rawRouteId]);
+                }
+                storedRouteCandidates.forEach(storedRoute => {
+                  if (!storedRoute) return;
+                  const storedColorCandidates = [storedRoute.MapLineColor, storedRoute.RouteColor, storedRoute.Color, storedRoute.color];
+                  storedColorCandidates.forEach(value => {
+                    if (typeof value === 'string') {
+                      colorCandidates.push(value);
+                    }
+                  });
                 });
               }
               let matchedColor = '';
@@ -3890,7 +3995,38 @@
                   break;
                 }
               }
-              matchedRoutes.push({ routeId, name: getRouteDisplayName(routeId), distance, color: matchedColor });
+              let routeName = '';
+              if (source === 'cat') {
+                if (typeof presetName === 'string' && presetName.trim()) {
+                  routeName = presetName.trim();
+                } else {
+                  const info = getCatRouteInfo(routeKey || rawRouteId);
+                  if (info) {
+                    const infoNameCandidates = [info.displayName, info.shortName, info.longName];
+                    for (const value of infoNameCandidates) {
+                      if (typeof value !== 'string') continue;
+                      const trimmed = value.trim();
+                      if (trimmed) {
+                        routeName = trimmed;
+                        break;
+                      }
+                    }
+                  }
+                  if (!routeName && rawRouteId) {
+                    routeName = `Route ${rawRouteId}`;
+                  }
+                }
+              } else {
+                routeName = getRouteDisplayName(rawRouteId ?? routeId);
+              }
+              matchedRoutes.push({
+                routeId,
+                rawRouteId: rawRouteId ?? routeId,
+                routeKey: routeKey || null,
+                name: routeName,
+                distance,
+                color: matchedColor
+              });
             }
           });
           if (!matchedRoutes.length) return;
@@ -7390,7 +7526,7 @@
                           }
                       }
                       if (!routeColor) {
-                          const idCandidates = [route.routeId, route.RouteId, route.RouteID];
+                          const idCandidates = [route.routeId, route.RouteId, route.RouteID, route.rawRouteId, route.routeKey];
                           for (const idCandidate of idCandidates) {
                               if (idCandidate === undefined || idCandidate === null) continue;
                               const directColor = sanitizeCssColor(routeColors ? routeColors[idCandidate] : '');


### PR DESCRIPTION
## Summary
- add projected-path support for CAT route geometries and include visible CAT routes when matching incidents to routes
- surface CAT route display names and colors in incident alerts and popups so matched CAT routes are rendered consistently

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d4da1b5efc8333bf846668efb90ce4