### PR TITLE
Show default grid on e-ink block display

### DIFF
--- a/eink-block.html
+++ b/eink-block.html
@@ -22,10 +22,17 @@
     width:100%;
     height:100%;
     display:flex;
-    flex-direction:column;
     align-items:center;
     justify-content:center;
     padding:6px;
+  }
+  [hidden]{
+    display:none !important;
+  }
+  #block-view{
+    display:flex;
+    flex-direction:column;
+    align-items:center;
     gap:4px;
   }
   #bus{
@@ -39,10 +46,34 @@
     letter-spacing:0.06em;
     text-transform:uppercase;
   }
+  #grid-view{
+    width:100%;
+    height:100%;
+    display:grid;
+    grid-template-columns:repeat(4,1fr);
+    gap:4px;
+    align-content:center;
+    justify-items:center;
+    font-weight:600;
+    font-size:20px;
+  }
+  #grid-view .cell{
+    width:100%;
+    padding:6px 0;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    border:1px solid #000;
+    border-radius:4px;
+    min-height:20px;
+  }
 </style>
 <main>
-  <div id="bus">--</div>
-  <div id="status"></div>
+  <div id="block-view">
+    <div id="bus">--</div>
+    <div id="status"></div>
+  </div>
+  <div id="grid-view" hidden></div>
 </main>
 <script>
 (function(){
@@ -51,12 +82,33 @@
   const periodParam=(params.get('period')||'').trim().toLowerCase();
   const statusEl=document.getElementById('status');
   const busEl=document.getElementById('bus');
+  const blockView=document.getElementById('block-view');
+  const gridView=document.getElementById('grid-view');
 
   if(!block){
-    statusEl.textContent='Missing block';
-    busEl.textContent='--';
+    document.title='Block Grid';
+    blockView.hidden=true;
+    gridView.hidden=false;
+    const columns=[
+      ['01','02','03','04','05','06','07','08','09'],
+      ['10','11','12','13','14','15','16AM','17','18AM'],
+      ['19','20AM','21AM','22AM','23AM','24AM','25AM','26AM','27'],
+      ['', '20PM','21PM','22PM','23PM','24PM','25PM','26PM','27PM']
+    ];
+    gridView.innerHTML='';
+    const rows=9;
+    for(let row=0;row<rows;row++){
+      for(let col=0;col<columns.length;col++){
+        const cell=document.createElement('div');
+        cell.className='cell';
+        cell.textContent=columns[col][row]||'';
+        gridView.appendChild(cell);
+      }
+    }
     return;
   }
+  blockView.hidden=false;
+  gridView.hidden=true;
   block=String(block).trim();
   let blockPeriod='';
   const blockMatch=block.match(/^(\d{2})(?:\s*(AM|PM))?$/i);


### PR DESCRIPTION
## Summary
- show a predefined 4x9 block grid when the e-ink block page loads without a block parameter
- add layout containers and styling so the page can switch between the grid view and the live block view

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68decef78bcc833398ee06194bf6d364