### PR TITLE
Add standalone e-ink block assignment display

### DIFF
--- a/eink-block.html
+++ b/eink-block.html
@@ -1,0 +1,168 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>E-ink Block Display</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  :root{
+    color-scheme: only light;
+  }
+  *{box-sizing:border-box;}
+  body{
+    margin:0;
+    width:250px;
+    height:122px;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    background:#fff;
+    color:#000;
+    font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;
+  }
+  main{
+    width:100%;
+    height:100%;
+    display:flex;
+    flex-direction:column;
+    align-items:center;
+    justify-content:center;
+    padding:6px;
+    gap:4px;
+  }
+  #bus{
+    font-size:62px;
+    font-weight:600;
+    letter-spacing:1px;
+    line-height:1;
+  }
+  #status{
+    font-size:14px;
+    letter-spacing:0.06em;
+    text-transform:uppercase;
+  }
+</style>
+<main>
+  <div id="bus">--</div>
+  <div id="status"></div>
+</main>
+<script>
+(function(){
+  const params=new URLSearchParams(location.search);
+  let block=params.get('block');
+  const period=(params.get('period')||'').trim().toLowerCase();
+  const statusEl=document.getElementById('status');
+  const busEl=document.getElementById('bus');
+
+  if(!block){
+    statusEl.textContent='Missing block';
+    busEl.textContent='--';
+    return;
+  }
+  block=String(block).trim();
+  if(!/^\d{2}$/.test(block)){
+    statusEl.textContent='Invalid block';
+    busEl.textContent='--';
+    return;
+  }
+
+  const periodSuffix=period==='am'||period==='pm'?period:'';
+  const key = periodSuffix ? `${block}_${periodSuffix}` : block;
+  const blockLabel = periodSuffix ? `${block} ${periodSuffix.toUpperCase()}` : block;
+  document.title = `Block ${blockLabel}`;
+
+  const BLOCK_KEYS={
+    '01':['[01]','[01]/[04]'],
+    '02':['[02]'],
+    '03':['[03]','[05]/[03]'],
+    '04':['[04]','[01]/[04]'],
+    '05':['[05]','[05]/[03]'],
+    '06':['[06]','[22]/[06]'],
+    '07':['[07]'],
+    '08':['[08]'],
+    '09':['[09]'],
+    '10':['[10]','[20]/[10]'],
+    '11':['[11]'],
+    '12':['[12]'],
+    '13':['[13]'],
+    '14':['[14]'],
+    '15':['[15]','[26]/[15]'],
+    '16_am':['[16] AM','[21]/[16] AM'],
+    '16_pm':['[16] PM'],
+    '17':['[17]','[23]/[17]'],
+    '18_am':['[18] AM','[24]/[18] AM'],
+    '18_pm':['[18] PM'],
+    '19':['[19]'],
+    '20_am':['[20] AM','[20]/[10]'],
+    '20_pm':['[20] PM','[20]/[10]'],
+    '21_am':['[21] AM','[21]/[16] AM'],
+    '21_pm':['[21] PM'],
+    '22_am':['[22] AM','[22]/[06]'],
+    '22_pm':['[22] PM'],
+    '23_am':['[23] AM','[23]/[17]'],
+    '23':['[23]','[23]/[17]'],
+    '24_am':['[24] AM','[24]/[18] AM'],
+    '24_pm':['[24] PM'],
+    '25_am':['[25] AM'],
+    '25':['[25]'],
+    '26_am':['[26] AM','[26]/[15]'],
+    '26_pm':['[26] PM','[26]/[15]'],
+    '27':['[27]']
+  };
+
+  function lookupKeys(){
+    const list=BLOCK_KEYS[key];
+    if(list) return list;
+    const defaultKey=periodSuffix?`[${block}] ${periodSuffix.toUpperCase()}`:`[${block}]`;
+    return [defaultKey];
+  }
+
+  async function refresh(){
+    try{
+      statusEl.textContent='';
+      const res=await fetch('/v1/dispatch/blocks');
+      if(!res.ok) throw new Error(res.status+'');
+      const data=await res.json();
+      const groups=data.block_groups||[];
+      const busByBlock=new Map();
+      for(const g of groups){
+        const raw=String(g.BlockGroupId||'').trim();
+        let bus='—';
+        const blocks=Array.isArray(g.Blocks)?g.Blocks:[];
+        for(const b of blocks){
+          const trips=Array.isArray(b.Trips)?b.Trips:[];
+          for(const t of trips){
+            if(t && t.VehicleName){
+              bus=String(t.VehicleName).trim();
+              break;
+            }
+          }
+          if(bus!=='—') break;
+        }
+        if(!busByBlock.has(raw) || busByBlock.get(raw)==='—'){
+          busByBlock.set(raw,bus);
+        }
+      }
+      const wantedKeys=lookupKeys();
+      let found='—';
+      for(const raw of wantedKeys){
+        if(busByBlock.has(raw)){
+          const candidate=busByBlock.get(raw);
+          if(candidate && candidate!=='—'){
+            found=candidate;
+            break;
+          }
+          if(found==='—') found=candidate||'—';
+        }
+      }
+      busEl.textContent=found||'—';
+      statusEl.textContent='';
+    }catch(err){
+      console.error(err);
+      statusEl.textContent='Offline';
+      busEl.textContent='--';
+    }
+  }
+
+  refresh();
+  setInterval(refresh, 30000);
+})();
+</script>


### PR DESCRIPTION
## Summary
- add a minimal `eink-block.html` page sized for the 2.13" e-ink screens
- resolve TransLoc block group aliases (including AM/PM interlined blocks) to display the assigned bus number for a given `?block=`
- poll the existing `/v1/dispatch/blocks` endpoint every 30 seconds and surface offline errors when data cannot be retrieved

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dec5b1bf1883339ccd303e3ce820b2