### PR TITLE
Fix diagnostic date abbreviation

### DIFF
--- a/downed.html
+++ b/downed.html
@@ -157,7 +157,7 @@ function abbreviateHeaderLabel(text){
   return String(text)
     .replace(/SUPERVISOR/gi,'SUP')
     .replace(/MECHANIC/gi,'MECH')
-    .replace(/DIAGNOSTIC DATE/gi,'DIAG DATE')
+    .replace(/DIAGNOSTIC[\s\u00a0]*DATE/gi,'DIAG DATE')
     .replace(/ACTUAL DELIVERY DATE/gi,'DELIVERY DATE');
 }
 


### PR DESCRIPTION
## Summary
- update the downed vehicles header abbreviation logic to collapse any whitespace between the Diagnostic and Date tokens so the "Diagnostic Date" header is shortened correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df52ad35508333a689db20681dbc02