### PR TITLE
Support AM/PM suffix in block query parameter

### DIFF
--- a/eink-block.html
+++ b/eink-block.html
@@ -48,7 +48,7 @@
 (function(){
   const params=new URLSearchParams(location.search);
   let block=params.get('block');
-  const period=(params.get('period')||'').trim().toLowerCase();
+  const periodParam=(params.get('period')||'').trim().toLowerCase();
   const statusEl=document.getElementById('status');
   const busEl=document.getElementById('bus');
 
@@ -58,13 +58,19 @@
     return;
   }
   block=String(block).trim();
+  let blockPeriod='';
+  const blockMatch=block.match(/^(\d{2})(?:\s*(AM|PM))?$/i);
+  if(blockMatch){
+    block=blockMatch[1];
+    if(blockMatch[2]) blockPeriod=blockMatch[2].toLowerCase();
+  }
   if(!/^\d{2}$/.test(block)){
     statusEl.textContent='Invalid block';
     busEl.textContent='--';
     return;
   }
 
-  const periodSuffix=period==='am'||period==='pm'?period:'';
+  const periodSuffix=blockPeriod||((periodParam==='am'||periodParam==='pm')?periodParam:'');
   const blockLabel = periodSuffix ? `${block} ${periodSuffix.toUpperCase()}` : block;
   document.title = `Block ${blockLabel}`;
 


### PR DESCRIPTION
## Summary
- allow the block query parameter to include an AM/PM suffix
- continue to fall back to the existing period parameter when no suffix is provided

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68decc08e5d483339c55f73ef11c8082