### PR TITLE
Add charter and training colors to E-ink grid

### DIFF
--- a/eink-block.html
+++ b/eink-block.html
@@ -440,10 +440,19 @@
     buildGrid();
   }
 
-  function getCellColors(block,period){
+  function getCellColors(block,period,customId){
     const blockId=(block||'').padStart(2,'0');
     const periodId=(period||'').toLowerCase();
+    const normalizedCustom=(customId||'').toLowerCase();
     if(!blockId) return null;
+
+    if(normalizedCustom.includes('charter')){
+      return {bg:'#FF69B4',text:'#000'};
+    }
+
+    if(normalizedCustom.includes('training')){
+      return {bg:'#92FB02',text:'#000'};
+    }
 
     const numeric=parseInt(blockId,10);
 
@@ -467,7 +476,7 @@
 
   function applyCellColors(cell){
     if(!enableColors || !cell || !cell.dataset) return;
-    const colors=getCellColors(cell.dataset.block,cell.dataset.period||'');
+    const colors=getCellColors(cell.dataset.block,cell.dataset.period||'',cell.dataset.customBlockId||'');
     if(colors){
       cell.style.backgroundColor=colors.bg;
       cell.style.color=colors.text;


### PR DESCRIPTION
## Summary
- detect charter and training blocks by custom identifiers when colors are enabled
- apply the requested pink and green backgrounds for those blocks in the grid view

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df2d203d288333a114410fc7b91466