### PR TITLE
Switch cyberpunk dispatcher map to radar

### DIFF
--- a/dispatcher.html
+++ b/dispatcher.html
@@ -147,6 +147,12 @@ const STATUS_LABELS = {DOWNED:'Downed',LIMITED:'Limited',COSMETIC:'Cosmetic',COM
 
 const CYBERPUNK_ENABLED = new URLSearchParams(window.location.search).get('cyberpunk') === 'true';
 if (CYBERPUNK_ENABLED) {
+  const mapFrame = document.getElementById('map-frame');
+  if (mapFrame) {
+    const url = new URL(mapFrame.getAttribute('src'), window.location.origin);
+    url.pathname = '/radar';
+    mapFrame.src = url.pathname + url.search;
+  }
   activateCyberpunkMode();
 }
 


### PR DESCRIPTION
## Summary
- update the dispatcher cyberpunk mode to load the radar view instead of the testmap embed
- preserve the dispatcher query string when switching the iframe source

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dcbc0744548333987ecaba9e054825