### PR TITLE
Enable trains by default in admin kiosk mode

### DIFF
--- a/testmap.js
+++ b/testmap.js
@@ -756,7 +756,7 @@ schedulePlaneStyleOverride();
       let trainMarkers = {};
       let trainMarkerStates = {};
       let trainNameBubbles = {};
-      let trainsVisible = false;
+      let trainsVisible = adminKioskMode;
       let planesVisible = false;
       let trainFetchPromise = null;
       const vehicleHeadingCache = new Map();


### PR DESCRIPTION
## Summary
- default the Show Amtrak toggle to on when adminKioskMode is enabled so trains render automatically

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d975b262c88333ad85b7a0e801cd57