### PR TITLE
Shorten downed vehicle date headers

### DIFF
--- a/downed.html
+++ b/downed.html
@@ -156,7 +156,9 @@ function abbreviateHeaderLabel(text){
   if(!text) return text;
   return String(text)
     .replace(/SUPERVISOR/gi,'SUP')
-    .replace(/MECHANIC/gi,'MECH');
+    .replace(/MECHANIC/gi,'MECH')
+    .replace(/DIAGNOSTIC DATE/gi,'DIAG DATE')
+    .replace(/ACTUAL DELIVERY DATE/gi,'DELIVERY DATE');
 }
 
 function normalizeHeader(text){


### PR DESCRIPTION
## Summary
- abbreviate the DIAGNOSTIC DATE column label to DIAG DATE
- simplify the ACTUAL DELIVERY DATE column label to DELIVERY DATE

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df51c1830c8333bf5f2c24004ca6ad