### PR TITLE
Include CAT routes in incident context when overlay enabled

### DIFF
--- a/cattestmap.html
+++ b/cattestmap.html
@@ -3866,7 +3866,7 @@
             if (!routeKey || routeKey === CAT_OUT_OF_SERVICE_ROUTE_KEY) {
               return;
             }
-            if (!isCatRouteVisible(routeKey)) {
+            if (!isCatRouteAllowedInCurrentMode(routeKey)) {
               return;
             }
             const projectedPath = ensureCatProjectedPath(geometry);


### PR DESCRIPTION
## Summary
- include CAT route geometries in incident proximity checks when the CAT overlay is enabled so incidents reference those routes even if they are not rendered

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d4e19ebef483338e7b0c6a77449278