### PR TITLE
Follow redirect for downed bus sheet

### DIFF
--- a/app.py
+++ b/app.py
@@ -1860,7 +1860,7 @@ async def route_vehicles_raw(route_id: int):
 # ---------------------------
 
 async def _fetch_downed_sheet_csv() -> str:
-    async with httpx.AsyncClient(timeout=20) as client:
+    async with httpx.AsyncClient(timeout=20, follow_redirects=True) as client:
         resp = await client.get(
             DISPATCHER_DOWNED_SHEET_URL,
             headers={"Cache-Control": "no-cache"},


### PR DESCRIPTION
## Summary
- ensure the dispatcher downed bus sheet fetch follows redirects when requesting the Google Sheet

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df2fcdcbe48333bcd518dc971d1695