### PR TITLE
Restore kiosk map stripes and marker styling

### DIFF
--- a/kioskmap.css
+++ b/kioskmap.css
@@ -141,12 +141,30 @@ body.kioskmap .map {
 }
 
 .stop-icon__circle {
-  width: 18px;
-  height: 18px;
+  position: relative;
+  width: 24px;
+  height: 24px;
   border-radius: 50%;
   border: 2px solid rgba(15, 23, 42, 0.65);
-  background: radial-gradient(circle at 35% 35%, #ffffff, #e2e8f0);
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.95), rgba(226, 232, 240, 0.8));
   box-shadow: 0 10px 20px rgba(15, 23, 42, 0.4);
+  overflow: hidden;
+}
+
+.stop-icon__pie {
+  position: absolute;
+  inset: 3px;
+  border-radius: 50%;
+  background: conic-gradient(#38bdf8 0% 100%);
+  box-shadow: inset 0 0 6px rgba(15, 23, 42, 0.25);
+}
+
+.stop-icon__core {
+  position: absolute;
+  inset: 8px;
+  border-radius: 50%;
+  background: rgba(248, 250, 252, 0.95);
+  box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.25);
 }
 
 .bus-icon__circle {
@@ -161,6 +179,31 @@ body.kioskmap .map {
 .bus-icon__circle--stale {
   opacity: 0.55;
   box-shadow: 0 10px 20px rgba(15, 23, 42, 0.35);
+}
+
+.bus-marker-icon {
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.bus-marker-icon__svg {
+  width: 100%;
+  height: 100%;
+  transform-origin: 50% 50%;
+  transform: rotate(var(--bus-heading, 0deg));
+  filter: drop-shadow(0 10px 28px rgba(15, 23, 42, 0.45));
+}
+
+.bus-marker-icon__svg > svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.bus-marker-icon--stale .bus-marker-icon__svg {
+  filter: drop-shadow(0 6px 18px rgba(15, 23, 42, 0.3));
+  opacity: 0.65;
 }
 
 .bus-label__container {


### PR DESCRIPTION
## Summary
- filter kiosk map routes to those with active vehicles and render overlapping segments with striped polylines
- rebuild stop markers as multicolor pie icons keyed to active route colors
- load the bus marker SVG for live vehicles (with fallback) and refresh kiosk CSS to support the restored visuals

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db3b100b108333bd7dadabc37f3b28