### PR TITLE
Improve kiosk map overlapping route rendering

### DIFF
--- a/kioskmap.html
+++ b/kioskmap.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="kioskmap.css" />
     <script defer src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
     <script defer src="https://unpkg.com/@mapbox/polyline@1.1.1"></script>
+    <script defer src="https://unpkg.com/rbush@3.0.1/rbush.min.js"></script>
     <script defer src="kioskmap.js"></script>
   </head>
   <body class="kioskmap">


### PR DESCRIPTION
## Summary
- load rbush in the kiosk map HTML so spatial indexing is available for overlap detection
- port the OverlapRouteRenderer logic from the test map into kioskmap.js with dynamic stroke weights and RBush-backed overlap handling
- update kiosk route rendering to drive the overlap renderer when available and fall back to the previous segment grouping when necessary

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db583298208333b67766657e6c38a0