### PR TITLE
Ensure CAT stops remain visible when re-enabling overlay

### DIFF
--- a/testmap.js
+++ b/testmap.js
@@ -8768,7 +8768,11 @@ schedulePlaneStyleOverride();
           if (catRouteSelections.has(normalized)) {
               return !!catRouteSelections.get(normalized);
           }
-          return activeFallbackSet instanceof Set ? activeFallbackSet.has(normalized) : false;
+          const fallbackSet = activeFallbackSet instanceof Set ? activeFallbackSet : null;
+          if (catOverlayEnabled && catRouteSelections.size === 0 && (!fallbackSet || fallbackSet.size === 0)) {
+              return true;
+          }
+          return fallbackSet ? fallbackSet.has(normalized) : false;
       }
 
       function isOutOfServiceRouteVisible() {
@@ -8809,7 +8813,11 @@ schedulePlaneStyleOverride();
           if (catRouteSelections.has(normalized)) {
               return !!catRouteSelections.get(normalized);
           }
-          return activeFallbackSet instanceof Set ? activeFallbackSet.has(normalized) : false;
+          const fallbackSet = activeFallbackSet instanceof Set ? activeFallbackSet : null;
+          if (catOverlayEnabled && catRouteSelections.size === 0 && (!fallbackSet || fallbackSet.size === 0)) {
+              return true;
+          }
+          return fallbackSet ? fallbackSet.has(normalized) : false;
       }
 
       function toNonEmptyString(value) {


### PR DESCRIPTION
## Summary
- default CAT route visibility to on when no explicit selections or active vehicles are present
- keep CAT stops visible after toggling the overlay off and back on

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d868bbb2d0833399d1b889e01f27a9