### PR TITLE
Address Codex feedback by skipping unattached table removal

### DIFF
--- a/downed.html
+++ b/downed.html
@@ -407,7 +407,6 @@ function renderSection(section){
     tbody.appendChild(tr);
   });
   if(!tbody.children.length){
-    wrapper.removeChild(table);
     const empty=document.createElement('div');
     empty.className='empty-indicator';
     empty.textContent='No records to display.';


### PR DESCRIPTION
## Summary
- stop calling `removeChild` on the table before it is appended when a section has no rows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e055b5f7d48333bb600df8defd690b