### PR TITLE
Ensure incident alerts refresh with PulsePoint and CAT toggles

### DIFF
--- a/cattestmap.html
+++ b/cattestmap.html
@@ -4083,6 +4083,7 @@
           latestActiveIncidents = activeRecords;
           evaluateIncidentRouteAlerts();
           applyIncidentMarkers(activeRecords);
+          updateControlPanel();
         } catch (error) {
           console.error('Failed to refresh PulsePoint incidents', error);
         } finally {
@@ -9377,6 +9378,7 @@
           fetchCatVehicles().catch(error => console.error('Failed to fetch CAT vehicles:', error));
           fetchCatServiceAlerts().catch(error => console.error('Failed to fetch CAT service alerts:', error));
           startCatRefreshIntervals();
+          updateControlPanel();
       }
 
       function disableCatOverlay() {
@@ -9402,6 +9404,7 @@
           if (enableOverlapDashRendering && overlapRenderer) {
               updateOverlapRendererWithCatRoutes();
           }
+          updateControlPanel();
       }
 
       function ensureCatLayerGroup() {


### PR DESCRIPTION
## Summary
- refresh the system control panel after each PulsePoint incident fetch so the incident card stays current
- refresh the system control panel when the CAT overlay is enabled or disabled to keep the incident card synchronized with route changes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4ddd746dc83339e4d57e26647fe84