### PR TITLE
Fix plane rotation reset during zoom

### DIFF
--- a/planes_integration.js
+++ b/planes_integration.js
@@ -617,7 +617,21 @@
     clearMoveDebounce();
   }
 
+  function reapplyLeafletMarkerRotations() {
+    if (!isLeafletMap(state.map)) {
+      return;
+    }
+    state.markers.forEach(entry => {
+      if (!entry || !entry.marker) {
+        return;
+      }
+      const rotationDeg = Number.isFinite(entry.rotationDeg) ? entry.rotationDeg : 0;
+      scheduleLeafletMarkerRotation(entry.marker, rotationDeg);
+    });
+  }
+
   function handleInteractionEnd() {
+    reapplyLeafletMarkerRotations();
     clearMoveDebounce();
     if (!state.started || state.disposed) {
       return;


### PR DESCRIPTION
## Summary
- add a helper that reapplies stored plane rotations to Leaflet markers
- call the helper whenever zoom/move interactions end so aircraft regain their headings

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5c20bed60833388fa53440c36ef4f