### PR TITLE
Align kiosk mode entry spacing

### DIFF
--- a/dispatcher.html
+++ b/dispatcher.html
@@ -36,7 +36,7 @@ body.cyberpunk .mono{font-family:'Courier Prime','Fira Code','Source Code Pro','
 h2{font-size:18px;margin:16px 0 0}
 #layout{display:flex}
 aside .panel+.panel{margin-top:16px}
-body.kiosk-mode{font-size:16px}
+body.kiosk-mode{font-size:16px;--kiosk-entry-height:2rem;--kiosk-entry-padding:4px}
 body.kiosk-mode header{padding:10px 12px}
 body.kiosk-mode #controls{flex-wrap:wrap;padding-right:0}
 body.kiosk-mode #controls label{flex:1 1 140px}
@@ -52,11 +52,12 @@ body.kiosk-mode #layout aside .panel .panel-body table{flex:1;overflow:auto;widt
 body.kiosk-mode #layout aside .panel .panel-body ul{flex:1;overflow:auto;margin:0;width:100%}
 body.kiosk-mode #blocks-table,body.kiosk-mode #future-blocks-table,body.kiosk-mode #downed-table{width:100%;table-layout:fixed}
 body.kiosk-mode #blocks td,body.kiosk-mode #future-blocks td{width:25%}
-body.kiosk-mode #blocks td .cell,body.kiosk-mode #future-blocks td .cell{min-height:3.2rem}
-body.kiosk-mode #extra-buses{grid-template-columns:repeat(auto-fill,minmax(8ch,1fr));grid-auto-rows:minmax(2.8rem,auto);gap:6px}
-body.kiosk-mode #extra-buses li{display:flex;align-items:center;justify-content:center;min-height:2.8rem}
+body.kiosk-mode #blocks td .cell,body.kiosk-mode #future-blocks td .cell{min-height:var(--kiosk-entry-height);padding:var(--kiosk-entry-padding) 0;gap:2px}
+body.kiosk-mode #extra-buses{grid-template-columns:repeat(auto-fill,minmax(8ch,1fr));grid-auto-rows:var(--kiosk-entry-height);gap:6px}
+body.kiosk-mode #extra-buses li{display:flex;align-items:center;justify-content:center;min-height:var(--kiosk-entry-height);padding:0 var(--kiosk-entry-padding)}
 body.kiosk-mode #downed-table th,body.kiosk-mode #downed-table td{width:50%}
-body.kiosk-mode #downed-table tbody td{padding:10px;min-height:2.8rem}
+body.kiosk-mode #downed-table tbody tr{height:var(--kiosk-entry-height)}
+body.kiosk-mode #downed-table tbody td{padding:var(--kiosk-entry-padding);line-height:1.1}
 body.kiosk-mode iframe#map-frame{flex:1.1;border-left:1px solid #1f2630}
 body.kiosk-mode .credit{margin-top:auto;padding:8px 12px}
 body.cyberpunk.kiosk-mode #layout aside .panel{background:rgba(3,18,28,.92);border-color:rgba(117,247,255,.35);box-shadow:0 0 18px rgba(0,255,255,.18)}


### PR DESCRIPTION
## Summary
- ensure kiosk mode bus panels share a consistent row height via shared CSS variables
- apply the same spacing rules to tables and the extra buses grid so up to 35 buses fit simultaneously

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de1540a0008333abd8136816be4b97