### PR TITLE
Improve map text rendering on iOS Safari

### DIFF
--- a/testmap.css
+++ b/testmap.css
@@ -426,8 +426,25 @@
       }
       body {
         font-family: 'FGDC', sans-serif;
-        font-size: 14px;
+        font-size: 15px;
+        font-weight: 500;
         color: var(--panel-text-color);
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
+      .leaflet-container,
+      .leaflet-control,
+      .leaflet-popup,
+      .leaflet-tooltip,
+      .leaflet-marker-icon {
+        font-weight: 500;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
+      .leaflet-marker-icon,
+      .leaflet-tooltip {
+        transform: translate(0, 0);
+        font-size: 15px;
       }
       #map {
         height: 100%;


### PR DESCRIPTION
## Summary
- add global font smoothing to the map UI to sharpen text on Safari
- enforce whole-pixel positioning and a slightly heavier font to keep labels crisp

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da22da1c98833388261f0206e818c2