### PR TITLE
Fix dispatcher overheight detection for name-based config

### DIFF
--- a/testmap.js
+++ b/testmap.js
@@ -394,11 +394,15 @@ schedulePlaneStyleOverride();
         openDispatcherPopupForVehicle(dispatcherLockState.vehicleKey);
       }
 
-      function selectNearestOverheightCandidate(currentCandidate, vehicleKey, lat, lon, config) {
+      function selectNearestOverheightCandidate(currentCandidate, vehicleKey, vehicleName, lat, lon, config) {
         if (!config || !config.overheightBusIds || config.overheightBusIds.size === 0) {
           return currentCandidate;
         }
-        if (!vehicleKey || !config.overheightBusIds.has(vehicleKey)) {
+        const normalizedVehicleId = vehicleKey ? `${vehicleKey}`.trim() : '';
+        const normalizedVehicleName = vehicleName ? `${vehicleName}`.trim() : '';
+        const isOverheight = (normalizedVehicleId && config.overheightBusIds.has(normalizedVehicleId))
+          || (normalizedVehicleName && config.overheightBusIds.has(normalizedVehicleName));
+        if (!isOverheight) {
           return currentCandidate;
         }
         const distance = computeGreatCircleDistanceMeters(lat, lon, config.bridgeLat, config.bridgeLng);
@@ -8541,6 +8545,7 @@ schedulePlaneStyleOverride();
                       dispatcherCandidate = selectNearestOverheightCandidate(
                           dispatcherCandidate,
                           vehicleKey,
+                          busName,
                           lat,
                           lon,
                           dispatcherConfigLocal


### PR DESCRIPTION
## Summary
- treat dispatcher overheight configuration entries as matching either vehicle IDs or bus names
- include the bus name when selecting the nearest overheight candidate so configured vehicles trigger alerts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9ceb9b78083338a71092631024d1e