### PR TITLE
Add dispatcher mode safeguards for overheight vehicles

### DIFF
--- a/testmap.css
+++ b/testmap.css
@@ -1603,3 +1603,23 @@
         outline: none;
         box-shadow: 0 0 0 3px var(--accent-soft), 0 16px 30px rgba(229, 114, 0, 0.42);
       }
+      .dispatcher-overheight-popup .leaflet-popup-content-wrapper {
+        background: #fff5f5;
+        border: 2px solid #dc2626;
+        border-radius: 12px;
+      }
+      .dispatcher-overheight-popup .leaflet-popup-tip {
+        background: #fff5f5;
+        border: 2px solid #dc2626;
+      }
+      .dispatcher-overheight-popup .leaflet-popup-content {
+        margin: 8px 12px;
+      }
+      .dispatcher-overheight-popup__content {
+        font-family: 'FGDC', sans-serif;
+        font-size: 16px;
+        font-weight: 800;
+        letter-spacing: 0.8px;
+        color: #b91c1c;
+        text-transform: uppercase;
+      }


### PR DESCRIPTION
## Summary
- add dispatcher URL flag that loads the shared safety configuration and monitors overheight vehicles near the 14th Street bridge
- lock the map on the bridge when a monitored vehicle enters the radius, drawing a red warning circle, opening a persistent popup, and disabling other map movement
- prevent other view changes while locked and style the dispatcher popup for accessibility

## Testing
- ⚠️ `uvicorn app:app --host 0.0.0.0 --port 8000` *(fails to reach live third-party APIs in the container, used only to capture the UI screenshot)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c7e7c170833392a3496dc191853b