### PR TITLE
Abbreviate supervisor and mechanic column headers

### DIFF
--- a/downed.html
+++ b/downed.html
@@ -152,6 +152,13 @@ let refreshTimer = null;
 
 const HIDDEN_HEADER_LABELS = new Set(['current eta']);
 
+function abbreviateHeaderLabel(text){
+  if(!text) return text;
+  return String(text)
+    .replace(/SUPERVISOR/gi,'SUP')
+    .replace(/MECHANIC/gi,'MECH');
+}
+
 function normalizeHeader(text){
   return String(text || '')
     .replace(/\s+/g,' ')
@@ -261,7 +268,7 @@ function renderSection(section){
     .filter(col=>!isHiddenHeader(col.text));
 
   visibleColumns.forEach(col => {
-    const text=col.text;
+    const text=abbreviateHeaderLabel(col.text);
     const th=document.createElement('th');
     const normalized=normalizeHeader(text);
     if(text && normalized!=='bus' && normalized!=='p&t support vehicle'){


### PR DESCRIPTION
## Summary
- abbreviate supervisor and mechanic column labels shown in downed vehicles table headers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df49445e3c8333bfb33830458a973a