### PR TITLE
Address feedback: clear CAT route markers during agency reset

### DIFF
--- a/testmap.js
+++ b/testmap.js
@@ -5203,6 +5203,7 @@ schedulePlaneStyleOverride();
           if (b.speedMarker) map.removeLayer(b.speedMarker);
           if (b.nameMarker) map.removeLayer(b.nameMarker);
           if (b.blockMarker) map.removeLayer(b.blockMarker);
+          if (b.routeMarker) map.removeLayer(b.routeMarker);
         });
         nameBubbles = {};
         stopMarkers.forEach(m => map.removeLayer(m));


### PR DESCRIPTION
## Summary
- remove CAT route bubble markers during agency changes so overlays do not linger

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6ce53c26c8333bae7ca3117597e91