### PR TITLE
Fix charter block fallback showing incorrect buses

### DIFF
--- a/eink-block.html
+++ b/eink-block.html
@@ -975,9 +975,8 @@
         if(lookup && lookup.has(blockIdNormalized)){
           const info=lookup.get(blockIdNormalized);
           const infoBusClean=cleanBusIdentifier(info.bus);
-          const entryBusClean=cleanBusIdentifier(entry.bus);
           const candidate={
-            bus:infoBusClean||entryBusClean||'—',
+            bus:infoBusClean||'—',
             blockNumbers:Array.isArray(info.numbers)&&info.numbers.length?info.numbers.slice():entry.blockNumbers.slice(),
             blockPeriods:(info.periods && Object.keys(info.periods).length)?info.periods:entry.blockPeriods,
             period:entry.period,


### PR DESCRIPTION
## Summary
- prevent custom/plain-language block entries from inheriting another block's bus assignment
- ensure Charter_* and similar blocks remain blank when no bus is assigned

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e06d0d4aa48333b36e0fab66f633a0