### PR TITLE
Adjust dispatcher kiosk layout for kiosk mode

### DIFF
--- a/dispatcher.html
+++ b/dispatcher.html
@@ -48,8 +48,9 @@ body.kiosk-mode #layout aside{border-left:none;padding:12px;display:grid;grid-te
 body.kiosk-mode #layout aside .panel{margin:0;display:flex;flex-direction:column;min-height:0;background:#0f141c;border:1px solid #1f2630;border-radius:10px;padding:12px}
 body.kiosk-mode #layout aside .panel h2{margin:0 0 8px;font-size:16px}
 body.kiosk-mode #layout aside .panel .panel-body{flex:1;min-height:0;display:flex;flex-direction:column;overflow:hidden}
-body.kiosk-mode #layout aside .panel .panel-body table{flex:1;overflow:auto}
-body.kiosk-mode #layout aside .panel .panel-body ul{flex:1;overflow:auto;margin:0}
+body.kiosk-mode #layout aside .panel .panel-body table{flex:1;overflow:auto;width:100%}
+body.kiosk-mode #layout aside .panel .panel-body ul{flex:1;overflow:auto;margin:0;width:100%}
+body.kiosk-mode #blocks-table,body.kiosk-mode #future-blocks-table,body.kiosk-mode #downed-table{width:100%}
 body.kiosk-mode #extra-buses{grid-template-columns:repeat(auto-fill,minmax(8ch,1fr));gap:6px}
 body.kiosk-mode iframe#map-frame{flex:1.1;border-left:1px solid #1f2630}
 body.kiosk-mode .credit{margin-top:auto;padding:8px 12px}
@@ -273,6 +274,7 @@ const STATUS_LABELS = {DOWNED:'Downed',LIMITED:'Limited',COSMETIC:'Cosmetic',COM
 const urlParams = new URLSearchParams(window.location.search);
 const CYBERPUNK_ENABLED = urlParams.get('cyberpunk') === 'true';
 const KIOSK_MODE = urlParams.has('kioskMode');
+const DOWNED_TABLE_COLSPAN = KIOSK_MODE ? 3 : 4;
 if (KIOSK_MODE) {
   document.body.classList.add('kiosk-mode');
 }
@@ -284,6 +286,19 @@ if (CYBERPUNK_ENABLED) {
     mapFrame.src = url.pathname + url.search;
   }
   activateCyberpunkMode();
+}
+
+if (KIOSK_MODE) {
+  const downedTable = document.getElementById('downed-table');
+  if (downedTable) {
+    const notesHeader = downedTable.querySelector('thead th:nth-child(3)');
+    if (notesHeader) {
+      notesHeader.remove();
+    }
+    downedTable.querySelectorAll('tbody td[colspan]').forEach(cell => {
+      cell.colSpan = DOWNED_TABLE_COLSPAN;
+    });
+  }
 }
 
 function normalizeHeaderText(value){
@@ -1024,7 +1039,7 @@ function renderDownedVehicles(rows){
   refreshDownedBusSets(rows);
   updateExtraBuses();
   if(!rows.length){
-    tbody.innerHTML='<tr><td class="hint" colspan="4">All buses available.</td></tr>';
+    tbody.innerHTML=`<tr><td class="hint" colspan="${DOWNED_TABLE_COLSPAN}">All buses available.</td></tr>`;
     return;
   }
   tbody.innerHTML=rows.map(row=>{
@@ -1047,12 +1062,15 @@ function renderDownedVehicles(rows){
       row.shopActualDeliveryText?`<div><strong>Delivery:</strong> ${htmlEscape(row.shopActualDeliveryText)}</div>`:''
     ].filter(Boolean);
     if(!shopParts.length) shopParts.push('<div class="hint">No shop updates yet.</div>');
-    return '<tr>'
-      +`<td class="mono">${htmlEscape(row.vehicleId)}</td>`
-      +`<td>${opsParts||'<span class="hint">—</span>'}</td>`
-      +`<td>${notes}</td>`
-      +`<td>${shopParts.join('')}</td>`
-      +'</tr>';
+    const cells=[
+      `<td class="mono">${htmlEscape(row.vehicleId)}</td>`,
+      `<td>${opsParts||'<span class="hint">—</span>'}</td>`
+    ];
+    if(!KIOSK_MODE){
+      cells.push(`<td>${notes}</td>`);
+    }
+    cells.push(`<td>${shopParts.join('')}</td>`);
+    return `<tr>${cells.join('')}</tr>`;
   }).join('');
 }
 
@@ -1068,7 +1086,7 @@ async function loadDownedBuses(){
     renderDownedVehicles(downed);
   }catch(err){
     if(!lastDownedRows.length){
-      tbody.innerHTML='<tr><td class="hint" colspan="4">Unable to load.</td></tr>';
+      tbody.innerHTML=`<tr><td class="hint" colspan="${DOWNED_TABLE_COLSPAN}">Unable to load.</td></tr>`;
     }
     console.error('Failed to load downed buses sheet', err);
   }


### PR DESCRIPTION
## Summary
- ensure dispatcher kiosk panels keep consistent widths by letting their tables and lists fill the card
- hide the downed bus notes column when kiosk mode is enabled and update placeholder messaging to match the new column count

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de0e3f58ac83339e12176a579409f8