### PR TITLE
Add kiosk map page for signage displays

### DIFF
--- a/app.py
+++ b/app.py
@@ -729,6 +729,7 @@ DRIVER_HTML = (BASE_DIR / "driver.html").read_text(encoding="utf-8")
 DISPATCHER_HTML = (BASE_DIR / "dispatcher.html").read_text(encoding="utf-8")
 MAP_HTML = (BASE_DIR / "map.html").read_text(encoding="utf-8")
 TESTMAP_HTML = (BASE_DIR / "testmap.html").read_text(encoding="utf-8")
+KIOSKMAP_HTML = (BASE_DIR / "kioskmap.html").read_text(encoding="utf-8")
 CATTESTMAP_HTML = (BASE_DIR / "cattestmap.html").read_text(encoding="utf-8")
 MADMAP_HTML = (BASE_DIR / "madmap.html").read_text(encoding="utf-8")
 METROMAP_HTML = (BASE_DIR / "metromap.html").read_text(encoding="utf-8")
@@ -3014,6 +3015,11 @@ async def testmap_css():
     return _serve_css_asset("testmap.css")
 
 
+@app.get("/kioskmap.css", include_in_schema=False)
+async def kioskmap_css():
+    return _serve_css_asset("kioskmap.css")
+
+
 @app.get("/vehicle_log/{log_name}", include_in_schema=False)
 async def vehicle_log_file(log_name: str):
     if not re.fullmatch(r"\d{8}_\d{2}\.jsonl", log_name):
@@ -3048,6 +3054,10 @@ async def map_page():
 @app.get("/testmap")
 async def testmap_page():
     return HTMLResponse(TESTMAP_HTML)
+
+@app.get("/kioskmap")
+async def kioskmap_page():
+    return HTMLResponse(KIOSKMAP_HTML)
 
 # ---------------------------
 # CAT TEST MAP PAGE

--- a/kioskmap.css
+++ b/kioskmap.css
@@ -1,0 +1,22 @@
+body.kioskmap {
+  overflow: hidden;
+}
+
+body.kioskmap #map {
+  pointer-events: none;
+}
+
+body.kioskmap #routeLegend {
+  pointer-events: none;
+}
+
+body.kioskmap .selector-panel,
+body.kioskmap .panel-toggle,
+body.kioskmap .credit,
+body.kioskmap #cookieBanner {
+  display: none !important;
+}
+
+body.kioskmap .loading-overlay {
+  pointer-events: none;
+}

--- a/kioskmap.html
+++ b/kioskmap.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Headway Guard – Kiosk Map</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
+    <link rel="stylesheet" href="testmap.css" />
+    <link rel="stylesheet" href="kioskmap.css" />
+    <script>
+      (function applyKioskDefaults() {
+        try {
+          const params = new URLSearchParams(window.location.search);
+          let modified = false;
+          if (!params.has('adminMode')) {
+            params.set('adminMode', 'true');
+            modified = true;
+          }
+          if (!params.has('adminKioskMode') && !params.has('kioskMode')) {
+            params.set('adminKioskMode', 'true');
+            modified = true;
+          }
+          if (modified) {
+            const query = params.toString();
+            const newUrl = window.location.pathname + (query ? `?${query}` : '') + (window.location.hash || '');
+            window.history.replaceState(null, '', newUrl);
+          }
+          if (typeof localStorage !== 'undefined') {
+            localStorage.setItem('agencyConsent', 'true');
+            if (!localStorage.getItem('selectedAgency')) {
+              localStorage.setItem('selectedAgency', 'https://uva.transloc.com');
+            }
+          }
+        } catch (error) {
+          console.warn('Unable to apply kiosk defaults', error);
+        }
+      })();
+    </script>
+    <script defer src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+    <script defer src="https://unpkg.com/@mapbox/polyline@1.1.1"></script>
+    <script defer src="https://unpkg.com/rbush@3.0.1/rbush.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/crypto-js@4.2.0/crypto-js.min.js"></script>
+    <script defer src="testmap.js"></script>
+    <script defer src="plane_globals.js"></script>
+    <script defer src="markers.js"></script>
+    <script defer src="planeObject.js"></script>
+    <script defer src="planes_integration.js"></script>
+  </head>
+  <body class="kioskmap">
+    <div id="map"></div>
+    <div id="routeLegend" aria-live="polite"></div>
+    <div id="controlPanel" class="selector-panel" aria-hidden="true"></div>
+    <div id="routeSelector" class="selector-panel" aria-hidden="true"></div>
+    <div id="controlPanelTab" class="panel-toggle panel-toggle--left" title="System controls"></div>
+    <div id="routeSelectorTab" class="panel-toggle panel-toggle--right" title="Route selector"></div>
+    <div class="credit" aria-hidden="true">proof of concept created by pat cox • phc6j@virginia.edu • Radar tiles © NOAA/NWS via Iowa Environmental Mesonet.</div>
+    <div id="cookieBanner" class="cookie-banner" style="display:none;" aria-hidden="true">
+      This site stores your selected transit agency on your device to remember your preference.
+      <button id="cookieAccept" type="button">OK</button>
+    </div>
+    <div id="loadingOverlay" class="loading-overlay" aria-live="polite" aria-busy="false">
+      <div class="loading-overlay__inner">
+        <div class="loading-overlay__spinner" aria-hidden="true"></div>
+        <div class="loading-overlay__text">Loading agency data…</div>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated kiosk map HTML shell with defaults for admin kiosk mode and UVA agency selection
- include kiosk-specific styling that hides interactive controls for signage deployments
- expose the kiosk map and stylesheet through FastAPI routes so it is served by the app

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68db34f59a348333ae5f75ab2b4b74e8