### PR TITLE
Fix CAT route bubble fallback

### DIFF
--- a/testmap.js
+++ b/testmap.js
@@ -10004,8 +10004,10 @@ schedulePlaneStyleOverride();
                       }
                       delete nameBubbles[bubbleKey].nameMarker;
                   }
+                  const rawRouteIdForLabel = toNonEmptyString(vehicle.routeId);
+                  const fallbackRouteId = rawRouteIdForLabel !== '' ? rawRouteIdForLabel : effectiveRouteKey;
                   const routeLabel = shouldShowRouteLabel
-                      ? formatCatRouteBubbleLabel(vehicle.routeId ?? effectiveRouteKey)
+                      ? formatCatRouteBubbleLabel(fallbackRouteId)
                       : null;
                   const routeIcon = routeLabel
                       ? createBlockBubbleDivIcon(routeLabel, routeColor, markerMetricsForZoom.scale, headingDeg)


### PR DESCRIPTION
## Summary
- ensure CAT vehicle route bubbles fall back to the effective route key when the API omits the routeId value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6d07b95ac8333a5ef38ec8e679c8d