### PR TITLE
Adjust dispatcher kiosk layout cell sizing

### DIFF
--- a/dispatcher.html
+++ b/dispatcher.html
@@ -13,15 +13,15 @@ header h1{flex-basis:100%}
 select{background:#10151c;color:#e8eef5;border:1px solid #2a3442;border-radius:10px;padding:8px 10px}
 .chip{display:inline-block;border:1px solid #2a3442;border-radius:999px;padding:2px 8px;margin-left:8px;color:#cfe1ff}
 table{width:100%;border-collapse:collapse;margin-top:8px}
-th,td{border-bottom:1px solid #1f2630;padding:10px;text-align:left}
+th,td{border-bottom:1px solid #1f2630;padding:8px 10px;text-align:left}
 #downed-table td{vertical-align:top}
-#blocks-table,#future-blocks-table{width:auto}
-#blocks td,#future-blocks td{border:none;padding:2px 4px;text-align:center;width:14ch;height:2.6em}
-#blocks td .cell,#future-blocks td .cell{border-radius:4px;background:var(--route-color,transparent);color:var(--text-color,#e8eef5);display:flex;flex-direction:column;justify-content:center;align-items:center;width:100%;height:100%}
-#extra-buses{list-style:none;padding:0;margin:0;display:grid;grid-template-columns:repeat(auto-fill,minmax(6ch,1fr));gap:4px}
+#blocks-table,#future-blocks-table{width:auto;table-layout:fixed}
+#blocks td,#future-blocks td{border:none;padding:2px 4px;text-align:center;width:12ch}
+#blocks td .cell,#future-blocks td .cell{border-radius:4px;background:var(--route-color,transparent);color:var(--text-color,#e8eef5);display:flex;flex-direction:column;justify-content:center;align-items:center;width:100%;min-height:2.6em;max-height:2.6em;padding:2px 0;line-height:1.15}
+#extra-buses{list-style:none;padding:0;margin:0;display:grid;grid-template-columns:repeat(auto-fill,minmax(10ch,1fr));gap:4px}
 .panel-body{position:relative}
-#extra-buses li{background:#10151c;border:1px solid #2a3442;border-radius:4px;padding:4px;text-align:center}
-#extra-buses .hint{background:none;border:none;padding:0;grid-column:1/-1;text-align:left}
+#extra-buses li{background:#10151c;border:1px solid #2a3442;border-radius:4px;padding:4px 6px;text-align:center;line-height:1.15;display:flex;align-items:center;justify-content:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;min-height:calc(1.2em + 8px)}
+#extra-buses .hint{background:none;border:none;padding:0;grid-column:1/-1;text-align:left;display:block;white-space:normal;overflow:visible;text-overflow:clip;min-height:auto;line-height:inherit}
 .mono{font-family:FGDC,ui-monospace,Menlo,Consolas,monospace}
 body.cyberpunk .mono{font-family:'Courier Prime','Fira Code','Source Code Pro','IBM Plex Mono','Lucida Console','Courier New',monospace}
 .pill{display:inline-flex;gap:8px;align-items:center;border:1px solid #2a3442;border-radius:999px;padding:4px 8px;background:#10151c}
@@ -36,7 +36,7 @@ body.cyberpunk .mono{font-family:'Courier Prime','Fira Code','Source Code Pro','
 h2{font-size:18px;margin:16px 0 0}
 #layout{display:flex}
 aside .panel+.panel{margin-top:16px}
-body.kiosk-mode{font-size:16px;--kiosk-entry-height:2rem;--kiosk-entry-padding:4px}
+body.kiosk-mode{font-size:16px;--kiosk-block-height:2.6em;--kiosk-entry-padding:4px}
 body.kiosk-mode header{padding:10px 12px}
 body.kiosk-mode #controls{flex-wrap:wrap;padding-right:0}
 body.kiosk-mode #controls label{flex:1 1 140px}
@@ -51,13 +51,13 @@ body.kiosk-mode #layout aside .panel .panel-body{flex:1;min-height:0;display:fle
 body.kiosk-mode #layout aside .panel .panel-body table{flex:1;overflow:auto;width:100%}
 body.kiosk-mode #layout aside .panel .panel-body ul{flex:1;overflow:auto;margin:0;width:100%}
 body.kiosk-mode #blocks-table,body.kiosk-mode #future-blocks-table,body.kiosk-mode #downed-table{width:100%;table-layout:fixed}
-body.kiosk-mode #blocks td,body.kiosk-mode #future-blocks td{width:25%}
-body.kiosk-mode #blocks td .cell,body.kiosk-mode #future-blocks td .cell{min-height:var(--kiosk-entry-height);padding:var(--kiosk-entry-padding) 0;gap:2px}
-body.kiosk-mode #extra-buses{grid-template-columns:repeat(auto-fill,minmax(8ch,1fr));grid-auto-rows:var(--kiosk-entry-height);gap:6px}
-body.kiosk-mode #extra-buses li{display:flex;align-items:center;justify-content:center;min-height:var(--kiosk-entry-height);padding:0 var(--kiosk-entry-padding)}
+body.kiosk-mode #blocks td,body.kiosk-mode #future-blocks td{width:clamp(11ch,25%,14ch)}
+body.kiosk-mode #blocks td .cell,body.kiosk-mode #future-blocks td .cell{min-height:var(--kiosk-block-height);max-height:var(--kiosk-block-height);padding:var(--kiosk-entry-padding) 0;gap:2px}
+body.kiosk-mode #extra-buses{grid-template-columns:repeat(auto-fill,minmax(11ch,1fr));grid-auto-rows:auto;gap:6px}
+body.kiosk-mode #extra-buses li{display:flex;align-items:center;justify-content:center;min-height:calc(1.2em + 2*var(--kiosk-entry-padding));padding:var(--kiosk-entry-padding) calc(var(--kiosk-entry-padding)*1.5)}
 body.kiosk-mode #downed-table th,body.kiosk-mode #downed-table td{width:50%}
-body.kiosk-mode #downed-table tbody tr{height:var(--kiosk-entry-height)}
-body.kiosk-mode #downed-table tbody td{padding:var(--kiosk-entry-padding);line-height:1.1}
+body.kiosk-mode #downed-table tbody tr{height:auto}
+body.kiosk-mode #downed-table tbody td{padding:var(--kiosk-entry-padding) calc(var(--kiosk-entry-padding)*1.5);line-height:1.1}
 body.kiosk-mode iframe#map-frame{flex:1.1;border-left:1px solid #1f2630}
 body.kiosk-mode .credit{margin-top:auto;padding:8px 12px}
 body.cyberpunk.kiosk-mode #layout aside .panel{background:rgba(3,18,28,.92);border-color:rgba(117,247,255,.35);box-shadow:0 0 18px rgba(0,255,255,.18)}


### PR DESCRIPTION
## Summary
- right-size dispatcher block assignment cells so two-line entries fit without oversized columns
- keep extra bus tiles to a single line and let downed bus rows shrink to their content in kiosk mode

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68deb8395d808333a86e29b222b0c445