### PR TITLE
Fix overheight popup duplication and show vehicle info

### DIFF
--- a/testmap.css
+++ b/testmap.css
@@ -1615,6 +1615,20 @@
       .dispatcher-overheight-popup .leaflet-popup-content {
         margin: 8px 12px;
       }
+      .dispatcher-overheight-popup__vehicle {
+        font-family: 'FGDC', sans-serif;
+        font-size: 14px;
+        font-weight: 700;
+        color: #1f2937;
+        margin-bottom: 4px;
+      }
+      .dispatcher-overheight-popup__block {
+        font-family: 'FGDC', sans-serif;
+        font-size: 13px;
+        font-weight: 600;
+        color: #374151;
+        margin-bottom: 6px;
+      }
       .dispatcher-overheight-popup__content {
         font-family: 'FGDC', sans-serif;
         font-size: 16px;
@@ -1622,4 +1636,5 @@
         letter-spacing: 0.8px;
         color: #b91c1c;
         text-transform: uppercase;
+        margin-top: 2px;
       }


### PR DESCRIPTION
## Summary
- ensure dispatcher overheight popups are cleared before rebinding so orphan popups are not left behind
- build popup content with the current vehicle name/number and block assignment for easier identification
- add supporting styles for the enriched popup layout

## Testing
- Manual: Launched the static testmap page and injected a sample dispatcher popup to confirm styling

------
https://chatgpt.com/codex/tasks/task_e_68d9e3ff35a08333a565d1948616eaec