### PR TITLE
Show all trains on testmap

### DIFF
--- a/app.py
+++ b/app.py
@@ -64,7 +64,7 @@ RIDESYSTEMS_CLIENTS_URL = os.getenv(
     "RIDESYSTEMS_CLIENTS_URL",
     "https://admin.ridesystems.net/api/Clients/GetClients",
 )
-TRAIN_TARGET_STATION_CODE = os.getenv("TRAIN_TARGET_STATION_CODE", "CVS").strip().upper()
+TRAIN_TARGET_STATION_CODE = os.getenv("TRAIN_TARGET_STATION_CODE", "").strip().upper()
 
 VEH_REFRESH_S   = int(os.getenv("VEH_REFRESH_S", "10"))
 ROUTE_REFRESH_S = int(os.getenv("ROUTE_REFRESH_S", "60"))

--- a/testmap.js
+++ b/testmap.js
@@ -706,7 +706,7 @@ schedulePlaneStyleOverride();
       const INCIDENTS_ALLOWED_AGENCY_NAMES = ['University of Virginia', 'University of Virginia Health'];
       const TRAINS_ENDPOINT = '/v1/testmap/trains';
       const TRAIN_POLL_INTERVAL_MS = 30000;
-      const TRAIN_TARGET_STATION_CODE = 'CVS';
+      const TRAIN_TARGET_STATION_CODE = '';
       const TRAIN_CARDINAL_HEADING_DEGREES = Object.freeze({
         N: 0,
         NORTH: 0,


### PR DESCRIPTION
## Summary
- remove the default CVS filter from the backend Amtrak train payload so all stations are included
- clear the frontend station filter constant so every fetched train renders on the test map

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5c80720b48333a5796fd81b9aacbf