### PR TITLE
Fix radar radar sweep markers not refreshing

### DIFF
--- a/radar.html
+++ b/radar.html
@@ -799,15 +799,6 @@
                 latestFetchSeen.add(vehicleId);
                 const pending = pendingUpdates.get(vehicleId);
                 const existingState = markerStates.get(vehicleId);
-                const prevLat = pending?.lat ?? existingState?.lat;
-                const prevLon = pending?.lon ?? existingState?.lon;
-                if (Number.isFinite(prevLat) && Number.isFinite(prevLon)) {
-                  const latDiff = Math.abs(prevLat - lat);
-                  const lonDiff = Math.abs(prevLon - lon);
-                  if (latDiff < 1e-5 && lonDiff < 1e-5) {
-                    return;
-                  }
-                }
                 const bearing = computeBearing(lat, lon);
                 pendingUpdates.set(vehicleId, {
                   id: vehicleId,


### PR DESCRIPTION
## Summary
- allow stationary vehicle updates to be re-queued during each fetch so the radar sweep keeps showing them

## Testing
- not run (HTML-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dcba0089308333a5292cfee7037bca