### PR TITLE
Ensure incident alerts refresh with PulsePoint and CAT toggles

### DIFF
--- a/cattestmap.html
+++ b/cattestmap.html
@@ -9378,6 +9378,7 @@
           fetchCatVehicles().catch(error => console.error('Failed to fetch CAT vehicles:', error));
           fetchCatServiceAlerts().catch(error => console.error('Failed to fetch CAT service alerts:', error));
           startCatRefreshIntervals();
+          evaluateIncidentRouteAlerts();
           updateControlPanel();
       }
 
@@ -9404,6 +9405,7 @@
           if (enableOverlapDashRendering && overlapRenderer) {
               updateOverlapRendererWithCatRoutes();
           }
+          evaluateIncidentRouteAlerts();
           updateControlPanel();
       }
 


### PR DESCRIPTION
## Summary
- refresh the system control panel after each PulsePoint incident fetch so the incident card stays current
- refresh the system control panel when the CAT overlay is enabled or disabled to keep the incident card synchronized with route changes
- recompute incident-route alerts whenever the CAT overlay is toggled so the control panel reflects CAT route visibility immediately

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4e01bd03c83338759b9ca6a673801