### PR TITLE
Strip CAT suffix from fallback stop tracking

### DIFF
--- a/testmap.js
+++ b/testmap.js
@@ -6746,14 +6746,13 @@ schedulePlaneStyleOverride();
                   .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
               const fallbackStopIdSet = new Set();
               stopEntries.forEach(entry => {
-                  if (typeof entry.stopIdText === 'string' && entry.stopIdText.trim() !== '') {
-                      entry.stopIdText.split(',').forEach(value => {
-                          const trimmed = value.trim();
-                          if (trimmed) {
-                              fallbackStopIdSet.add(trimmed);
-                          }
-                      });
-                  }
+                  const entryStopIds = Array.isArray(entry?.stopIds) ? entry.stopIds : [];
+                  entryStopIds.forEach(value => {
+                      const normalized = normalizeIdentifier(value);
+                      if (normalized) {
+                          fallbackStopIdSet.add(normalized);
+                      }
+                  });
               });
               const fallbackStopIdText = Array.from(fallbackStopIdSet)
                   .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))


### PR DESCRIPTION
## Summary
- build fallback stop identifier sets from the raw stop IDs instead of the formatted text
- keep CAT stop popups tracked by avoiding mismatches with suffixed IDs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6daefca388333b8d5ba50f68937f3