### PR TITLE
Refine block period matching for bus selection

### DIFF
--- a/eink-block.html
+++ b/eink-block.html
@@ -449,7 +449,12 @@
       }else{
         const unspecified=matches.filter(entry=>{
           const assigned=entry.blockPeriods&&entry.blockPeriods[blockNumber];
-          return !assigned;
+          if(assigned) return false;
+          const explicitPeriod=(entry.period||'').toLowerCase();
+          if(explicitPeriod && explicitPeriod!==normalizedPeriod) return false;
+          const inferred=(entry.inferredPeriod||'').toLowerCase();
+          if(inferred && inferred!==normalizedPeriod) return false;
+          return true;
         });
         if(unspecified.length){
           filtered=unspecified;


### PR DESCRIPTION
## Summary
- prevent PM requests from reusing AM buses when period information is missing
- respect explicit or inferred periods before falling back to unspecified entries in bus selection

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68dee2537f4c833384d576d22af1b2a5