### PR TITLE
Use system fonts on iOS for testmap

### DIFF
--- a/testmap.css
+++ b/testmap.css
@@ -1,4 +1,20 @@
-.custom-popup {
+      :root {
+        --navy: #232D4B;
+        --navy-dark: #1b274a;
+        --navy-darker: #1a2441;
+        --panel-surface: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(245, 248, 255, 0.96));
+        --panel-border-color: rgba(35, 45, 75, 0.12);
+        --panel-shadow: 0 20px 45px rgba(15, 23, 42, 0.25);
+        --panel-highlight: rgba(35, 45, 75, 0.06);
+        --panel-text-color: #1f2937;
+        --panel-heading-color: #232D4B;
+        --panel-muted-text: #4b5563;
+        --accent: #E57200;
+        --accent-bright: #ff9c3e;
+        --accent-soft: rgba(229, 114, 0, 0.28);
+        --app-font-family: 'FGDC', sans-serif;
+      }
+      .custom-popup {
         position: absolute;
         background: linear-gradient(135deg, var(--navy), var(--navy-dark));
         border: 3px solid rgba(255, 255, 255, 0.92);
@@ -10,7 +26,7 @@
         z-index: 1000;
         color: #f8fafc;
         text-transform: uppercase;
-        font-family: 'FGDC', sans-serif;
+        font-family: var(--app-font-family);
         font-size: 14px;
         letter-spacing: 0.35px;
         box-shadow: 0 18px 36px rgba(15, 23, 42, 0.38);
@@ -55,7 +71,7 @@
         gap: 12px;
         color: #f8fafc;
         text-transform: none;
-        font-family: 'FGDC', sans-serif;
+        font-family: var(--app-font-family);
         letter-spacing: 0.3px;
         white-space: normal;
       }
@@ -201,7 +217,7 @@
         color: #fff7ed;
         border: 3px solid rgba(255, 255, 255, 0.9);
         box-shadow: 0 12px 24px rgba(15, 23, 42, 0.45);
-        font-family: 'FGDC', sans-serif;
+        font-family: var(--app-font-family);
         font-weight: 800;
         letter-spacing: 0.6px;
         text-transform: uppercase;
@@ -218,7 +234,7 @@
         border-radius: 10px;
         padding: 8px 10px;
         border: 1px solid rgba(255, 255, 255, 0.2);
-        font-family: 'FGDC', sans-serif;
+        font-family: var(--app-font-family);
         font-size: 13px;
         letter-spacing: 0.35px;
         text-transform: none;
@@ -409,28 +425,16 @@
         font-family: 'FGDC';
         src: url('FGDC.ttf') format('truetype');
       }
-      :root {
-        --navy: #232D4B;
-        --navy-dark: #1b274a;
-        --navy-darker: #1a2441;
-        --panel-surface: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(245, 248, 255, 0.96));
-        --panel-border-color: rgba(35, 45, 75, 0.12);
-        --panel-shadow: 0 20px 45px rgba(15, 23, 42, 0.25);
-        --panel-highlight: rgba(35, 45, 75, 0.06);
-        --panel-text-color: #1f2937;
-        --panel-heading-color: #232D4B;
-        --panel-muted-text: #4b5563;
-        --accent: #E57200;
-        --accent-bright: #ff9c3e;
-        --accent-soft: rgba(229, 114, 0, 0.28);
-      }
       body {
-        font-family: 'FGDC', sans-serif;
+        font-family: var(--app-font-family);
         font-size: 15px;
         font-weight: 500;
         color: var(--panel-text-color);
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
+      }
+      body.ios-font {
+        --app-font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
       }
       .leaflet-container,
       .leaflet-control,
@@ -464,7 +468,7 @@
         justify-content: center;
         background: rgba(71, 85, 105, 0.55);
         color: #f1f5f9;
-        font-family: 'FGDC', sans-serif;
+        font-family: var(--app-font-family);
         font-size: 18px;
         letter-spacing: 0.3rem;
         text-transform: uppercase;
@@ -1157,7 +1161,7 @@
         background: rgba(255, 255, 255, 0.92);
         box-shadow: 0 6px 18px rgba(17, 24, 39, 0.1);
         font-size: 16px;
-        font-family: 'FGDC', sans-serif;
+        font-family: var(--app-font-family);
         color: var(--panel-text-color);
         transition: border-color 0.2s ease, box-shadow 0.2s ease;
         appearance: none;
