### PR TITLE
Align kiosk map overlap rendering with test map

### DIFF
--- a/kioskmap.js
+++ b/kioskmap.js
@@ -107,6 +107,8 @@
     document.body.dataset.debugMode = debugMode ? 'true' : 'false';
   }
 
+  let sharedRouteRenderer = null;
+
   const map = L.map('map', {
     zoomControl: false,
     scrollWheelZoom: false,
@@ -124,6 +126,18 @@
     maxZoom: 19,
     attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
   }).addTo(map);
+
+  if (typeof L === 'object' && typeof L.svg === 'function') {
+    try {
+      sharedRouteRenderer = L.svg({ padding: 0 });
+      if (sharedRouteRenderer) {
+        map.addLayer(sharedRouteRenderer);
+      }
+    } catch (error) {
+      console.warn('Failed to initialize shared SVG renderer for routes.', error);
+      sharedRouteRenderer = null;
+    }
+  }
 
   const ROUTE_PANE = 'routes';
   const STOP_PANE = 'stops';
@@ -747,7 +761,6 @@
     updateWhenIdle: true,
     interactive: false
   });
-  let sharedRouteRenderer = null;
   const routePaneName = ROUTE_PANE;
 
   function createSpatialIndex(options = {}) {
@@ -1633,6 +1646,7 @@
         strokeWeight: DEFAULT_ROUTE_STROKE_WEIGHT,
         minStrokeWeight: MIN_ROUTE_STROKE_WEIGHT,
         maxStrokeWeight: MAX_ROUTE_STROKE_WEIGHT,
+        renderer: sharedRouteRenderer,
         pane: ROUTE_PANE,
         layerGroup
       });
@@ -1720,6 +1734,7 @@
     }
 
     if (overlapUsed) {
+      routeLayerGroup.clearLayers();
       return boundsPoints;
     }
 


### PR DESCRIPTION
## Summary
- create and reuse a shared SVG renderer on the kiosk map so dashed overlap segments match the test map implementation
- clear the fallback route layer group when the overlap renderer is active to avoid stale segments

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db5da0659c8333a49292f686f0d197