### PR TITLE
Ensure radar toggles do not persist enabled state

### DIFF
--- a/testmap.js
+++ b/testmap.js
@@ -895,10 +895,24 @@ schedulePlaneStyleOverride();
           if (!parsed || typeof parsed !== "object") {
             return null;
           }
-          return {
-            enabled: parsed.enabled === true,
+          const sanitizedState = {
             product: normalizeRadarProduct(parsed.product),
             opacity: clampRadarOpacity(parsed.opacity)
+          };
+          if (Object.prototype.hasOwnProperty.call(parsed, "enabled")) {
+            try {
+              window.sessionStorage.setItem(
+                RADAR_SESSION_STORAGE_KEY,
+                JSON.stringify(sanitizedState)
+              );
+            } catch (error) {
+              console.warn("Failed to sanitize radar session state:", error);
+            }
+          }
+          return {
+            enabled: false,
+            product: sanitizedState.product,
+            opacity: sanitizedState.opacity
           };
         } catch (error) {
           console.warn("Failed to load radar session state:", error);
@@ -915,7 +929,6 @@ schedulePlaneStyleOverride();
             return;
           }
           const payload = {
-            enabled: !!radarEnabled,
             product: radarProduct,
             opacity: radarOpacity
           };


### PR DESCRIPTION
## Summary
- prevent the radar toggle from loading a persisted enabled state
- stop saving the enabled flag and sanitize any stored session data so radar starts disabled after reloads

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68db22297c78833382d842ab42c7e454