@@ -1275,7 +1279,7 @@
         border-radius: 999px;
         padding: 10px 16px;
         font-size: 15px;
-        font-family: 'FGDC', sans-serif;
+        font-family: var(--app-font-family);
         font-weight: 600;
         cursor: pointer;
         transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, color 0.2s ease;
@@ -1603,7 +1607,7 @@
         background: linear-gradient(135deg, var(--accent), var(--accent-bright));
         color: #1f1300;
         padding: 10px 20px;
-        font-family: 'FGDC', sans-serif;
+        font-family: var(--app-font-family);
         font-weight: 600;
         cursor: pointer;
         box-shadow: 0 12px 24px rgba(229, 114, 0, 0.35);
@@ -1633,21 +1637,21 @@
         margin: 8px 12px;
       }
       .dispatcher-overheight-popup__vehicle {
-        font-family: 'FGDC', sans-serif;
+        font-family: var(--app-font-family);
         font-size: 14px;
         font-weight: 700;
         color: #1f2937;
         margin-bottom: 4px;
       }
       .dispatcher-overheight-popup__block {
-        font-family: 'FGDC', sans-serif;
+        font-family: var(--app-font-family);
         font-size: 13px;
         font-weight: 600;
         color: #374151;
         margin-bottom: 6px;
       }
       .dispatcher-overheight-popup__content {
-        font-family: 'FGDC', sans-serif;
+        font-family: var(--app-font-family);
         font-size: 16px;
         font-weight: 800;
         letter-spacing: 0.8px;

--- a/testmap.js
+++ b/testmap.js
@@ -1,5 +1,66 @@
 'use strict';
 
+const DEFAULT_MAP_FONT_STACK = `FGDC, sans-serif`;
+const IOS_MAP_FONT_STACK = `system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif`;
+const IOS_BODY_CLASS = 'ios-font';
+
+function detectIOSPlatform() {
+  if (typeof navigator !== 'object' || navigator === null) {
+    return false;
+  }
+
+  const userAgent = typeof navigator.userAgent === 'string' ? navigator.userAgent : '';
+  const platform = typeof navigator.platform === 'string' ? navigator.platform : '';
+  const maxTouchPoints = typeof navigator.maxTouchPoints === 'number' ? navigator.maxTouchPoints : 0;
+
+  if (/iPad|iPhone|iPod/i.test(userAgent) || /iPad|iPhone|iPod/i.test(platform)) {
+    return true;
+  }
+
+  if (platform === 'MacIntel' && maxTouchPoints > 1) {
+    return true;
+  }
+
+  if (typeof navigator.userAgentData === 'object' && navigator.userAgentData !== null) {
+    try {
+      const brands = Array.isArray(navigator.userAgentData.brands) ? navigator.userAgentData.brands : [];
+      const hasIOSBrand = brands.some(brand => typeof brand.brand === 'string' && /iOS/i.test(brand.brand));
+      if (hasIOSBrand) {
+        return true;
+      }
+    } catch (error) {
+      // Ignore structured UA parsing failures.
+    }
+  }
+
+  return false;
+}
+
+const IS_IOS_PLATFORM = detectIOSPlatform();
+const ACTIVE_MAP_FONT_STACK = IS_IOS_PLATFORM ? IOS_MAP_FONT_STACK : DEFAULT_MAP_FONT_STACK;
+
+if (typeof document !== 'undefined' && IS_IOS_PLATFORM) {
+  const applyIOSClass = () => {
+    if (document.body) {
+      document.body.classList.add(IOS_BODY_CLASS);
+      return true;
+    }
+    return false;
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+      applyIOSClass();
+    }, { once: true });
+  } else {
+    if (!applyIOSClass()) {
+      document.addEventListener('DOMContentLoaded', () => {
+        applyIOSClass();
+      }, { once: true });
+    }
+  }
+}
+
 window.ADSB_PROXY_ENDPOINT = window.ADSB_PROXY_ENDPOINT || '/adsb';
 
 function applyPlaneStyleOptions() {
@@ -3456,7 +3517,7 @@ schedulePlaneStyleOverride();
       let BUS_MARKER_SVG_TEXT = null;
       let BUS_MARKER_SVG_LOAD_PROMISE = null;
       let busMarkerVisibleExtents = null;
-      const BUS_MARKER_LABEL_FONT_FAMILY = 'FGDC, sans-serif';
+      const BUS_MARKER_LABEL_FONT_FAMILY = ACTIVE_MAP_FONT_STACK;
       const BUS_MARKER_LABEL_MIN_FONT_PX = 10;
       const SPEED_BUBBLE_BASE_FONT_PX = 12;
       const SPEED_BUBBLE_HORIZONTAL_PADDING = 12;
@@ -11720,7 +11781,7 @@ schedulePlaneStyleOverride();
               <svg width="${svgWidth}" height="${svgHeight}" viewBox="0 0 ${svgWidth} ${svgHeight}" xmlns="http://www.w3.org/2000/svg" style="pointer-events: none;">
                   <g>
                       <rect x="0" y="0" width="${svgWidth}" height="${svgHeight}" rx="${radiusRounded}" ry="${radiusRounded}" fill="${fillColor}" stroke="white" stroke-width="${strokeWidthRounded}" />
-                      <text x="${textX}" y="${textY}" dominant-baseline="middle" alignment-baseline="middle" text-anchor="middle" font-size="${roundToTwoDecimals(fontSize)}" font-weight="bold" fill="${textColor}" font-family="FGDC">${escapeHtml(label)}</text>
+                      <text x="${textX}" y="${textY}" dominant-baseline="middle" alignment-baseline="middle" text-anchor="middle" font-size="${roundToTwoDecimals(fontSize)}" font-weight="bold" fill="${textColor}" font-family="${BUS_MARKER_LABEL_FONT_FAMILY}">${escapeHtml(label)}</text>
                   </g>
               </svg>`;
           return L.divIcon({
@@ -11767,7 +11828,7 @@ schedulePlaneStyleOverride();
               <svg width="${svgWidth}" height="${svgHeight}" viewBox="0 0 ${svgWidth} ${svgHeight}" xmlns="http://www.w3.org/2000/svg" style="pointer-events: none;">
                   <g>
                       <rect x="0" y="${rectY}" width="${svgWidth}" height="${rectHeightRounded}" rx="${radiusRounded}" ry="${radiusRounded}" fill="${fillColor}" stroke="white" stroke-width="${strokeWidthRounded}" />
-                      <text x="${textX}" y="${textY}" dominant-baseline="middle" alignment-baseline="middle" text-anchor="middle" font-size="${fontSizeRounded}" font-weight="bold" fill="${textColor}" font-family="FGDC">${escapeHtml(name)}</text>
+                      <text x="${textX}" y="${textY}" dominant-baseline="middle" alignment-baseline="middle" text-anchor="middle" font-size="${fontSizeRounded}" font-weight="bold" fill="${textColor}" font-family="${BUS_MARKER_LABEL_FONT_FAMILY}">${escapeHtml(name)}</text>
                   </g>
               </svg>`;
           return L.divIcon({
@@ -11814,7 +11875,7 @@ schedulePlaneStyleOverride();
               <svg width="${svgWidth}" height="${svgHeight}" viewBox="0 0 ${svgWidth} ${svgHeight}" xmlns="http://www.w3.org/2000/svg" style="pointer-events: none;">
                   <g>
                       <rect x="0" y="${rectY}" width="${svgWidth}" height="${rectHeightRounded}" rx="${radiusRounded}" ry="${radiusRounded}" fill="${fillColor}" stroke="white" stroke-width="${strokeWidthRounded}" />
-                      <text x="${textX}" y="${textY}" dominant-baseline="middle" alignment-baseline="middle" text-anchor="middle" font-size="${fontSizeRounded}" font-weight="bold" fill="${textColor}" font-family="FGDC">${escapeHtml(name)}</text>
+                      <text x="${textX}" y="${textY}" dominant-baseline="middle" alignment-baseline="middle" text-anchor="middle" font-size="${fontSizeRounded}" font-weight="bold" fill="${textColor}" font-family="${BUS_MARKER_LABEL_FONT_FAMILY}">${escapeHtml(name)}</text>
                   </g>
               </svg>`;
           return L.divIcon({


### PR DESCRIPTION
## Summary
- detect iOS devices during bootstrap and fall back to a system font stack for marker rendering
- drive the UI typography through a custom property so the ios-font body class swaps FGDC for the system stack

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da252c63f48333b7195db14e18a4a8