### PR TITLE
Abbreviate delivery date header in downed view

### DIFF
--- a/downed.html
+++ b/downed.html
@@ -183,7 +183,7 @@ function abbreviateHeaderLabel(text){
     .replace(/SUPERVISOR/gi,'SUP')
     .replace(/MECHANIC/gi,'MECH')
     .replace(/DIAGNOSTIC[\s\u00a0]*DATE/gi,'DIAG DATE')
-    .replace(/ACTUAL DELIVERY DATE/gi,'DELIVERY DATE');
+    .replace(/ACTUAL DELIVERY DATE/gi,'DEL DATE');
 }
 
 function normalizeHeader(text){


### PR DESCRIPTION
## Summary
- abbreviate the "ACTUAL DELIVERY DATE" table header to read "DEL DATE" on the downed buses page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e05a7d557c8333a0c39a84c17fc995