### PR TITLE
Stack downed sections vertically

### DIFF
--- a/downed.html
+++ b/downed.html
@@ -45,22 +45,10 @@
   }
   #sections{
     flex:1;
-    display:grid;
-    grid-template-columns:repeat(2,minmax(0,1fr));
-    gap:24px;
-    align-items:start;
-    position:relative;
-  }
-  #sections::before{
-    content:'';
-    position:absolute;
-    top:12px;
-    bottom:12px;
-    left:50%;
-    width:1px;
-    background:var(--line);
-    pointer-events:none;
-    transform:translateX(-0.5px);
+    display:flex;
+    flex-direction:column;
+    gap:12px;
+    align-items:stretch;
   }
   section{
     background:var(--panel);
@@ -142,8 +130,7 @@
     section h2{font-size:22px;}
   }
   @media (max-width:960px){
-    #sections{grid-template-columns:1fr;}
-    #sections::before{display:none;}
+    #sections{gap:10px;}
   }
 </style>
 </head>


### PR DESCRIPTION
## Summary
- stack the Bus and P&T Support Vehicle sections vertically to present a horizontal split layout
- reduce spacing between panels so the two sections appear closer together

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68df399d865083338ac58edcb19cacee