### PR TITLE
Restore CAT stop markers when toggling overlay

### DIFF
--- a/testmap.js
+++ b/testmap.js
@@ -8438,10 +8438,14 @@ schedulePlaneStyleOverride();
           catOverlayEnabled = true;
           ensureCatLayerGroup();
           ensureCatBusMarkerSvgLoaded();
+          const restoredCatStops = restoreCatStopDataCacheFromStoredStops();
           updateCatToggleButtonState();
           refreshServiceAlertsUI();
           updateRouteSelector(activeRoutes, true);
           renderCatRoutes();
+          if (restoredCatStops) {
+              renderBusStops(stopDataCache);
+          }
           fetchCatRoutes().catch(error => console.error('Failed to fetch CAT routes:', error));
           fetchCatStops().catch(error => console.error('Failed to fetch CAT stops:', error));
           fetchCatRoutePatterns().catch(error => console.error('Failed to fetch CAT route patterns:', error));
@@ -9399,6 +9403,21 @@ schedulePlaneStyleOverride();
               }
               return results;
           });
+      }
+
+      function restoreCatStopDataCacheFromStoredStops() {
+          if (Array.isArray(catStopDataCache) && catStopDataCache.length > 0) {
+              return true;
+          }
+          if (!(catStopsById instanceof Map) || catStopsById.size === 0) {
+              return false;
+          }
+          const cachedStops = Array.from(catStopsById.values());
+          if (!Array.isArray(cachedStops) || cachedStops.length === 0) {
+              return false;
+          }
+          catStopDataCache = buildCatStopDataForRendering(cachedStops);
+          return Array.isArray(catStopDataCache) && catStopDataCache.length > 0;
       }
 
       async function fetchCatStops(force = false) {


### PR DESCRIPTION
## Summary
- restore the CAT stop render cache when the overlay is re-enabled so cached stops appear again without another fetch
- add a helper that rebuilds the CAT stop cache from stored metadata before triggering refreshes

## Testing
- not run (frontend change)


------
https://chatgpt.com/codex/tasks/task_e_68d86acd9f7c8333ba58e487bd1cefdd