### PR TITLE
Restore split layout for downed vehicles view

### DIFF
--- a/downed.html
+++ b/downed.html
@@ -43,20 +43,24 @@
     gap:20px;
     min-height:100vh;
   }
-  #meta{
-    display:flex;
-    align-items:center;
-    justify-content:space-between;
-    gap:16px;
-    font-size:18px;
-    color:var(--muted);
-    flex-wrap:wrap;
-  }
   #sections{
     flex:1;
     display:grid;
-    grid-template-columns:repeat(auto-fit,minmax(420px,1fr));
-    gap:20px;
+    grid-template-columns:repeat(2,minmax(0,1fr));
+    gap:24px;
+    align-items:start;
+    position:relative;
+  }
+  #sections::before{
+    content:'';
+    position:absolute;
+    top:12px;
+    bottom:12px;
+    left:50%;
+    width:1px;
+    background:var(--line);
+    pointer-events:none;
+    transform:translateX(-0.5px);
   }
   section{
     background:var(--panel);
@@ -135,25 +139,22 @@
     table{font-size:14px;}
     tbody td{font-size:16px;}
     main{padding:20px 16px;}
-    #sections{grid-template-columns:repeat(auto-fit,minmax(360px,1fr));}
     section h2{font-size:22px;}
+  }
+  @media (max-width:960px){
+    #sections{grid-template-columns:1fr;}
+    #sections::before{display:none;}
   }
 </style>
 </head>
 <body>
 <main>
-  <div id="meta">
-    <span id="updated">Last updated: —</span>
-    <span id="status"></span>
-  </div>
   <div id="sections"></div>
 </main>
 <script>
 const ENDPOINT = '/v1/dispatcher/downed_buses';
 const REFRESH_MS = 60000;
 const sectionsContainer = document.getElementById('sections');
-const updatedEl = document.getElementById('updated');
-const statusEl = document.getElementById('status');
 let refreshTimer = null;
 
 function parseCsv(text){
@@ -180,19 +181,6 @@ function parseCsv(text){
   }
   if(cur!=='' || row.length){ row.push(cur); rows.push(row); }
   return rows;
-}
-
-function formatTimestamp(ts){
-  if(!ts) return '—';
-  const date = new Date(ts);
-  if(Number.isNaN(date.getTime())) return '—';
-  return date.toLocaleString('en-US', {
-    hour12:false,
-    month:'short',
-    day:'numeric',
-    hour:'2-digit',
-    minute:'2-digit'
-  });
 }
 
 function cleanCell(value){
@@ -321,17 +309,14 @@ function renderSheet(data){
 
 async function loadSheet(){
   try{
-    statusEl.textContent='Fetching latest updates…';
     const res=await fetch(ENDPOINT,{cache:'no-store'});
     if(!res.ok) throw new Error('HTTP '+res.status);
     const payload=await res.json();
     const csv=(payload && typeof payload.csv==='string') ? payload.csv : '';
     renderSheet(parseSheet(csv));
-    updatedEl.textContent='Last updated: '+formatTimestamp(payload?.fetched_at);
-    statusEl.textContent=payload?.error ? 'Warning: '+payload.error : 'Live data';
   }catch(err){
-    statusEl.textContent='Unable to reach server';
     console.error('Failed to load downed vehicles sheet', err);
+    renderSheet({ headerLine:[], sections:[] });
   }
 }
 


### PR DESCRIPTION
## Summary
- remove the live data header so the table content sits higher on the page
- restore a two-column layout with a center divider for the Bus and P&T Support Vehicle sections
- simplify data refresh handling by dropping the status text and using the existing fallback message on errors

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df37d65f088333bce1f66ee61167f3