### PR TITLE
Fix dispatcher overheight popup lingering after vehicle leaves radius

### DIFF
--- a/testmap.js
+++ b/testmap.js
@@ -531,16 +531,13 @@ schedulePlaneStyleOverride();
           if (!dispatcherLockState.active) {
             return;
           }
+          const previousVehicleKey = dispatcherLockState.vehicleKey;
           restoreMapInteractionsForDispatcher();
           if (dispatcherLockState.circle && typeof map.removeLayer === 'function') {
             map.removeLayer(dispatcherLockState.circle);
           }
-          const activeMarker = dispatcherLockState.vehicleKey ? markers && markers[dispatcherLockState.vehicleKey] : null;
-          if (activeMarker && typeof activeMarker.closePopup === 'function') {
-            activeMarker.closePopup();
-          }
-          if (activeMarker && typeof activeMarker.unbindPopup === 'function') {
-            activeMarker.unbindPopup();
+          if (previousVehicleKey) {
+            clearDispatcherPopupForVehicle(previousVehicleKey);
           }
           dispatcherLockState.circle = null;
           dispatcherLockState.popup = null;


### PR DESCRIPTION
## Summary
- ensure dispatcher cleanup clears the overheight popup using the existing suppression helper so it does not immediately reopen

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da0faa2598833385d29f5a6a77fa02