### PR TITLE
Proxy external feeds through FastAPI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.115.0
 uvicorn[standard]==0.30.6
 httpx==0.27.2
+pycryptodome==3.20.0


### PR DESCRIPTION
## Summary
- centralize external data access behind FastAPI with TTL caches for TransLoc, CAT, PulsePoint, Amtraker, RideSystems, and ADS-B
- trim payloads server-side so the test map only receives the fields it needs and expose new JSON endpoints for each feed
- refactor the test map front-end to consume the new local endpoints, reuse cached snapshots, and drop direct third-party fetches
- add pycryptodome dependency for decrypting PulsePoint responses

## Testing
- pip install -r requirements.txt
- python -m compileall app.py testmap.js

------
https://chatgpt.com/codex/tasks/task_e_68d5996b623c8333b17612ae2b428d51