### PR TITLE
Add pulse indicator for missing diagnostic date statuses

### DIFF
--- a/downed.html
+++ b/downed.html
@@ -117,6 +117,27 @@
     border-radius:50%;
     background:currentColor;
   }
+  .pill.pulse-alert{position:relative;}
+  .pill.pulse-alert .dot{
+    position:relative;
+    z-index:1;
+  }
+  .pill.pulse-alert .dot::after{
+    content:'';
+    position:absolute;
+    inset:-6px;
+    border-radius:50%;
+    background:currentColor;
+    opacity:0.45;
+    transform:scale(0.6);
+    z-index:-1;
+    animation:statusPulse 1.8s ease-out infinite;
+  }
+  @keyframes statusPulse{
+    0%{transform:scale(0.6); opacity:0.45;}
+    70%{transform:scale(1.6); opacity:0;}
+    100%{transform:scale(1.6); opacity:0;}
+  }
   .pill.down,
   .pill.downed{color:var(--pill-down);}
   .pill.hold{color:var(--pill-hold);}
@@ -178,6 +199,18 @@ function isHiddenHeader(text){
 
 function isStatusHeader(text){
   return normalizeHeader(text) === 'status';
+}
+
+function findDiagnosticDateIndex(headers){
+  if(!Array.isArray(headers)) return -1;
+  for(let i=0;i<headers.length;i++){
+    const normalized=normalizeHeader(headers[i]);
+    if(!normalized) continue;
+    if(normalized==='diagnostic date' || normalized==='diag date' || normalized.includes('diagnostic date')){
+      return i;
+    }
+  }
+  return -1;
 }
 
 function parseCsv(text){
@@ -293,10 +326,13 @@ function renderSection(section){
   table.appendChild(thead);
 
   const tbody=document.createElement('tbody');
+  const diagnosticIndex=findDiagnosticDateIndex(section.headers);
   section.rows.forEach(row => {
     const tr=document.createElement('tr');
     const padded=row.slice();
     while(padded.length<section.headers.length){ padded.push(''); }
+    const diagnosticValue=(diagnosticIndex>=0 && diagnosticIndex<padded.length) ? padded[diagnosticIndex] : '';
+    const hasDiagnosticDate=!!(diagnosticValue && String(diagnosticValue).trim());
     visibleColumns.forEach(col => {
       const { index, text: headerText } = col;
       const cell=padded[index];
@@ -308,6 +344,9 @@ function renderSection(section){
         if(text && cls){
           const pill=document.createElement('span');
           pill.classList.add('pill', cls);
+          if(!hasDiagnosticDate){
+            pill.classList.add('pulse-alert');
+          }
 
           const dot=document.createElement('span');
           dot.className='dot';


### PR DESCRIPTION
## Summary
- add a pulsing effect behind status pills when a diagnostic date is missing
- detect the diagnostic date column while rendering sections to control the indicator

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68df588187bc8333a22bf10fedea8a95