### PR TITLE
Add radar sweep map page with shared defaults

### DIFF
--- a/app.py
+++ b/app.py
@@ -744,6 +744,7 @@ TRANSLOC_TICKER_HTML = (BASE_DIR / "transloc_ticker.html").read_text(encoding="u
 ARRIVALSDISPLAY_HTML = (BASE_DIR / "arrivalsdisplay.html").read_text(encoding="utf-8")
 BUS_TABLE_HTML = (BASE_DIR / "buses.html").read_text(encoding="utf-8")
 NOT_FOUND_HTML = (BASE_DIR / "404.html").read_text(encoding="utf-8")
+RADAR_HTML = (BASE_DIR / "radar.html").read_text(encoding="utf-8")
 
 ADSB_URL_TEMPLATE = "https://opendata.adsb.fi/api/v2/lat/{lat}/lon/{lon}/dist/{dist}"
 ADSB_CORS_HEADERS = {
@@ -2934,6 +2935,11 @@ async def busmarker_svg():
     return FileResponse(BASE_DIR / "busmarker.svg", media_type="image/svg+xml")
 
 
+@app.get("/map_defaults.js", include_in_schema=False)
+async def map_defaults_js():
+    return _serve_js_asset("map_defaults.js")
+
+
 @app.get("/plane_globals.js", include_in_schema=False)
 async def plane_globals_js():
     return _serve_js_asset("plane_globals.js")
@@ -3011,6 +3017,11 @@ async def landing_page():
 @app.get("/map")
 async def map_page():
     return HTMLResponse(MAP_HTML)
+
+
+@app.get("/radar")
+async def radar_page():
+    return HTMLResponse(RADAR_HTML)
 
 # ---------------------------
 # TEST MAP PAGE

--- a/kioskmap.html
+++ b/kioskmap.html
@@ -9,6 +9,7 @@
     <script defer src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
     <script defer src="https://unpkg.com/@mapbox/polyline@1.1.1"></script>
     <script defer src="https://unpkg.com/rbush@3.0.1/rbush.min.js"></script>
+    <script defer src="map_defaults.js"></script>
     <script defer src="kioskmap.js"></script>
   </head>
   <body class="kioskmap">

--- a/kioskmap.js
+++ b/kioskmap.js
@@ -3,8 +3,18 @@
   'use strict';
 
   const REFRESH_INTERVAL_MS = 5000;
-  const UVA_DEFAULT_CENTER = [38.03799212281404, -78.50981502838886];
-  const UVA_DEFAULT_ZOOM = 15;
+  const mapDefaults = (typeof window !== 'undefined' && window.HeadwayMapDefaults)
+    ? window.HeadwayMapDefaults
+    : null;
+  const FALLBACK_CENTER = [38.03799212281404, -78.50981502838886];
+  const rawCenter = Array.isArray(mapDefaults?.center) && mapDefaults.center.length === 2
+    ? [Number(mapDefaults.center[0]), Number(mapDefaults.center[1])]
+    : [NaN, NaN];
+  const UVA_DEFAULT_CENTER = rawCenter.every(value => Number.isFinite(value))
+    ? rawCenter
+    : FALLBACK_CENTER;
+  const rawZoom = mapDefaults?.zoom;
+  const UVA_DEFAULT_ZOOM = Number.isFinite(Number(rawZoom)) ? Number(rawZoom) : 15;
   const DEFAULT_ROUTE_COLOR = '#000000';
   const ROUTE_STROKE_WEIGHT = 6;
   const ROUTE_STRIPE_DASH_LENGTH = 16;

--- a/map_defaults.js
+++ b/map_defaults.js
@@ -1,0 +1,30 @@
+(function initHeadwayMapDefaults() {
+  const globalScope = (typeof window !== 'undefined' ? window : globalThis);
+  const DEFAULT_CENTER = [38.03799212281404, -78.50981502838886];
+  const DEFAULT_ZOOM = 15;
+
+  const existing = globalScope.HeadwayMapDefaults && typeof globalScope.HeadwayMapDefaults === 'object'
+    ? globalScope.HeadwayMapDefaults
+    : {};
+
+  const toNumber = (value, fallback) => {
+    const num = Number(value);
+    return Number.isFinite(num) ? num : fallback;
+  };
+
+  const resolveCenter = () => {
+    if (Array.isArray(existing.center) && existing.center.length === 2) {
+      const lat = toNumber(existing.center[0], DEFAULT_CENTER[0]);
+      const lon = toNumber(existing.center[1], DEFAULT_CENTER[1]);
+      return [lat, lon];
+    }
+    return DEFAULT_CENTER.slice();
+  };
+
+  const resolveZoom = () => toNumber(existing.zoom, DEFAULT_ZOOM);
+
+  globalScope.HeadwayMapDefaults = Object.assign({}, existing, {
+    center: resolveCenter(),
+    zoom: resolveZoom(),
+  });
+})();

--- a/radar.html
+++ b/radar.html
@@ -1,0 +1,563 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Headway Guard — Radar Sweep</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
+    <style>
+      :root {
+        color-scheme: dark;
+      }
+      html, body {
+        height: 100%;
+        margin: 0;
+        background: radial-gradient(circle at center, #05121e 0%, #02070d 100%);
+        font-family: "FGDC", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      body {
+        position: relative;
+        overflow: hidden;
+      }
+      #map {
+        position: absolute;
+        inset: 0;
+      }
+      #radarCanvas {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        pointer-events: none;
+        z-index: 450;
+      }
+      .leaflet-container {
+        background: #02070d;
+      }
+      .radar-bus-marker-wrapper {
+        width: 36px;
+        height: 59px;
+        position: relative;
+        transform-origin: center;
+      }
+      .radar-bus-icon {
+        width: 36px;
+        height: 59px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        filter: drop-shadow(0 0 6px rgba(80, 255, 220, 0.35));
+      }
+      .radar-bus-icon__svg {
+        width: 100%;
+        height: 100%;
+        display: block;
+      }
+      .radar-bus-icon__svg svg {
+        width: 100%;
+        height: 100%;
+        display: block;
+      }
+      .radar-bus-fallback {
+        width: 16px !important;
+        height: 16px !important;
+        border-radius: 50%;
+        background: rgba(80, 255, 220, 0.85);
+        box-shadow: 0 0 12px rgba(80, 255, 220, 0.75);
+      }
+      .radar-status {
+        position: absolute;
+        top: 16px;
+        left: 16px;
+        padding: 10px 14px;
+        border-radius: 12px;
+        background: rgba(5, 18, 30, 0.72);
+        color: rgba(230, 244, 250, 0.88);
+        font-size: 14px;
+        letter-spacing: 0.6px;
+        text-transform: uppercase;
+        backdrop-filter: blur(12px);
+        box-shadow: 0 10px 30px rgba(3, 15, 26, 0.45);
+        z-index: 900;
+      }
+      .radar-status__pulse {
+        display: inline-block;
+        width: 10px;
+        height: 10px;
+        margin-right: 8px;
+        border-radius: 50%;
+        background: rgba(80, 255, 220, 0.9);
+        box-shadow: 0 0 0 rgba(80, 255, 220, 0.5);
+        animation: radarPulse 2.4s infinite;
+        vertical-align: middle;
+      }
+      @keyframes radarPulse {
+        0% {
+          box-shadow: 0 0 0 0 rgba(80, 255, 220, 0.6);
+        }
+        70% {
+          box-shadow: 0 0 0 14px rgba(80, 255, 220, 0);
+        }
+        100% {
+          box-shadow: 0 0 0 0 rgba(80, 255, 220, 0);
+        }
+      }
+    </style>
+    <script defer src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+    <script defer src="map_defaults.js"></script>
+  </head>
+  <body>
+    <div id="map" role="presentation" aria-hidden="true"></div>
+    <canvas id="radarCanvas" aria-hidden="true"></canvas>
+    <div class="radar-status" aria-live="polite"><span class="radar-status__pulse"></span>Radar Sweep Active</div>
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        'use strict';
+
+        const MAP_DEFAULTS = (typeof window !== 'undefined' && window.HeadwayMapDefaults) || { center: [38.03799212281404, -78.50981502838886], zoom: 15 };
+        const CENTER = Array.isArray(MAP_DEFAULTS.center) && MAP_DEFAULTS.center.length === 2
+          ? [Number(MAP_DEFAULTS.center[0]), Number(MAP_DEFAULTS.center[1])]
+          : [38.03799212281404, -78.50981502838886];
+        const ZOOM = Number.isFinite(Number(MAP_DEFAULTS.zoom)) ? Number(MAP_DEFAULTS.zoom) : 15;
+        const REFRESH_INTERVAL_MS = 5000;
+        const SWEEP_SPEED_DEG_PER_SEC = 60;
+        const RING_COUNT = 4;
+        const RING_ALPHA_BASE = 0.14;
+        const SWEEP_TAIL_DEG = 18;
+        const MARKER_PANE_NAME = 'radar-markers';
+        const BUS_MARKER_WIDTH = 36;
+        const BUS_MARKER_HEIGHT = 59;
+        const BUS_MARKER_ANCHOR = [18.0034, 29.4966];
+        const DEFAULT_ROUTE_COLOR = '#4bf5ce';
+
+        const map = L.map('map', {
+          zoomControl: true,
+          attributionControl: true,
+          preferCanvas: false,
+          worldCopyJump: false,
+        }).setView(CENTER, ZOOM);
+
+        L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}{r}.png', {
+          subdomains: 'abcd',
+          maxZoom: 19,
+          attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+        }).addTo(map);
+
+        map.createPane(MARKER_PANE_NAME);
+        const markerPane = map.getPane(MARKER_PANE_NAME);
+        if (markerPane) {
+          markerPane.style.zIndex = 480;
+        }
+
+        const canvas = document.getElementById('radarCanvas');
+        const ctx = canvas.getContext('2d');
+        const radarAudio = new Audio('radar.wav');
+        radarAudio.preload = 'auto';
+        let audioUnlocked = false;
+
+        const ensureAudioUnlocked = () => {
+          if (audioUnlocked) {
+            return;
+          }
+          const unlock = () => {
+            radarAudio.play().then(() => {
+              radarAudio.pause();
+              radarAudio.currentTime = 0;
+              audioUnlocked = true;
+            }).catch(() => {}).finally(() => {
+              document.removeEventListener('pointerdown', unlock);
+              document.removeEventListener('keydown', unlock);
+            });
+          };
+          document.addEventListener('pointerdown', unlock, { once: true });
+          document.addEventListener('keydown', unlock, { once: true });
+        };
+
+        ensureAudioUnlocked();
+
+        const iconCache = new Map();
+        const markerStates = new Map();
+        const pendingUpdates = new Map();
+        const latestFetchSeen = new Set();
+        const routeColors = new Map();
+        let busMarkerSvgText = null;
+        let busMarkerSvgPromise = null;
+        let fetchTimeout = null;
+        let mapCenter = map.getCenter();
+        let centerPoint = map.latLngToContainerPoint(mapCenter);
+        let devicePixelRatioCache = window.devicePixelRatio || 1;
+
+        const fallbackIcon = L.divIcon({
+          className: 'radar-bus-fallback',
+          iconSize: [16, 16],
+          iconAnchor: [8, 8],
+          popupAnchor: [0, -8],
+        });
+
+        function requestBusMarkerSvg() {
+          if (busMarkerSvgPromise) {
+            return busMarkerSvgPromise;
+          }
+          busMarkerSvgPromise = fetch('busmarker.svg', { cache: 'no-store' })
+            .then(response => {
+              if (!response.ok) {
+                throw new Error(`HTTP ${response.status}`);
+              }
+              return response.text();
+            })
+            .then(text => {
+              busMarkerSvgText = text;
+              return text;
+            })
+            .catch(error => {
+              console.error('Radar page failed to load bus marker SVG:', error);
+              busMarkerSvgText = null;
+              busMarkerSvgPromise = null;
+              throw error;
+            });
+          return busMarkerSvgPromise;
+        }
+
+        requestBusMarkerSvg().finally(() => {
+          // Once the SVG is ready, refresh existing icons.
+          if (busMarkerSvgText) {
+            iconCache.clear();
+            markerStates.forEach(state => {
+              state.marker.setIcon(getBusIcon(state.routeColor));
+            });
+          }
+        });
+
+        function normalizeColor(value) {
+          if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (/^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(trimmed)) {
+              return trimmed;
+            }
+            if (/^[0-9a-f]{6}$/i.test(trimmed)) {
+              return `#${trimmed}`;
+            }
+          }
+          return DEFAULT_ROUTE_COLOR;
+        }
+
+        function getBusIcon(routeColor) {
+          const normalized = normalizeColor(routeColor);
+          if (!busMarkerSvgText) {
+            return fallbackIcon;
+          }
+          const key = normalized.toLowerCase();
+          if (iconCache.has(key)) {
+            return iconCache.get(key);
+          }
+          const template = document.createElement('template');
+          template.innerHTML = busMarkerSvgText.trim();
+          const svg = template.content.firstElementChild;
+          if (!svg) {
+            return fallbackIcon;
+          }
+          const routeShape = svg.querySelector('#route_color');
+          if (routeShape) {
+            routeShape.setAttribute('fill', normalized);
+            if (routeShape.style && typeof routeShape.style.setProperty === 'function') {
+              routeShape.style.setProperty('fill', normalized);
+            }
+          }
+          svg.setAttribute('aria-hidden', 'true');
+          const container = document.createElement('div');
+          container.className = 'radar-bus-icon';
+          container.dataset.routeColor = normalized;
+          const svgWrapper = document.createElement('div');
+          svgWrapper.className = 'radar-bus-icon__svg';
+          svgWrapper.appendChild(svg);
+          container.appendChild(svgWrapper);
+          const icon = L.divIcon({
+            className: 'radar-bus-marker-wrapper',
+            html: container.outerHTML,
+            iconSize: [BUS_MARKER_WIDTH, BUS_MARKER_HEIGHT],
+            iconAnchor: BUS_MARKER_ANCHOR,
+            popupAnchor: [0, -BUS_MARKER_HEIGHT / 2],
+          });
+          iconCache.set(key, icon);
+          return icon;
+        }
+
+        function resizeCanvas() {
+          const size = map.getSize();
+          const dpr = window.devicePixelRatio || 1;
+          if (canvas.width !== size.x * dpr || canvas.height !== size.y * dpr) {
+            canvas.width = size.x * dpr;
+            canvas.height = size.y * dpr;
+            canvas.style.width = `${size.x}px`;
+            canvas.style.height = `${size.y}px`;
+            if (ctx) {
+              ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+            }
+          }
+          devicePixelRatioCache = dpr;
+          centerPoint = map.latLngToContainerPoint(mapCenter);
+        }
+
+        function updateCenterPoint() {
+          mapCenter = map.getCenter();
+          centerPoint = map.latLngToContainerPoint(mapCenter);
+        }
+
+        resizeCanvas();
+        updateCenterPoint();
+        window.addEventListener('resize', resizeCanvas);
+        map.on('resize', resizeCanvas);
+        map.on('move', () => {
+          updateCenterPoint();
+          pendingUpdates.forEach(update => {
+            update.bearing = computeBearing(update.lat, update.lon);
+          });
+        });
+        map.on('zoom', () => {
+          resizeCanvas();
+          updateCenterPoint();
+          pendingUpdates.forEach(update => {
+            update.bearing = computeBearing(update.lat, update.lon);
+          });
+        });
+
+        function toRadians(value) {
+          return value * Math.PI / 180;
+        }
+
+        function computeBearing(lat, lon) {
+          const lat1 = toRadians(mapCenter.lat);
+          const lat2 = toRadians(lat);
+          const dLon = toRadians(lon - mapCenter.lng);
+          const y = Math.sin(dLon) * Math.cos(lat2);
+          const x = Math.cos(lat1) * Math.sin(lat2) - Math.sin(lat1) * Math.cos(lat2) * Math.cos(dLon);
+          const brng = Math.atan2(y, x);
+          const deg = (brng * 180 / Math.PI + 360) % 360;
+          return deg;
+        }
+
+        function hasAngleCrossed(startAngle, endAngle, targetAngle) {
+          if (startAngle === endAngle) {
+            return false;
+          }
+          const normStart = (startAngle + 360) % 360;
+          const normEnd = (endAngle + 360) % 360;
+          const normTarget = (targetAngle + 360) % 360;
+          if (normStart < normEnd) {
+            return normTarget > normStart && normTarget <= normEnd;
+          }
+          return normTarget > normStart || normTarget <= normEnd;
+        }
+
+        function scheduleNextFetch() {
+          if (fetchTimeout) {
+            window.clearTimeout(fetchTimeout);
+          }
+          fetchTimeout = window.setTimeout(fetchVehicles, REFRESH_INTERVAL_MS);
+        }
+
+        async function fetchVehicles() {
+          const fetchStartedAt = Date.now();
+          try {
+            const response = await fetch('/v1/testmap/transloc', { cache: 'no-store' });
+            if (!response.ok) {
+              throw new Error(`HTTP ${response.status}`);
+            }
+            const payload = await response.json();
+            latestFetchSeen.clear();
+            routeColors.clear();
+            if (Array.isArray(payload?.routes)) {
+              payload.routes.forEach(route => {
+                const rid = route?.RouteID ?? route?.routeID ?? route?.RouteId ?? route?.id;
+                const color = normalizeColor(route?.Color ?? route?.color ?? route?.RouteColor);
+                if (rid !== undefined && rid !== null) {
+                  routeColors.set(String(rid), color);
+                }
+              });
+            }
+            if (Array.isArray(payload?.vehicles)) {
+              payload.vehicles.forEach(vehicle => {
+                const rawId = vehicle?.VehicleID ?? vehicle?.VehicleId ?? vehicle?.VehicleId ?? vehicle?.id;
+                if (rawId === null || rawId === undefined) {
+                  return;
+                }
+                const vehicleId = String(rawId);
+                const lat = Number(vehicle?.Latitude ?? vehicle?.Lat ?? vehicle?.latitude);
+                const lon = Number(vehicle?.Longitude ?? vehicle?.Lon ?? vehicle?.Lng ?? vehicle?.longitude);
+                if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+                  return;
+                }
+                const routeId = vehicle?.RouteID ?? vehicle?.RouteId ?? vehicle?.routeID;
+                const color = routeId !== undefined && routeId !== null
+                  ? routeColors.get(String(routeId)) || DEFAULT_ROUTE_COLOR
+                  : DEFAULT_ROUTE_COLOR;
+                latestFetchSeen.add(vehicleId);
+                const pending = pendingUpdates.get(vehicleId);
+                const existingState = markerStates.get(vehicleId);
+                const prevLat = pending?.lat ?? existingState?.lat;
+                const prevLon = pending?.lon ?? existingState?.lon;
+                if (Number.isFinite(prevLat) && Number.isFinite(prevLon)) {
+                  const latDiff = Math.abs(prevLat - lat);
+                  const lonDiff = Math.abs(prevLon - lon);
+                  if (latDiff < 1e-5 && lonDiff < 1e-5) {
+                    return;
+                  }
+                }
+                const bearing = computeBearing(lat, lon);
+                pendingUpdates.set(vehicleId, {
+                  id: vehicleId,
+                  lat,
+                  lon,
+                  routeColor: color,
+                  bearing,
+                  updatedAt: fetchStartedAt,
+                });
+              });
+            }
+            markerStates.forEach((state, id) => {
+              if (latestFetchSeen.has(id)) {
+                state.lastSeenAt = fetchStartedAt;
+              }
+            });
+          } catch (error) {
+            console.error('Radar page failed to fetch vehicle data:', error);
+          } finally {
+            scheduleNextFetch();
+          }
+        }
+
+        function playRadarSound() {
+          if (!audioUnlocked) {
+            return;
+          }
+          try {
+            const clone = radarAudio.cloneNode();
+            clone.volume = 0.9;
+            clone.play().catch(() => {});
+          } catch (error) {
+            console.warn('Radar audio playback failed:', error);
+          }
+        }
+
+        let absoluteSweepAngle = 0;
+        let lastFrameTime = null;
+
+        function applyPendingUpdates(startAngle, endAngle, deltaAngle) {
+          const passedFullRotation = deltaAngle >= 360;
+          pendingUpdates.forEach((update, id) => {
+            const bearing = Number.isFinite(update.bearing) ? update.bearing : computeBearing(update.lat, update.lon);
+            if (!passedFullRotation && !hasAngleCrossed(startAngle, endAngle, bearing)) {
+              return;
+            }
+            let state = markerStates.get(id);
+            if (!state) {
+              const marker = L.marker([update.lat, update.lon], {
+                icon: getBusIcon(update.routeColor),
+                pane: MARKER_PANE_NAME,
+                opacity: 0,
+              }).addTo(map);
+              state = {
+                marker,
+                lat: update.lat,
+                lon: update.lon,
+                routeColor: update.routeColor,
+                lastUpdateAbsAngle: absoluteSweepAngle,
+                lastSeenAt: update.updatedAt,
+              };
+              markerStates.set(id, state);
+            } else {
+              state.marker.setLatLng([update.lat, update.lon]);
+              state.lat = update.lat;
+              state.lon = update.lon;
+              if (update.routeColor !== state.routeColor) {
+                state.routeColor = update.routeColor;
+                state.marker.setIcon(getBusIcon(update.routeColor));
+              }
+            }
+            state.marker.setOpacity(1);
+            state.lastUpdateAbsAngle = absoluteSweepAngle;
+            state.lastSeenAt = update.updatedAt;
+            pendingUpdates.delete(id);
+            playRadarSound();
+          });
+        }
+
+        function updateMarkerOpacity() {
+          markerStates.forEach((state, id) => {
+            const delta = absoluteSweepAngle - state.lastUpdateAbsAngle;
+            if (!Number.isFinite(delta) || delta < 0) {
+              return;
+            }
+            const progress = Math.min(delta / 360, 1);
+            const opacity = Math.max(1 - progress, 0);
+            state.marker.setOpacity(opacity);
+            if (opacity <= 0 && !pendingUpdates.has(id)) {
+              const unseenFor = Date.now() - (state.lastSeenAt || 0);
+              if (!latestFetchSeen.has(id) && unseenFor > 60000) {
+                map.removeLayer(state.marker);
+                markerStates.delete(id);
+              }
+            }
+          });
+        }
+
+        function drawRadar(angle) {
+          if (!ctx) {
+            return;
+          }
+          const width = canvas.width / devicePixelRatioCache;
+          const height = canvas.height / devicePixelRatioCache;
+          ctx.clearRect(0, 0, width, height);
+          const maxRadius = Math.min(width, height) * 0.45;
+          ctx.save();
+          ctx.translate(centerPoint.x, centerPoint.y);
+          ctx.lineWidth = 1.2;
+          for (let i = 1; i <= RING_COUNT; i += 1) {
+            ctx.beginPath();
+            const ringRadius = maxRadius * (i / RING_COUNT);
+            ctx.strokeStyle = `rgba(80, 255, 220, ${(RING_ALPHA_BASE * i).toFixed(3)})`;
+            ctx.arc(0, 0, ringRadius, 0, Math.PI * 2);
+            ctx.stroke();
+          }
+          const sweepAngleRad = (angle - 90) * Math.PI / 180;
+          const tailRad = SWEEP_TAIL_DEG * Math.PI / 180;
+          const gradient = ctx.createRadialGradient(0, 0, 0, 0, 0, maxRadius);
+          gradient.addColorStop(0, 'rgba(80, 255, 220, 0.18)');
+          gradient.addColorStop(1, 'rgba(80, 255, 220, 0)');
+          ctx.fillStyle = gradient;
+          ctx.beginPath();
+          ctx.moveTo(0, 0);
+          ctx.arc(0, 0, maxRadius, sweepAngleRad - tailRad, sweepAngleRad, false);
+          ctx.closePath();
+          ctx.fill();
+          ctx.beginPath();
+          ctx.strokeStyle = 'rgba(120, 255, 220, 0.85)';
+          ctx.lineWidth = 2.2;
+          ctx.moveTo(0, 0);
+          ctx.lineTo(Math.cos(sweepAngleRad) * maxRadius, Math.sin(sweepAngleRad) * maxRadius);
+          ctx.stroke();
+          ctx.restore();
+        }
+
+        function animationStep(timestamp) {
+          if (lastFrameTime === null) {
+            lastFrameTime = timestamp;
+          }
+          const deltaMs = Math.min(1000, Math.max(0, timestamp - lastFrameTime));
+          lastFrameTime = timestamp;
+          const deltaAngle = (deltaMs / 1000) * SWEEP_SPEED_DEG_PER_SEC;
+          const previousAngle = ((absoluteSweepAngle % 360) + 360) % 360;
+          absoluteSweepAngle += deltaAngle;
+          const currentAngle = ((absoluteSweepAngle % 360) + 360) % 360;
+          applyPendingUpdates(previousAngle, currentAngle, deltaAngle);
+          updateMarkerOpacity();
+          drawRadar(currentAngle);
+          window.requestAnimationFrame(animationStep);
+        }
+
+        fetchVehicles();
+        window.requestAnimationFrame(animationStep);
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a shared map_defaults.js helper so templates can reuse the standard center and zoom
- include the helper on the kiosk map and introduce a radar.html page with a sweeping overlay, marker fades, and audio pings
- expose the new assets through FastAPI routes, including a /radar endpoint that renders the radar view

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68dcadadadd083339c4708443829d241