### PR TITLE
Refactor testmap assets for faster loading (follow-up: plane style timing)

### DIFF
--- a/testmap.js
+++ b/testmap.js
@@ -10,11 +10,30 @@ function applyPlaneStyleOptions() {
   }
 }
 
-if (document.readyState === 'complete') {
-  applyPlaneStyleOptions();
-} else {
-  window.addEventListener('load', applyPlaneStyleOptions, { once: true });
+function schedulePlaneStyleOverride() {
+  if (typeof window.setPlaneStyleOptions === 'function') {
+    applyPlaneStyleOptions();
+    return;
+  }
+
+  const tryApply = () => {
+    applyPlaneStyleOptions();
+    window.removeEventListener('load', tryApply);
+  };
+
+  if (document.readyState === 'loading' || document.readyState === 'interactive') {
+    document.addEventListener('DOMContentLoaded', tryApply, { once: true });
+    window.addEventListener('load', tryApply, { once: true });
+  } else if (document.readyState === 'complete') {
+    if (typeof queueMicrotask === 'function') {
+      queueMicrotask(applyPlaneStyleOptions);
+    } else {
+      setTimeout(applyPlaneStyleOptions, 0);
+    }
+  }
 }
+
+schedulePlaneStyleOverride();
 
 // Manually set these variables.
       // adminMode: true for admin view (with speed/block bubbles and unit numbers).


### PR DESCRIPTION
## Summary
- ensure the plane style override runs as soon as plane_globals exposes setPlaneStyleOptions so markers initialize with the correct styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5919872588333b8995eb06577a4b3