### PR TITLE
Adopt testmap-style vehicle label bubbles on kiosk map

### DIFF
--- a/kioskmap.css
+++ b/kioskmap.css
@@ -140,6 +140,14 @@ body.kioskmap .map {
   pointer-events: none !important;
 }
 
+.leaflet-div-icon.bus-label-icon {
+  pointer-events: none !important;
+  background: transparent !important;
+  border: none !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+}
+
 .stop-icon__circle {
   position: relative;
   width: 24px;
@@ -204,46 +212,6 @@ body.kioskmap .map {
 .bus-marker-icon--stale .bus-marker-icon__svg {
   filter: drop-shadow(0 6px 18px rgba(15, 23, 42, 0.3));
   opacity: 0.65;
-}
-
-.bus-label__container {
-  transform: translate(-50%, -110%);
-  padding: 6px 12px;
-  border-radius: 999px;
-  background: rgba(15, 23, 42, 0.92);
-  border: 1px solid rgba(148, 163, 184, 0.6);
-  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.55);
-  font-size: 13px;
-  font-weight: 600;
-  letter-spacing: 0.25px;
-  color: #f8fafc;
-  white-space: nowrap;
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.bus-label__dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: var(--bus-color, #38bdf8);
-  box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.75);
-}
-
-.bus-label__text {
-  display: inline-flex;
-  gap: 6px;
-  align-items: baseline;
-}
-
-.bus-label__primary {
-  font-size: 13px;
-}
-
-.bus-label__segment {
-  font-size: 12px;
-  opacity: 0.8;
 }
 
 @keyframes spin {


### PR DESCRIPTION
## Summary
- adopt the testmap name/block bubble rendering for kiosk map vehicles
- add helper utilities to measure label text and position the bubbles around bus markers
- simplify kiosk map CSS to support the new bubble overlays and drop the old label styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db4d5210d08333bca99cc1c3f7b09a