### PR TITLE
Fix CAT stop overlay caching after toggle

### DIFF
--- a/testmap.js
+++ b/testmap.js
@@ -9399,7 +9399,14 @@ schedulePlaneStyleOverride();
           }
           const now = Date.now();
           if (!force && catStopsById.size > 0 && (now - catStopsLastFetchTime) < CAT_METADATA_REFRESH_INTERVAL_MS) {
-              return Array.from(catStopsById.values());
+              const cachedStops = Array.from(catStopsById.values());
+              if (!Array.isArray(catStopDataCache) || catStopDataCache.length === 0) {
+                  catStopDataCache = buildCatStopDataForRendering(cachedStops);
+                  if (catOverlayEnabled) {
+                      renderBusStops(stopDataCache);
+                  }
+              }
+              return cachedStops;
           }
           try {
               const response = await fetch(CAT_STOPS_ENDPOINT, { cache: 'no-store' });


### PR DESCRIPTION
## Summary
- rebuild the CAT stop rendering cache when reusing cached stop metadata
- refresh stop markers when restoring cached data so stops return after re-enabling the overlay

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d861edbb608333922e296607b27118