### PR TITLE
Stop kiosk map from auto-fitting active routes

### DIFF
--- a/kioskmap.js
+++ b/kioskmap.js
@@ -1311,12 +1311,7 @@
     updateRouteLegend(filteredRoutes);
 
     if (!hasInitialView) {
-      if (boundsPoints.length > 0) {
-        const bounds = L.latLngBounds(boundsPoints);
-        map.fitBounds(bounds, { padding: [48, 48], maxZoom: 16 });
-      } else {
-        map.setView(UVA_DEFAULT_CENTER, UVA_DEFAULT_ZOOM);
-      }
+      map.setView(UVA_DEFAULT_CENTER, UVA_DEFAULT_ZOOM);
       hasInitialView = true;
     }
   }


### PR DESCRIPTION
## Summary
- keep the kiosk map at its configured default center/zoom instead of auto-fitting active route bounds

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db52cf1418833383d6eb41dbc7525d