### PR TITLE
Improve e-ink grid layout

### DIFF
--- a/eink-block.html
+++ b/eink-block.html
@@ -18,6 +18,12 @@
     color:#000;
     font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;
   }
+  body.grid-mode{
+    width:auto;
+    min-width:280px;
+    height:auto;
+    padding:12px;
+  }
   main{
     width:100%;
     height:100%;
@@ -25,6 +31,11 @@
     align-items:center;
     justify-content:center;
     padding:6px;
+  }
+  body.grid-mode main{
+    height:auto;
+    justify-content:flex-start;
+    padding:0;
   }
   [hidden]{
     display:none !important;
@@ -50,24 +61,29 @@
     width:100%;
     height:100%;
     display:grid;
-    grid-template-columns:repeat(4,1fr);
-    gap:4px;
-    align-content:center;
-    justify-items:center;
+    grid-template-columns:repeat(4,minmax(0,1fr));
+    grid-template-rows:repeat(9,minmax(0,1fr));
+    gap:6px;
+    align-content:stretch;
+    justify-items:stretch;
     font-weight:600;
     font-size:18px;
   }
+  body.grid-mode #grid-view{
+    max-width:420px;
+    height:auto;
+  }
   #grid-view .cell{
     width:100%;
-    padding:4px 0;
+    padding:6px 4px;
     display:flex;
     flex-direction:column;
     align-items:center;
     justify-content:center;
     border:1px solid #000;
     border-radius:4px;
-    min-height:20px;
-    gap:2px;
+    min-height:32px;
+    gap:4px;
   }
   #grid-view .cell .block-label{
     font-size:14px;
@@ -125,12 +141,14 @@
   }
 
   if(isGridMode){
+    document.body.classList.add('grid-mode');
     document.title='Block Grid';
     blockView.hidden=true;
     gridView.hidden=false;
     buildGrid();
   }
   if(!isGridMode){
+    document.body.classList.remove('grid-mode');
     blockView.hidden=false;
     gridView.hidden=true;
     block=String(block).trim();


### PR DESCRIPTION
## Summary
- adjust the e-ink grid view styling so a 4x9 layout renders with enough space for text
- toggle a grid-mode body class to size the page appropriately when no block is requested

## Testing
- Manual verification via browser screenshot


------
https://chatgpt.com/codex/tasks/task_e_68ded285864c83339515f8c988e17437