### PR TITLE
Ensure incident markers refresh when route alerts change

### DIFF
--- a/testmap.js
+++ b/testmap.js
@@ -2043,8 +2043,14 @@ schedulePlaneStyleOverride();
             lookup.set(candidateId, entry);
           }
         });
+        const previousSignature = incidentRouteAlertSignature;
         incidentsNearRoutesLookup = lookup;
         incidentRouteAlertSignature = typeof signature === 'string' ? signature : '';
+        const shouldRefreshIncidentMarkers = previousSignature !== incidentRouteAlertSignature
+          || (lookup && lookup.size > 0);
+        if (shouldRefreshIncidentMarkers) {
+          applyIncidentMarkers(latestActiveIncidents);
+        }
         applyIncidentHaloStates();
         refreshOpenIncidentPopups();
         maintainIncidentLayers();


### PR DESCRIPTION
## Summary
- trigger a marker refresh when the set of route-adjacent incidents changes so that pinned incidents appear even if incidents are hidden

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d597a86268833389a40503bb800cf1