### PR TITLE
Remove shadows from kiosk bus stop markers

### DIFF
--- a/kioskmap.css
+++ b/kioskmap.css
@@ -155,7 +155,6 @@ body.kioskmap .map {
   border-radius: 50%;
   border: 2px solid rgba(15, 23, 42, 0.65);
   background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.95), rgba(226, 232, 240, 0.8));
-  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.4);
   overflow: hidden;
 }
 
@@ -164,7 +163,6 @@ body.kioskmap .map {
   inset: 3px;
   border-radius: 50%;
   background: conic-gradient(#38bdf8 0% 100%);
-  box-shadow: inset 0 0 6px rgba(15, 23, 42, 0.25);
 }
 
 .stop-icon__core {
@@ -172,7 +170,6 @@ body.kioskmap .map {
   inset: 8px;
   border-radius: 50%;
   background: rgba(248, 250, 252, 0.95);
-  box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.25);
 }
 
 .bus-icon__circle {


### PR DESCRIPTION
## Summary
- remove box shadows from kiosk stop icon layers to eliminate the drop shadow effect

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db55352558833398be13f29244d07b