### PR TITLE
Add IPS database breakdown page

### DIFF
--- a/app.py
+++ b/app.py
@@ -824,6 +824,7 @@ NOT_FOUND_HTML = (BASE_DIR / "404.html").read_text(encoding="utf-8")
 RADAR_HTML = (BASE_DIR / "radar.html").read_text(encoding="utf-8")
 EINK_BLOCK_HTML = (BASE_DIR / "eink-block.html").read_text(encoding="utf-8")
 DOWNED_HTML = (BASE_DIR / "downed.html").read_text(encoding="utf-8")
+IPS_HTML = (BASE_DIR / "ips.html").read_text(encoding="utf-8")
 
 ADSB_URL_TEMPLATE = "https://opendata.adsb.fi/api/v2/lat/{lat}/lon/{lon}/dist/{dist}"
 ADSB_CORS_HEADERS = {
@@ -3514,3 +3515,8 @@ async def arrivalsdisplay_page():
 @app.get("/replay")
 async def replay_page():
     return HTMLResponse(REPLAY_HTML)
+
+
+@app.get("/ips")
+async def ips_page():
+    return HTMLResponse(IPS_HTML)

--- a/ips.html
+++ b/ips.html
@@ -1,0 +1,4088 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='utf-8'>
+<title>Luminator IPS Database Overview</title>
+<style>body{font-family:Arial, sans-serif; margin:2rem; background:#f6f8fb;} h1,h2{color:#123;} table{border-collapse:collapse; width:100%; margin-bottom:1rem; background:#fff;} th,td{border:1px solid #ccc; padding:0.25rem 0.5rem; font-size:0.85rem;} th{background:#003366; color:#fff;} tbody tr:nth-child(even){background:#f2f2f2;} .summary{margin-bottom:1.5rem; background:#fff; padding:1rem; border:1px solid #ccd;} .note{font-style:italic; color:#555;} .toc ul{columns:2; margin:0; padding-left:1.2rem;} .toc a{text-decoration:none; color:#0066aa;} .toc a:hover{text-decoration:underline;} section{margin-bottom:2.5rem;} code{background:#eef;padding:0 0.3rem;border-radius:3px;} .error{color:#b00;font-weight:bold;}</style>
+</head>
+<body>
+<h1>Luminator Database Breakdown</h1>
+<p class='summary'>This page summarizes the contents of <code>luminator.ips</code>, a Microsoft Access / Jet database. Each section lists the first 50 rows from every table along with row counts. Use your browser's find to navigate to specific data.</p>
+<section class="toc"><h2>Tables</h2><ul>
+<li><a href='#ClassAMsgs'>ClassAMsgs</a> — 3 rows, 7 columns</li>
+<li><a href='#ClassBMsgs'>ClassBMsgs</a> — 29 rows, 5 columns</li>
+<li><a href='#ClassDMsgs'>ClassDMsgs</a> — 0 rows, 7 columns</li>
+<li><a href='#ClassEMsgs'>ClassEMsgs</a> — 0 rows, 5 columns</li>
+<li><a href='#ClassMsgs'>ClassMsgs</a> — 0 rows, 5 columns</li>
+<li><a href='#ColorGraphic'>ColorGraphic</a> — 108 rows, 5 columns</li>
+<li><a href='#ColorZone'>ColorZone</a> — 0 rows, 14 columns</li>
+<li><a href='#EffectZones'>EffectZones</a> — 925 rows, 18 columns</li>
+<li><a href='#Fonts'>Fonts</a> — 62 rows, 9 columns</li>
+<li><a href='#Graphics'>Graphics</a> — 136 rows, 11 columns</li>
+<li><a href='#LoadModules'>LoadModules</a> — 6 rows, 3 columns</li>
+<li><a href='#LogicalSignBuild'>LogicalSignBuild</a> — 4 rows, 5 columns</li>
+<li><a href='#LogicalSigns'>LogicalSigns</a> — 4 rows, 5 columns</li>
+<li><a href='#MsgClass'>MsgClass</a> — 5 rows, 3 columns</li>
+<li><a href='#MsgListingElements'>MsgListingElements</a> — 21 rows, 4 columns</li>
+<li><a href='#PhysicalSigns'>PhysicalSigns</a> — 4 rows, 41 columns</li>
+<li><a href='#RenumberColorZone'>RenumberColorZone</a> — 0 rows, 14 columns</li>
+<li><a href='#RenumberEffectZones'>RenumberEffectZones</a> — 2 rows, 18 columns</li>
+<li><a href='#RenumberMsgFrames'>RenumberMsgFrames</a> — 6 rows, 32 columns</li>
+<li><a href='#RenumberMsgs'>RenumberMsgs</a> — 1 row, 5 columns</li>
+<li><a href='#RenumberSignProperties'>RenumberSignProperties</a> — 4 rows, 5 columns</li>
+<li><a href='#SignMsgCodeProperties'>SignMsgCodeProperties</a> — 704 rows, 5 columns</li>
+<li><a href='#SignSetBuild'>SignSetBuild</a> — 4 rows, 2 columns</li>
+<li><a href='#tblClipboardMsgs'>tblClipboardMsgs</a> — 1 row, 2 columns</li>
+<li><a href='#TemplateZones'>TemplateZones</a> — 38 rows, 16 columns</li>
+<li><a href='#VersionControl'>VersionControl</a> — 10 rows, 5 columns</li>
+<li><a href='#ClassCMsgs'>ClassCMsgs</a> — 144 rows, 13 columns</li>
+<li><a href='#ClassTemplates'>ClassTemplates</a> — 9 rows, 5 columns</li>
+<li><a href='#History'>History</a> — 473 rows, 4 columns</li>
+<li><a href='#MessageFrames'>MessageFrames</a> — 1561 rows, 32 columns</li>
+<li><a href='#MsgClassElements'>MsgClassElements</a> — 11 rows, 4 columns</li>
+<li><a href='#NumericProperties'>NumericProperties</a> — 2 rows, 4 columns</li>
+<li><a href='#SignSets'>SignSets</a> — 1 row, 9 columns</li>
+</ul></section>
+<section id='ClassAMsgs'><h2>ClassAMsgs</h2>
+<p><strong>Rows:</strong> 3 • <strong>Columns:</strong> 7</p>
+<table>
+<thead><tr><th>MsgCode</th><th>MsgClassID</th><th>Approved</th><th>Title</th><th>IDTitle</th><th>Text</th><th>IDText</th></tr></thead>
+<tbody>
+<tr><td>1</td><td>1</td><td>0</td><td>     </td><td>1</td><td>EXCEEDED RANGEÃ·PLEASE ENTER^EXCEEDED RANGEÃ·NEW DESTINATION</td><td>2</td></tr>
+<tr><td>2</td><td>1</td><td>0</td><td>911  PLEASE CALL^POLICE  </td><td>1</td><td>PLEASE SITÃ·DESTINATION LOGO</td><td>2</td></tr>
+<tr><td>3</td><td>1</td><td>0</td><td>CHECK FILE</td><td>1</td><td>THIS SIGN IS NOTÃ·SELECTED...CHECK MW</td><td>2</td></tr>
+</tbody></table>
+</section>
+<section id='ClassBMsgs'><h2>ClassBMsgs</h2>
+<p><strong>Rows:</strong> 29 • <strong>Columns:</strong> 5</p>
+<table>
+<thead><tr><th>MsgCode</th><th>MsgClassID</th><th>Approved</th><th>PRText</th><th>IDPRText</th></tr></thead>
+<tbody>
+<tr><td>1</td><td>2</td><td>1</td><td>#HOOS GOT YOUR BACK!</td><td>3</td></tr>
+<tr><td>2</td><td>2</td><td>1</td><td>WELCOME BACK HOOS!</td><td>3</td></tr>
+<tr><td>3</td><td>2</td><td>1</td><td>GO HOOS!</td><td>3</td></tr>
+<tr><td>4</td><td>2</td><td>1</td><td>NOW HIRING STUDENTS!</td><td>3</td></tr>
+<tr><td>5</td><td>2</td><td>1</td><td>HAPPY HOLIDAYS!</td><td>3</td></tr>
+<tr><td>6</td><td>2</td><td>1</td><td>GO VOTE ON NOV. 5!</td><td>3</td></tr>
+<tr><td>7</td><td>2</td><td>1</td><td>ACTIVE DETOUR</td><td>3</td></tr>
+<tr><td>8</td><td>2</td><td>1</td><td>HAPPY EARTH WEEK!</td><td>3</td></tr>
+<tr><td>9</td><td>2</td><td>1</td><td>DOWNLOAD THE TRANSLOCÃ·APP FOR REAL-TIME INFO</td><td>3</td></tr>
+<tr><td>10</td><td>2</td><td>1</td><td>CLEAN COMMUTE MONTH^#CLEANCOMMUTECVILLE</td><td>3</td></tr>
+<tr><td>11</td><td>2</td><td>1</td><td>HAPPY NURSES WEEK!</td><td>3</td></tr>
+<tr><td>12</td><td>2</td><td>1</td><td>FOLLOW THE BUS^TWITTER: @UVAUTSÃ·INSTAGRAM: @UVA.UTS</td><td>3</td></tr>
+<tr><td>13</td><td>2</td><td>1</td><td>TEXT &#x27;&#x27;HEALTH&#x27;&#x27; TO 434.939.4307^FOR PARKING &amp; TRANSIT ALERTS</td><td>3</td></tr>
+<tr><td>14</td><td>2</td><td>1</td><td>GOOD LUCK WITH EXAMS!</td><td>3</td></tr>
+<tr><td>15</td><td>2</td><td>1</td><td>NOW HIRING FULL TIME DRIVERS!</td><td>3</td></tr>
+<tr><td>16</td><td>2</td><td>1</td><td>BATTERY ELECTRIC BUS</td><td>3</td></tr>
+<tr><td>17</td><td>2</td><td>1</td><td>CONGRATSÃ·UTS GRAD CASEY^CONGRATSÃ·UTS GRAD LIAM</td><td>3</td></tr>
+<tr><td>18</td><td>2</td><td>1</td><td>CONGRATSÃ·UTS GRAD JONAH^CONGRATSÃ·UTS GRAD BERNARD^CONGRATSÃ·UTS GRAD BRIAN</td><td>3</td></tr>
+<tr><td>19</td><td>2</td><td>1</td><td>BATTERY ELECTRIC BUS</td><td>3</td></tr>
+<tr><td>20</td><td>2</td><td>1</td><td>IN LOVING MEMORY OF KELVIN</td><td>3</td></tr>
+<tr><td>21</td><td>2</td><td>1</td><td>HAPPYÃ·RETIREMENT BECCA WHITE</td><td>3</td></tr>
+<tr><td>22</td><td>2</td><td>1</td><td>TRANSIT EMPLOYEE APPRECIATION DAY</td><td>3</td></tr>
+<tr><td>23</td><td>2</td><td>1</td><td>REMEMBER DEVIN^REMEMBER D&#x27;SEAN^REMEMBER LAVEL^UVA STRONG</td><td>3</td></tr>
+<tr><td>316</td><td>2</td><td>1</td><td>RAIL REPLACEMENT BUS</td><td>3</td></tr>
+<tr><td>322</td><td>2</td><td>1</td><td>HAPPY PRIDE MONTH</td><td>3</td></tr>
+<tr><td>405</td><td>2</td><td>1</td><td>PIPELINES &amp; PATHWAYS</td><td>3</td></tr>
+<tr><td>407</td><td>2</td><td>1</td><td>ON DETOUR</td><td>3</td></tr>
+<tr><td>600</td><td>2</td><td>1</td><td>GAME DELAY</td><td>3</td></tr>
+<tr><td>849</td><td>2</td><td>1</td><td>THANKS!</td><td>3</td></tr>
+</tbody></table>
+</section>
+<section id='ClassDMsgs'><h2>ClassDMsgs</h2>
+<p><strong>Rows:</strong> 0 • <strong>Columns:</strong> 7</p>
+<table>
+<thead><tr><th>MsgCode</th><th>MsgClassID</th><th>Approved</th><th>Announce</th><th>IDAnnounce</th><th>NextStop</th><th>IDNextStop</th></tr></thead>
+<tbody>
+<tr><td colspan="7">(no rows)</td></tr>
+</tbody></table>
+</section>
+<section id='ClassEMsgs'><h2>ClassEMsgs</h2>
+<p><strong>Rows:</strong> 0 • <strong>Columns:</strong> 5</p>
+<table>
+<thead><tr><th>MsgCode</th><th>MsgClassID</th><th>Approved</th><th>ForbiddenWord</th><th>IDForbiddenWord</th></tr></thead>
+<tbody>
+<tr><td colspan="5">(no rows)</td></tr>
+</tbody></table>
+</section>
+<section id='ClassMsgs'><h2>ClassMsgs</h2>
+<p><strong>Rows:</strong> 0 • <strong>Columns:</strong> 5</p>
+<table>
+<thead><tr><th>MsgCode</th><th>MsgClassID</th><th>ElementID</th><th>ElementText</th><th>Approved</th></tr></thead>
+<tbody>
+<tr><td colspan="5">(no rows)</td></tr>
+</tbody></table>
+</section>
+<section id='ColorGraphic'><h2>ColorGraphic</h2>
+<p><strong>Rows:</strong> 108 • <strong>Columns:</strong> 5</p>
+<table>
+<thead><tr><th>ID</th><th>GraphicID</th><th>RedAttribute</th><th>GreenAttribute</th><th>BlueAttribute</th></tr></thead>
+<tbody>
+<tr><td>1</td><td>52</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>2</td><td>53</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>3</td><td>54</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>4</td><td>55</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>5</td><td>56</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>6</td><td>57</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>7</td><td>58</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>8</td><td>59</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>9</td><td>60</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>10</td><td>61</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>11</td><td>62</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>12</td><td>63</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>13</td><td>64</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>14</td><td>65</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>15</td><td>66</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>16</td><td>67</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>17</td><td>68</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>18</td><td>69</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>19</td><td>70</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>20</td><td>71</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>21</td><td>72</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>22</td><td>73</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>23</td><td>74</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>24</td><td>75</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>25</td><td>76</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>26</td><td>77</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>27</td><td>78</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>28</td><td>79</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>29</td><td>80</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>30</td><td>81</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>31</td><td>82</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>32</td><td>83</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>33</td><td>84</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>34</td><td>85</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>35</td><td>86</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>36</td><td>87</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>37</td><td>88</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>38</td><td>89</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>39</td><td>90</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>40</td><td>91</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>41</td><td>92</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>42</td><td>93</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>43</td><td>94</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>44</td><td>95</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>45</td><td>96</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>46</td><td>97</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>47</td><td>98</td><td>128</td><td>64</td><td>32</td></tr>
+<tr><td>48</td><td>99</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>49</td><td>100</td><td>128</td><td>64</td><td>25</td></tr>
+<tr><td>50</td><td>101</td><td>128</td><td>64</td><td>25</td></tr>
+</tbody></table>
+<p class="note">58 additional rows not shown.</p>
+</section>
+<section id='ColorZone'><h2>ColorZone</h2>
+<p><strong>Rows:</strong> 0 • <strong>Columns:</strong> 14</p>
+<table>
+<thead><tr><th>ID</th><th>MsgClassID</th><th>MsgCode</th><th>LSign</th><th>Frame</th><th>Phrase</th><th>ColorStr</th><th>GraphicID</th><th>Text</th><th>ColorNumber</th><th>XStart</th><th>YStart</th><th>XEnd</th><th>YEnd</th></tr></thead>
+<tbody>
+<tr><td colspan="14">(no rows)</td></tr>
+</tbody></table>
+</section>
+<section id='EffectZones'><h2>EffectZones</h2>
+<p><strong>Rows:</strong> 925 • <strong>Columns:</strong> 18</p>
+<table>
+<thead><tr><th>EffZoneID</th><th>MsgClassID</th><th>MsgCode</th><th>LSignID</th><th>Frame</th><th>OriginX</th><th>OriginY</th><th>Height</th><th>Width</th><th>Alert</th><th>ScrollIn</th><th>Scroll</th><th>Blink</th><th>Sparkle</th><th>Format</th><th>ScrollDirection</th><th>ScrollSpeed</th><th>AttrNumber</th></tr></thead>
+<tbody>
+<tr><td>824830</td><td>3</td><td>121</td><td>1</td><td>1</td><td>1</td><td>1</td><td>14</td><td>100</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>824837</td><td>3</td><td>121</td><td>10</td><td>1</td><td>1</td><td>1</td><td>8</td><td>96</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>824838</td><td>3</td><td>121</td><td>11</td><td>1</td><td>1</td><td>1</td><td>16</td><td>48</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>824839</td><td>3</td><td>121</td><td>12</td><td>1</td><td>1</td><td>1</td><td>16</td><td>160</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>824874</td><td>3</td><td>123</td><td>1</td><td>1</td><td>1</td><td>1</td><td>14</td><td>100</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>824881</td><td>3</td><td>123</td><td>10</td><td>1</td><td>1</td><td>1</td><td>8</td><td>96</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>824882</td><td>3</td><td>123</td><td>11</td><td>1</td><td>1</td><td>1</td><td>16</td><td>48</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>824883</td><td>3</td><td>123</td><td>12</td><td>1</td><td>1</td><td>1</td><td>16</td><td>160</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>824896</td><td>3</td><td>124</td><td>1</td><td>1</td><td>1</td><td>1</td><td>14</td><td>100</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>824903</td><td>3</td><td>124</td><td>10</td><td>1</td><td>1</td><td>1</td><td>8</td><td>96</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>824904</td><td>3</td><td>124</td><td>11</td><td>1</td><td>1</td><td>1</td><td>16</td><td>48</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>824905</td><td>3</td><td>124</td><td>12</td><td>1</td><td>1</td><td>1</td><td>16</td><td>160</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>824940</td><td>3</td><td>126</td><td>1</td><td>1</td><td>1</td><td>1</td><td>14</td><td>100</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>824947</td><td>3</td><td>126</td><td>10</td><td>1</td><td>1</td><td>1</td><td>8</td><td>96</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>824948</td><td>3</td><td>126</td><td>11</td><td>1</td><td>1</td><td>1</td><td>16</td><td>48</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>824949</td><td>3</td><td>126</td><td>12</td><td>1</td><td>1</td><td>1</td><td>16</td><td>160</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>824962</td><td>3</td><td>141</td><td>1</td><td>1</td><td>1</td><td>1</td><td>14</td><td>100</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>824969</td><td>3</td><td>141</td><td>10</td><td>1</td><td>1</td><td>1</td><td>8</td><td>96</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>824970</td><td>3</td><td>141</td><td>11</td><td>1</td><td>1</td><td>1</td><td>16</td><td>48</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>824971</td><td>3</td><td>141</td><td>12</td><td>1</td><td>1</td><td>1</td><td>16</td><td>160</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>824984</td><td>3</td><td>142</td><td>1</td><td>1</td><td>1</td><td>1</td><td>14</td><td>100</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>824991</td><td>3</td><td>142</td><td>10</td><td>1</td><td>1</td><td>1</td><td>8</td><td>96</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>824992</td><td>3</td><td>142</td><td>11</td><td>1</td><td>1</td><td>1</td><td>16</td><td>48</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>824993</td><td>3</td><td>142</td><td>12</td><td>1</td><td>1</td><td>1</td><td>16</td><td>160</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>825006</td><td>3</td><td>143</td><td>1</td><td>1</td><td>1</td><td>1</td><td>14</td><td>100</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>825013</td><td>3</td><td>143</td><td>10</td><td>1</td><td>1</td><td>1</td><td>8</td><td>96</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>825014</td><td>3</td><td>143</td><td>11</td><td>1</td><td>1</td><td>1</td><td>16</td><td>48</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>825015</td><td>3</td><td>143</td><td>12</td><td>1</td><td>1</td><td>1</td><td>16</td><td>160</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>825028</td><td>3</td><td>144</td><td>1</td><td>1</td><td>1</td><td>1</td><td>14</td><td>100</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>825035</td><td>3</td><td>144</td><td>10</td><td>1</td><td>1</td><td>1</td><td>8</td><td>96</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>825036</td><td>3</td><td>144</td><td>11</td><td>1</td><td>1</td><td>1</td><td>16</td><td>48</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>825037</td><td>3</td><td>144</td><td>12</td><td>1</td><td>1</td><td>1</td><td>16</td><td>160</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>825050</td><td>3</td><td>145</td><td>1</td><td>1</td><td>1</td><td>1</td><td>14</td><td>100</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>825057</td><td>3</td><td>145</td><td>10</td><td>1</td><td>1</td><td>1</td><td>8</td><td>96</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>825058</td><td>3</td><td>145</td><td>11</td><td>1</td><td>1</td><td>1</td><td>16</td><td>48</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>825059</td><td>3</td><td>145</td><td>12</td><td>1</td><td>1</td><td>1</td><td>16</td><td>160</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>825072</td><td>3</td><td>171</td><td>1</td><td>1</td><td>1</td><td>1</td><td>14</td><td>100</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>825079</td><td>3</td><td>171</td><td>10</td><td>1</td><td>1</td><td>1</td><td>8</td><td>96</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>825080</td><td>3</td><td>171</td><td>11</td><td>1</td><td>1</td><td>1</td><td>16</td><td>48</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>825081</td><td>3</td><td>171</td><td>12</td><td>1</td><td>1</td><td>1</td><td>16</td><td>160</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>825094</td><td>3</td><td>172</td><td>1</td><td>1</td><td>1</td><td>1</td><td>14</td><td>100</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>825101</td><td>3</td><td>172</td><td>10</td><td>1</td><td>1</td><td>1</td><td>8</td><td>96</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>825102</td><td>3</td><td>172</td><td>11</td><td>1</td><td>1</td><td>1</td><td>16</td><td>48</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>825103</td><td>3</td><td>172</td><td>12</td><td>1</td><td>1</td><td>1</td><td>16</td><td>160</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>825116</td><td>3</td><td>173</td><td>1</td><td>1</td><td>1</td><td>1</td><td>14</td><td>100</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>825123</td><td>3</td><td>173</td><td>10</td><td>1</td><td>1</td><td>1</td><td>8</td><td>96</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>825124</td><td>3</td><td>173</td><td>11</td><td>1</td><td>1</td><td>1</td><td>16</td><td>48</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>825125</td><td>3</td><td>173</td><td>12</td><td>1</td><td>1</td><td>1</td><td>16</td><td>160</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>825138</td><td>3</td><td>174</td><td>1</td><td>1</td><td>1</td><td>1</td><td>14</td><td>100</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>825145</td><td>3</td><td>174</td><td>10</td><td>1</td><td>1</td><td>1</td><td>8</td><td>96</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+</tbody></table>
+<p class="note">875 additional rows not shown.</p>
+</section>
+<section id='Fonts'><h2>Fonts</h2>
+<p><strong>Rows:</strong> 62 • <strong>Columns:</strong> 9</p>
+<table>
+<thead><tr><th>FontID</th><th>FontName</th><th>FontDescription</th><th>FontType</th><th>FontSize</th><th>FontAllowMod</th><th>FontFile</th><th>FontWidth</th><th>Font</th></tr></thead>
+<tbody>
+<tr><td>22</td><td>Standard</td><td>New Font</td><td>User</td><td>5</td><td>1</td><td>5vw.fnt</td><td>1</td><td>5X SINGLE STROKE       i       £ ¨ ­ ² ³ µ · ¼ Á Ã Æ È Í Ñ Ô Ø Ü á å é í ñ õ ö ø û ÿ	&quot;&amp;*-159&gt;CGKPTX]afkpuz£§«¯³·¼   
+
+
+	
+
+
+
+
+
+
+
+
+
+
+
+	
+
+
+	
+	
+
+                                    </td></tr>
+<tr><td>23</td><td>Standard</td><td>New Font</td><td>User</td><td>5</td><td>1</td><td>5dvw.fnt</td><td>2</td><td>5X DOUBLE STROKE       `          £ ¥ ¨ « ° ¶ ¹ ¼ ¾ Ä Ê Î Ó Ø Þ ã é î ô ú ü ÿ!&#x27;-27=CGLRW^ekqw}¢¨®³¹¾ÃÇÎ   
+
+
+	
+
+	
+
+
+
+
+
+
+
+
+
+
+	
+	</td></tr>
+<tr><td>24</td><td>Standard</td><td>New Font</td><td>User</td><td>6</td><td>1</td><td>6dvw.fnt</td><td>2</td><td>6X DOUBLE STROKE       `          ¢ ¥ ¨ « ° ¶ ¹ ¼ ¾ Ã É Í Ó Ù ß ä ê ð ö ü þ	
+$*05:@FJOUZahntz ¦¬²·¼ÁÆÊÑ   //???????$*?*363%*(!!&gt;&gt;&gt; 8000?!!?&quot;?? 2;)-&#x27;&amp;3!%?
+	??7%=?%%=19
+?%%?/))? ;6&quot;&quot;6)-?!)-/&lt;&gt;&gt;&lt;??%%??!!3??!!???%%!???!):????!??!0 ???3!??   ?????????!!???		?!1.??	?&amp;7%-;???  ?0????#66#&lt;&lt;!19-&#x27;#??!!!0!!!??````?!!!!!?</td></tr>
+<tr><td>26</td><td>Standard</td><td>New Font</td><td>User</td><td>7</td><td>1</td><td>7dvw.fnt</td><td>2</td><td>7X DOUBLE STROKE       `          ¢ ¥ ¨ « ° ¶ ¹ ¼ ¾ Ä Ê Î Ô Ú à å ë ñ ÷ ý ÿ
+%+16;AGKPV[biou{¡§­³¸¾ÃÈÌÓ   __$**3fc6IV P&gt;AA&gt;&gt;&gt;&gt;@p0```0&gt;AA&gt;B@BcqYOF&quot;cII6/oIy1&gt;IIy2qy
+6II6&amp;OII&gt;66@v66cc6QY&gt;AYU_|~~|II6&gt;AAc&quot;AA&gt;IIA		&gt;AI;zAA `@?6cA@@@&gt;AA&gt;		&gt;A1^9oF&amp;oII{2?@@?0`000c66cxxaqYMGCAAA0`AAA@@@@AAAAA</td></tr>
+<tr><td>27</td><td>7dvwl</td><td>New Font</td><td>User</td><td>7</td><td>1</td><td>7dvwl.fnt</td><td>2</td><td>7X DOUBLE STROKE       ~   À Ã Å Ê Ï Ô Ù Þ á ä ç ì ò õ ø ú 
+!&#x27;-39;&gt;BFJOU[agmrw}¥«±·½ÃÉÏÖÝãéïôúÿ#&#x27;+/0489&gt;BFJNRVY]bglquz   __$**3fc6IV P&gt;AA&gt;&gt;&gt;&gt;@p0```0&gt;AA&gt;B@BcqYOF&quot;cII6/oIy1&gt;IIy2qy
+6II6&amp;OII&gt;66@v66cc6QY&gt;AYU_|~~|II6&gt;AAc&quot;AA&gt;IIA		&gt;AI;zAA `@?6cA@@@&gt;AA&gt;		&gt;A1^9oF&amp;oII{2?@@?0`000c66cxxaqYMGCAAA0`AAA@@@@AAAAAxxHH08DDH0HH8TTX~	8DT0pz @@&gt;(D|xx|x8DD8|||HTT$?D&lt;@@&lt; @ &lt;@8@&lt;D((DpDdTL  UUUUU   *****</td></tr>
+<tr><td>29</td><td>Standard</td><td>New Font</td><td>User</td><td>8</td><td>1</td><td>8vw.fnt</td><td>1</td><td>8X SINGLE STROKE  4    ~   À Ã Ä É Î Ó Ù Þ à ã æ ë ð ò ö ø ý
+#(-.048&lt;AFKPUZ^bglosx|¤©®³¸½ÃÈÍÒ×Ûàäèìðôøü 	
+#&#x27;*.38=AEJOTY   ¿ÿÿÿÿÿDJÿR&quot;Ã#ÄÃv` &lt;BB&lt;&quot;&quot;&gt;`ÀÀ ~~ÿÂ¡BvÿOp~rñ	vvN~$d(DD(¹~¹¥¿üüÿv~Bÿ~ÿÿ		~rÿÿÿ@ÿ$Bÿÿÿÿÿ~~ÿ			~¡A¾ÿ)IFrÿ?@@?ÿ`8`ÿÃ$$ÃðÁ¡ÿÿ ÿÿÿÿdøÿpxpÿxþ	¤¤|ÿðú@zÿ Pÿøððøðxxü$$$$üød~xx8@@8xpxP P  |È¨ÿ ÿ ÿUUUUU ÿ ÿ ªªªªª</td></tr>
+<tr><td>30</td><td>Standard</td><td>New Font</td><td>User</td><td>8</td><td>1</td><td>8dvw.fnt</td><td>2</td><td>8X DOUBLE STROKE       `          ¥ ¨ « ® ´ º ½ Â Ä Ê Ð Ô Ú à æ ì ò ø þ	&quot;(.4:?DJPTY_dkrx~£ª±·½ÂÈÍÔØß   ßßÿÿÿÿÿ$ÿ$ÿ$DJÿÿR&quot;Ãã0ÇÃ`ö®@ &lt;~~&lt;&quot;&quot;~~à`ÀÀ`0~ÿÿ~ÿÿÂã±BÃÿvÿÿOÏùp~ÿùráñvÿÿvNÿ~66æf8lÆÆl8ÑÙ~ÿ¹¥¾üþþüÿÿÿv~ÿÃBÿÿÿ~ÿÿÿÿ		~ÿsòÿÿÿÿÿÿ@Àÿÿÿ6ãÁÿÿÿÿÿÿÿÿ0ÿÿ~ÿÿ~ÿÿ		~ÿ¡¾ÿÿ9ïÆFÏûrÿÿÿÿ?`À`?ÿ00ÿÃç&lt;&lt;çÃøøÁá±ÿÿ0`ÿÿÿÿ</td></tr>
+<tr><td>31</td><td>Standard</td><td>New Font</td><td>User</td><td>9</td><td>1</td><td>9vw.fnt</td><td>1</td><td>9X SINGLE STROKE      	 ~  À Ì Ø ä ð ü ,8DP\ht¤°¼ÈÔàìø(4@LXdp| ¬¸ÄÐÜèô $0:FT`p~¨´ÂÎÚæðü .:&lt;FPRbnx¨²¾ÈÖâìø                                       L ÿ   d B %  H ¤ B Æ). À@             8 D       D 8             |          `                  @     @       |   |  ÿ     A!  î 0 ( $ &quot;ÿ   á ðH$&quot;! À  ñ 	   î î  þ       P          Ð      ( D      ( ( ( ( (    D (   q    È$$$Äøü &quot; ! ! &quot;üÿ î þ ÿ  |ÿÿ      þ!!! âÿ    ÿ  ÿ  ÿ  ÿ  ( D ÿ     ÿ    ÿÿ     ÿ þ þÿ      þ!A ~ÿ  1 Q   â  ÿ   ÿ     ÿ ? @    @ ?ÿ  @ @ ÿ  D 8 8 D    ð   A!	  ÿ           @     ÿ               ÿÿ È$$$ ø ÿ à ð  àÿ ðHHHHH0 þ    0HHHHH øÿ     àô À    ôÿ   P ÿø    p  ðø    ð ð ðø H H H H 0  $ $ $ü ø      PPPP   þ   ø     ø x    x ø   à   ø  ` ` 8@@@ øH(  þ  ï   þ       </td></tr>
+<tr><td>32</td><td>Standard</td><td>New Font</td><td>User</td><td>9</td><td>1</td><td>9dvw.fnt</td><td>2</td><td>9X DOUBLE STROKE      	 `       ¤ ° ¼ È Î Ö Þ ê ö ü
+&quot;*6BNZfr~ ¬¸ÄÔàìø&amp;2:DPZhv¦²¾ÊØæô &quot;,:DR      ÿÿÿÿÿÿ Dÿ Dÿ D  ÿÿ  b Ã ã 0  Æï9o Æ@    | þ þ | D ( þ þ ( D   ~ ~   À À      À ` 0    þÿÿ þÿÿ Ãa1 ÿ î 0 ( $þÿ   ñ à þÿó â  áù   îÿÿ î ÿ þ Ì Ì Ì Ì  8 l Æ $ $ $ $ $ $ Æ l 8   ±¹   þÿ»«¿ &gt;üþ # #þüÿÿÿ î þÿ ÿÿÿ þÿÿÿÿ    þÿ óò  ÿÿ  ÿÿÿÿ  ÿ ÿÿÿ 8 lÇÿÿ   ÿþ   þÿÿÿ  8 àÿÿ þÿÿ þÿÿ     þÿA ÿ~ÿÿ 1 qß ó â  ÿÿ   ÿÿ  ÿ ÿ ?  À À  ?ÿ ÿ ` 0 ` ÿÿÇ l 8 lÇ  ðð  Áqÿÿ    0 ` Àÿÿ ` 0    0 `ÿÿ</td></tr>
+<tr><td>34</td><td>Standard</td><td>New Font</td><td>User</td><td>10</td><td>1</td><td>10dvw.fnt</td><td>2</td><td>10X DOUBLE STROKE     
+ `       ¬ ¼ Ê Ø Þ æ î þ&quot;0&gt;FTbp~¨¶ºÀÌØäð *8DP^ltª¸ÆÔâðþ
+(8HXfp~ °      ??ÿÿÿÿÿÿÿ Ìÿÿ Ì Ìÿÿ Ì &gt;2ÿÿ2ò àÃ ` 0 Æï9oÆ    üþþ ü Ì xÿÿ x Ì 0 0 0þþ 0 0 0  0 0 0 0 0   À ` 0    üþþ üÿÿ Ãc333ÿÎ p x l fÿÿ `¿¿333óàþÿ333çÆ  ã ;  Îÿ333ÿÎ333ÿþ Ì Ì    p Ø Ì Ì Ì Ì Ì Ì Ø p    cs  þÿ3{K &gt;øü f c füøÿÿ333ÿÎþÿÿÿÿþÿÿ333ÿÿ 3 3 3 þÿ33óòÿÿ 0 0 0ÿÿÿÿ  ÿÿÿÿ 8 l Æÿÿ    ÿÿ  8 8 ÿÿÿÿ  8 àÿÿþÿÿþÿÿ 3 3 3 ? þÿCÿþÿÿ s ó³?¿333çÆ  ÿÿ  ÿÿ   ÿÿ  ? à à ? ÿÿ À p p Àÿÿ Ì x x Ì   ðð   Ãs;ÿÿ    0 ` Àÿÿ ` 0    0 `     ÿÿ</td></tr>
+<tr><td>36</td><td>10NYC</td><td>New Font</td><td>User</td><td>10</td><td>1</td><td>10NYC.fnt</td><td>2</td><td>10X DOUBLE STROKE     
+ z   ¸ ¾ Â Ð à ð þ&quot;2BHRVdrz¤²ÀÎÜêîô $4BP^lx ¨´ÂÎÞìú$2&gt;L\l|¤²¼ÊÔäðü(4@HR^hv¨´ÀÌØæô       ??ÿÿÿÿÿÿÿ Ìÿÿ Ì Ìÿÿ Ì &gt;2ÿÿ2ò àÃ ` 0 Æï9oÆ    üþþ ü Ì xÿÿ x Ì 0 0 0þþ 0 0 0  0 0 0 0 0   À ` 0    üþþ üÿÿ Ãc333ÿÎ p x l fÿÿ `¿¿333óàþÿ333çÆ  ã ;  Îÿ333ÿÎ333ÿþ Ì Ì    p Ø Ì Ì Ì Ì Ì Ì Ø p    cs  þÿ3{K &gt;øü f c füøÿÿ333ÿÎþÿÿÿÿþÿÿ333ÿÿ 3 3 3 þÿ33óòÿÿ 0 0 0ÿÿÿÿ  ÿÿÿÿ 8 l Æÿÿ    ÿÿ  8 8 ÿÿÿÿ  8 àÿÿþÿÿþÿÿ 3 3 3 ? þÿCÿþÿÿ s ó³?¿333çÆ  ÿÿ  ÿÿ   ÿÿ  ÿÀÀ ÿ ÿÿ À p p Àÿÿ Ì x x Ì   ðð   Ãs;ÿÿ    0 ` Àÿÿ ` 0    0 `     ÿÿÀà ° °àÀððPPð àð0 ðððàððPPðð P P àð° ðð @ @ðððð   ðððð Àà0ðð   ðð ` À `ðððð ` Àððàððàðð   ð `àððàðð ð` pPÐ°   ðð  ðð  ðð p ð  ð pðð Àðð0`ÀÀ`0 0 pÀÀ p 0Ðp0</td></tr>
+<tr><td>37</td><td>10DFW</td><td>New Font</td><td>User</td><td>10</td><td>1</td><td>10DfW.FNT</td><td>2</td><td>10X DOUBLE STROKE     
+ z   ¸ ¾ Â Ð à ð þ&quot;2BHRVdp| ¬¸ÄÐÜàæòþ
+&amp;2&gt;JVbnzª¶ÂÎÚæòþ
+&quot;.:FR^hv¤°¼ÈÔàìø $2&gt;JVbnz¬¸ÄÐ      ??ÿÿÿÿÿÿÿ Ìÿÿ Ì Ìÿÿ Ì &gt;2ÿÿ2ò àÃ ` 0 Æï9oÆ    üþþ ü Ì xÿÿ x Ì 0 0 0þþ 0 0 0  0 0 0 0 0   À ` 0   þÿÿþ  ÿÿ   Çc333ÿÎ x l fÿÿ `¿¿33óàþÿ33çÆ  ãó  Îÿ33ÿÎ33ÿþ Ì Ì    p Ø Ì Ì Ì Ì Ì Ì Ø p    cs  þÿ3{K &gt;üþ g gþüÿÿ33ÿÎþÿÿÿÿþÿÿ333ÿÿ 3 3 3 þÿ3óòÿÿ 0 0ÿÿ  ÿÿ    ÿÿÿÿ x Ìÿÿ    ÿþ  þÿÿÿ  pÿÿþÿÿþÿÿ 3 3 ? þÿÿþÿÿ s ó¿¿33÷æ  ÿÿ  ÿÿ  ÿÿ    ÿÿ À ÀÿÿÏ p pÏ  ðð  Ãs;ÿÿ    0 ` Àÿÿ ` 0    0 `     ÿÿ    àÀÿÿ  àÀÀà   @Àà  ÿÿÀà  àÀ 0 0þÿ 3 2Àà  ààÿÿ ` `àÀìì  ììÿÿ à°ÿÿàÀ ` À `àÀàà @ `àÀÀà  àÀàà     à @ @ à    àààà @ ` ` @@à     0 0üü 0 0àà  àà àà  à ààà  àà `ÀÀ` `ààà    ``</td></tr>
+<tr><td>38</td><td>10dwr</td><td>New Font</td><td>User</td><td>10</td><td>1</td><td>10dvwr.fnt</td><td>2</td><td>10X DOUBLE STROKE     
+ z   ¸ ¾ Â Ð à ð þ&quot;2BHRVdpx¨´ÀÌØÜâîú&quot;0&gt;LZfr¢°¼ÌÚèö ,:JZjz ª¸ÂÎÚæòþ
+&quot;.2&gt;JN\ht¤°¼ÈÖâîú      ??ÿÿÿÿÿÿÿ Ìÿÿ Ì Ìÿÿ Ì &gt;2ÿÿ2ò àÃ ` 0 Æï9oÆ    üþþ ü Ì xÿÿ x Ì 0 0 0þþ 0 0 0  0 0 0 0 0   À ` 0    üÿÿ üÿÿ Ãc?33ÿÎ x | `ÿÿ `¿¿33óãþÿ33÷æ  Ãó ? Îÿ33ÿÎ33ÿþ Ì Ì    p Ø Ì Ì Ì Ì Ì Ì Ø p    cs  þÿ3{K &gt;øü f c füøÿÿ333ÿÎþÿÿÿÿþÿÿ333ÿÿ 3 3 3 þÿ33óòÿÿ 0 0 0ÿÿÿÿ  ÿÿÿÿ 8 l Æÿÿ    ÿÿ  8 8 ÿÿÿÿ  8 àÿÿþÿÿþÿÿ 3 3 3 ? þÿCÿþÿÿ s ó³?¿333çÆ  ÿÿ  ÿÿ   ÿÿ  ? à à ? ÿÿ À p p Àÿÿ Ì x x Ì   ðð   Ãs;ÿÿ    0 ` Àÿÿ ` 0    0 `     ÿÿ    àÀÿÿ  àÀÀà  `@Àà  ÿÿÀà  àÀ 0þÿ 3 7 6Àà  ààÿÿ ` `àÀìì  ììÿÿ à°ÿÿàà @ à @àÀàÀ    àÀÀà  àÀàà     à @ @ à    àààà @   ` @@à     0 0üü 0 0àà  àà àà  à ààà  àà `ÀÀ` `ààà    ``</td></tr>
+<tr><td>39</td><td>Standard</td><td>New Font</td><td>User</td><td>11</td><td>1</td><td>11dvw.fnt</td><td>2</td><td>11X DOUBLE STROKE      `       ¬ ¼ Ê Ø Þ æ î þ&quot;0&gt;FTbp~¨¶ºÀÎÚèö&quot;0&gt;JVdrz °¾ÌÚèö.&gt;N^lv¦¶      ÿÿÿÿÿÿÿþþþþ&gt;&amp;ÿÿ&amp;æÆà p ßqß    üþþü ðþþ ð ` ` `üü ` ` `    0 0 0 0 0    À ` 0  üþþüÿÿ Ãc?33ÿÎ p x l fÿÿ `??333óàþÿ333çÆ  Ã s  ß###ß?cccÿþ    p Ø Ø p    Ãã 3  þÿsûËÿ ~øü Æ Ã Æüøÿÿ333ÿÎþÿÿÿÿþÿÿ333ÿÿ 3 3 3 þÿccçæÿÿ 0 0 0ÿÿÿÿ    ÿÿÿÿ p Øÿÿ    ÿþ  p p þÿÿÿ  pÀÿÿþÿÿþÿÿ c c c  &gt;þÿÿþÿÿ ããc&gt;?333çÆ  ÿÿ  ÿÿ   ÿÿ  À  À  ÿÿÀ à àÀÿÿ Ø p p Ø   ðð   Ãó?ÿÿ   0 ` À ÿÿ À ` 0  0 ` À     ÿÿ</td></tr>
+<tr><td>40</td><td>Standard</td><td>New Font</td><td>User</td><td>12</td><td>1</td><td>12dvw.fnt</td><td>2</td><td>12X DOUBLE STROKE      `       ® ¾ Ì Ü â ê ò&quot;&amp;4BN\jx¢°¾ÂÈÖâðþ*8FR^lz¨¸ÆÔâðþ&amp;6FVft~¤®¾      ÿÿÿÿÿÿÿÿÿÿþþþþ&lt;~fÿÿfæÆÀ ð &lt;Îqß
+      ðüü ð ðþþ ð ` ` `üü ` ` `    ` ` ` ` `    À ð &lt;  üþþüÿÿ  
+ãccÿ p x l fÿÿ `??333óàþÿcccçÆ  Ã ó ? ¿ócó¿&gt;cccÿþ  @ à°° à @  
+
+Ã c ? þÿó
+û
+
+ÿ þøü Æ Ã Æüøÿÿcccÿþÿÿÿÿþÿÿcccÿÿ c c c þÿccçæÿÿ ` ` `ÿÿÿÿ    ÿÿÿÿ à ð¼ÿÿ    ÿþ  p p þÿÿÿ &lt; ðÀÿÿþÿÿþÿÿ c c c  &gt;þÿ
+ÿþÿÿ ããc&gt;&gt;cccçÆ  ÿÿ  ÿÿ   ÿÿ ? ÿ   ÿ ?ÿÿÀÀÿÿ ð ð   ðð   Ãó?ÿÿ   &lt; ðÀ  ÿÿ À ` 0  0 ` À     ÿÿ</td></tr>
+<tr><td>41</td><td>Standard</td><td>New Font</td><td>User</td><td>13</td><td>1</td><td>13dvw.fnt</td><td>2</td><td>13X DOUBLE STROKE     
+ `      ¬ ¼ Ê Ú à è ð  $2@LZhx¢°¾ÂÈØäô .&lt;JVbp~ ¬¼ÊØæô*:JZjx¬¶Æ      ÿÿÿÿÿÿÿÿÿþþþþ&lt;~fÿÿfæÆÀ ð &lt;Îó     ðüüð ðþþ ð ` ` `üü ` ` `    ` ` ` ` `    À ð &lt;  þÿÿþÿÿ  ãccÿ à ð Ø Ì Æÿÿ À??333óàþÿcccçÆ  ã  ÿcccÿ~ÿÃÃÃÿþ  @ à°° à @  Ã c ? üþãó7þüøü Æ Ã Æüøÿÿcccÿþÿÿÿÿþÿÿcccÿÿ c c c þÿÃÃÇÆÿÿ ` ` `ÿÿÿÿ    ÿÿÿÿ àð¼ÿÿ    ÿþ  p p þÿÿÿ &lt; ðÀÿÿþÿÿþÿÿ c c c  &gt;þÿÿþÿÿ cãã&gt;&gt;cccçÆ  ÿÿ  ÿÿ   ÿÿ ÿ  ÿ ÿÿ  ÿÿ¸ðð¸   &lt;ðð &lt;  Ãó?ÿÿ   &lt; ðÀ  ÿÿ À ` 0 ` À     ÿÿ</td></tr>
+<tr><td>42</td><td>Standard</td><td>New Font</td><td>User</td><td>14</td><td>1</td><td>14dvw.fnt</td><td>2</td><td>14X DOUBLE STROKE      `       ® ¾ Î Þ ä ì ô*.&gt;NZjzªºÊÚÞäô  0@P`p~¬¸ÆÖäö&amp;6FVbp¢²ÂÌÜæô       3ÿ3ÿ?ÿ?ÿ?ÿ?ÿ?ÿ?ÿ?ÿ?ÿ0üü00üü0|þÆ?ÿ?ÿÆÆ0&lt; À ð &lt;00 9ß q!¿6 ,    ðü&lt;00&lt;üð0àüüà0 À À Àøø À À À  &gt;   À À À À À À À À0 0 0 &lt;  À ð &lt;  üþ8008þü00?ÿ?ÿ0 0 08&lt;631ç0~0800Ã8Çþ&lt; à ð Ø Ì Æ?ÿ?ÿ À80c0c0c0cÃüþ90Ã0Ã8Ã  &gt;?ã {  ¾9ç0Ã0Ã9ç¾&lt;~0Ç0Ã0Ã8gþü  &gt; À`00 000000 00`À    33Ã g ~ &lt;üþ81ã3ó373þü?ø?ü?ü?ø?ÿ?ÿ0Ã0Ã0Ã9çþ&lt;üþ8008?ÿ?ÿ0008þü?ÿ?ÿ0Ã0Ã0Ã0Ã0?ÿ?ÿ Ã Ã Ã Ã üþ8011??ÿ?ÿ À À À À?ÿ?ÿ00?ÿ?ÿ00  0 0 0 ÿÿ?ÿ?ÿ À Àð&lt;&lt;0?ÿ?ÿ0 0 0 0 0 ?ÿ?ÿ &lt; ðà ð &lt;?ÿ?ÿ?ÿ?ÿ 8 ðÀ ?ÿ?ÿüþ8008þü?ÿ?ÿ Ã Ã Ã ç ~ &lt;üþ826&lt;þ7ü?ÿ?ÿ ÃÃÃç&lt;~0&lt;&lt;~8ç0Ã0Ã9Ç  ?ÿ?ÿ  ÿÿ8 0 8 ÿÿ ÿÿ &lt; &lt;  ÿ ÿ?ÿ?ÿ ÀàÀ ?ÿ?ÿ0&lt;&lt;ðð&lt;&lt;0  ? ð?À?À ð ? 8&lt;?3Ã0ó0?00?ÿ?ÿ000   &lt; ðÀ &lt; 0 000?ÿ?ÿ À ` 0 ` À0 0 0 0 0 0 ?ÿ       ?ÿ</td></tr>
+<tr><td>43</td><td>14nyc2</td><td>New Font</td><td>User</td><td>14</td><td>1</td><td>14nyc2.fnt</td><td>2</td><td>14X DOUBLE STROKE      z   ¸ ¾ Â Ò â ò (8HN^br®¾ÎÞîþ(4DTdt¤²ÀÐàìú
+*:JZjz¤´ÆÖæö (4FTbp~¤²ºÆÔàðþ(6DP^n~°      3ÿ3ÿ?ÿ?ÿ?ÿ?ÿ?ÿ?ÿ?ÿ?ÿ0üü00üü0|þÆ?ÿ?ÿÆÆ0&lt; À ð &lt;00 9ß q!¿6 ,    ðü&lt;00&lt;üð0àüüà0 À À Àøø À À À  &gt;   À À À À À À À À0 0 0 &lt;  À ð &lt;  üþ8008þü00?ÿ?ÿ0 0 08&lt;631ç0~0800Ã8Çþ&lt; à ð Ø Ì Æ?ÿ?ÿ À80c0c0c0cÃüþ90Ã0Ã8Ã  &gt;?ã {  ¾9ç0Ã0Ã9ç¾&lt;~0Ç0Ã0Ã8gþü  &gt; À`00 000000 00`À    33Ã g ~ &lt;üþ81ã3ó373þü?ø?ü?ü?ø?ÿ?ÿ0Ã0Ã0Ã9çþ&lt;üþ8008?ÿ?ÿ0008þü?ÿ?ÿ0Ã0Ã0Ã0Ã0?ÿ?ÿ Ã Ã Ã Ã üþ8011??ÿ?ÿ À À À À?ÿ?ÿ00?ÿ?ÿ00  0 0 0 ÿÿ?ÿ?ÿ À Àð&lt;&lt;0?ÿ?ÿ0 0 0 0 0 ?ÿ?ÿ &lt; ðà ð &lt;?ÿ?ÿ?ÿ?ÿ 8 ðÀ ?ÿ?ÿüþ8008þü?ÿ?ÿ Ã Ã Ã ç ~ &lt;üþ826&lt;þ7ü?ÿ?ÿ ÃÃÃç&lt;~0&lt;&lt;~8ç0Ã0Ã9Ç  ?ÿ?ÿ  ÿÿ8 0 8 ÿÿ ÿÿ &lt; &lt;  ÿ ÿ?ÿ?ÿ ÀàÀ ?ÿ?ÿ0&lt;&lt;ðð&lt;&lt;0  ? ð?À?À ð ? 8&lt;?3Ã0ó0?00?ÿ?ÿ000   &lt; ðÀ &lt; 0 000?ÿ?ÿ À ` 0 ` À0 0 0 0 0 0 ?ÿ       ?ÿ??À```?À??ð?ð303030?ðàà?ð0000008p`?ð?ð000000?ðà?ð?ð30303000?ð?ð000 0à?ð003030?0 ?ð?ð   ?ð?ð0`?à?à0` 8 0 0 ?ðð?ð?ðÀ`800?ð?ð0 0 0 0 ?ð?ð à à?ð?ð?ð?ð à ?ð?ðà?ð000000?ðà?ð?ð000ðàà?ð004080ð/à?ð?ð0003ð!àà;ð303030&gt;p` 0 0?ð?ð 0 0ð?ð0 0 0 ?ððàà 8 8  àà?ðð    ð?ð008pÀÀ8p00 p ð? ?  ð p0080&lt;0703°0ð0p0000</td></tr>
+<tr><td>45</td><td>Standard</td><td>New Font</td><td>User</td><td>15</td><td>1</td><td>15dvw.fnt</td><td>2</td><td>15X DOUBLE STROKE      `        ° À Ð à æ î ö,0@P\l|¬¼ÌÜàæø&amp;6FVfv¢²¾ÌÜêþ 0@P`p¤¸ÌÜæö 2        gÿgÿÿÿÿÿÿÿÿÿ0?þ?þ00?þ?þ00|0þ0Æÿÿ0Æ?Æ0&lt; À ð &lt;00 ?qß`qa¿6 ,    ðüx``xüð0àüüà0 À À Àøø À À À@ | &lt;  À À À À À À À À` ` 0 &lt;  À ð &lt;  ü?þp``p?þü``ÿÿ` ` `pxngaç`~`8p``ÃpÇ?þ&lt; à ð Ø Ì Æÿÿ Àÿ0ÿ`Ã`Ã`ÃpÃ? ü?þq`Ã`ÃpÃ?  ~ã {  ?¾qç`Ã`Ãqç?¾|0þaaapÇ?þü00@ |0&lt;0 À`00`@000000@`00`À    ggÃ g ~ &lt;ü?þpcãgóf7gþüøüüøÿÿ`Ã`Ã`Ãqç?þ&lt;ü?þp``p8ÿÿ```p?þüÿÿ`Ã`Ã`Ã`Ã`ÿÿ Ã Ã Ã Ã ü?þp`aa?ÿÿ À À À Àÿÿ``ÿÿ`` 8 p ` p ?ÿÿÿÿ ÀÀð&lt;x`ÿÿ` ` ` ` ` ÿÿ &lt; ðÀÀ ð &lt;ÿÿÿÿ  xà ÿÿü?þp``p?þüÿÿ Ã Ã Ã ç ~ &lt;ü?þpdlx?þoüÿÿ ÃÃÃçx~`&lt;&lt;0~pç`Ã`ÃqÇ?   ÿÿ   ÿ?ÿp ` ` p ?ÿÿÿÿ x x  ÿÿÿÿ àà ÿÿ`x&lt;pÀÀp&lt;x`   &lt; ðÀÀ ð &lt;  p|ocÃ`ó`?``ÿÿ```   &lt; ðÀ &lt; 0 ```ÿÿ  À ` 0 ` À ` ` ` ` ` ` ÿ@@@@@@@@ÿ</td></tr>
+<tr><td>46</td><td>Standard</td><td>New Font</td><td>User</td><td>16</td><td>1</td><td>16dvw.fnt</td><td>2</td><td>16X DOUBLE STROKE      `        ° Ä Ö è î ö þ&amp;,&lt;@Rdp¦¸ÊÜî 
+,&gt;P`r¨¸ÈÚìø*&gt;PbtªºÌàô.&lt;N\n~        ÏÿÏÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ0?þ?þ00?þ?þ0 x`üaÎaÿÿÿÿas? Àð&lt; À ðà&lt;àà&gt;  áÀÿÁáÇ?Üp Ð    ð?üðÀÀð?üð0`À?ü?üÀ`0øøÀ ü &lt;  À À À À À À À ÀÀ À À ð &lt;  À ð &lt;  ?üþàÀÀÀàþ?üÀÀÿÿÿÿÀ À àðØÌÆÃÁçÀ~À0pàÀÁÁáþ&gt;|Àà°ÿÿÿÿ ÿ`ÿÀÃÀÃÀÃÀÃáÃ? ?üþãÁÁÁá&gt;   þÿã {  &gt;&lt;~ãÇÁÁÁãÇ~&gt;&lt; |`þÁÁÁÁàÇþ?ü00À ü0&lt;0 À`00`@````````@`00`À     ÏÏÃ ç ~ &lt;?üþàÇÃÏãÌgÏþüÿðÿøÿøÿðÿÿÿÿÁÁÁÁãÇþ&gt;|?üþàÀÀÀàp0ÿÿÿÿÀÀÀÀàþ?üÿÿÿÿÁÁÁÁÁÀÿÿÿÿ ?üþàÀÃÃÃÿÿÿÿÿÿÿÿÿÀÀÿÿÿÿÀÀ0 p à À À à ÿ?ÿÿÿÿÿÀð&lt;&lt;ðÀÿÿÿÿÀ À À À À À ÿÿÿÿ &lt; ðÀÀ ð &lt;ÿÿÿÿÿÿÿÿ &lt; ðÀ &lt; ÿÿÿÿ?üþàÀÀÀàþ?üÿÿÿÿÇ þ |?üþàÀÈØðþßüÿÿÿÿ=ÇðþÀ| |`þáÇÁÁÁã&gt;   ÿÿÿÿ   ?ÿÿà À À À à ÿ?ÿ ÿÿ &lt; ð ð &lt;  ÿ ÿÿÿÿÿ&gt;  ÀÀ &gt; ÿÿÿÿÀð&lt;&lt;pÀÀp&lt;&lt;ðÀ   &lt; ðÿÀÿÀ ð &lt;  àðüÏÃÃÀóÀ?ÀÀÿÿÿÿÀÀÀÀÀ   &lt; ðÀ &lt; ð À ÀÀÀÀÀÿÿÿÿ   À ` À  À À À À À À À À ÿÿÿÿ</td></tr>
+<tr><td>48</td><td>16dfw</td><td>New Font</td><td>User</td><td>16</td><td>1</td><td>L16dfw.fnt</td><td>2</td><td>16X DOUBLE STROKE      z   ¸ Ê Î Þ î&amp;,4&lt;Pdjz~¢´ÆØêü 2DHN`p¤¶ÈÚìþ&quot;4@Pbrª¼Îàò(&lt;Pdv¤¶ÆÚî*&gt;Nbvz²ÆÚî*:Nbv°                  ÏÿÏÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ0?þ?þ00?þ?þ0 x`üaÎaÿÿÿÿas? Àð&lt; À ðà&lt;àà&gt;  áÀÿÁáÇ?Üp Ð    ð?üðÀÀð?üð0`À?ü?üÀ`0øøÀ ü &lt;  À À À À À À À ÀÀ À À ð &lt;  À ð &lt;  ?üþàÀÀÀàþ?ü  ÀÀÿÿÿÿÀ À     àðØÌÆÃÁçÀ~À0pàÀÁÁáþ&gt;|Àà°ÿÿÿÿ ÿ`ÿÀÃÀÃÀÃÀÃáÃ? ?üþãÁÁÁá&gt;   þÿã {  &gt;&lt;~ãÇÁÁÁãÇ~&gt;&lt; |`þÁÁÁÁàÇþ?ü00À ü0&lt;0 À`00`@````````@`00`À     ÏÏÃ ç ~ &lt;?üþàÇÃÏãÌgÏþüÿðÿøÿøÿðÿÿÿÿÁÁÁÁãÇþ&gt;|?üþàÀÀÀàp0ÿÿÿÿÀÀÀÀàþ?üÿÿÿÿÁÁÁÁÁÀ  ÿÿÿÿ   ?üþàÀÃÃÃÿÿÿÿÿÿÿÿÿÀÀÿÿÿÿÀÀ0 p à À À à ÿ?ÿÿÿÿÿÀð&lt;&lt;ðÀÿÿÿÿÀ À À À À À ÿÿÿÿ &lt; ðÀÀ ð &lt;ÿÿÿÿÿÿÿÿ &lt; ðÀ &lt; ÿÿÿÿ?üþàÀÀÀàþ?üÿÿÿÿÇ þ |?üþàÀÈØðþßüÿÿÿÿ=ÇðþÀ| |`þáÇÁÁÁã&gt;   ÿÿÿÿ   ?ÿÿà À À À à ÿ?ÿ ÿÿ &lt; ð ð &lt;  ÿ ÿÿÿÿÿ&gt;  ÀÀ &gt; ÿÿÿÿÀð&lt;&lt;pÀÀp&lt;&lt;ðÀ   &lt; ðÿÀÿÀ ð &lt;  àðüÏÃÃÀóÀ?ÀÀÿÿÿÿÀÀÀÀÀ   &lt; ðÀ &lt; ð À ÀÀÀÀÀÿÿÿÿ   À ` À  À À À À À À À À ÿÿÿÿ&gt;  ãÁÁÁÁc ÿÿÿÿÿÿc ÁÁÁÁã &gt; &gt;  ãÁÁÁÁãc &quot; &gt;  ãÁÁÁÁc ÿÿÿÿ&gt;  ÉÉÉÉÉÉo .   ÿøÿü&lt;8&#x27; oÍÍÍÍÍÍ?ÿÿÿÿ ÿ þ ÿ°ÿ°p ð À À À À ÿ°°ÿÿÿÿ  1`ÀÀ`0ÿÿÿÿÿÿ  ÿÿ ÿÿ ÿ þ &gt;  ãÁÁÁÁã &gt; ÿÿ    ÿÿÿÿ   &amp; g ÉÉÉÉÉÉ{ 2  À À Àÿüÿü À À À?à À À À À à ?0 ` À À ` 0 ?À À x x À À ?Àa3    3 aÀ  GÏØ Ø Ø Ø Ì ÿáññÙÉÍÅÇÃÃ</td></tr>
+<tr><td>49</td><td>Standard</td><td>New Font</td><td>User</td><td>6</td><td>1</td><td>6vw.fnt</td><td>1</td><td>6X SINGLE STROKE       i       £ ¨ ­ ² ³ µ · ¼ Á Ã Æ È Í Ñ Ô Ø Ü á å é í ñ õ ö ø û ÿ	&quot;&amp;*-159&gt;CGKPTX]afkpuz£§«¯³·¼   /????
+
+
+$*?*&quot;&quot;&#x27;+(!!*&gt;*&gt; 00 !!&quot;? &quot;1)&amp;!%%
+?&#x27;%%%%9%%)) &quot;
+
+
+
+&quot;-!-/&lt;
+	
+&lt;?%%!!&quot;?!!?%%!?!)9??!?!  ?
+1?   ????!!?		!).?	&amp;&quot;%%?   ??1
+
+181)%#!??!!! !!!??    ?!!!?                                    </td></tr>
+<tr><td>50</td><td>Standard</td><td>New Font</td><td>User</td><td>16</td><td>1</td><td>F16vw.fnt</td><td>1</td><td>16X DOUBLE STROKE      }   ¾ Ä È Ø è ø *4DTZjp¬¼ÎÞîþ$*&lt;HZj|¬¼ÌÜìü0@Rbr¦¶ÆÔäö&amp;6FVht°ÄØìü$(8JNfz¢¶ÊÞî.BVj~      3ÿ3ÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ0üü00üü0|þÆ?ÿ?ÿÆÆ Ä `0 9ó0s1¿6?&#x27;    àø88øà0àüüà0 À À Àøø À À À. &gt;   À À À À À À À À8 8 8 0 &lt;  À ð &lt;  ü?þp``p?þü``ÿÿ` ` `pxngaç`~`8p``ÃpÇ?þ&lt; À à ð Ø Ì Æÿÿ Àÿ0ÿ`Ã`Ã`ÃpÃ? ü?þq`Ã`ÃpÃ?  ~ã {  ?¾qç`Ã`Ãqç?¾|0þaaapÇ?þü888.8&gt;88À`00`À000000À`00`À   33Ã g ~ &lt;øÀ¿°Æ°F°F¿þü?ø?ü?ü?ø?ÿ?ÿ0Ã0Ã0Ã9çþ&lt;üþ8008?ÿ?ÿ0008þü?ÿ?ÿ0Ã0Ã0Ã0Ã00?ÿ?ÿ Ã Ã Ã Ã  üþ8011??ÿ?ÿ À À À À?ÿ?ÿ000?ÿ?ÿ000  8 0 0 8 ÿÿ?ÿ?ÿ Àà00 ?ÿ?ÿ0 0 0 0 0 0 ?ÿ?ÿ &lt; ðÀ ð &lt;?ÿ?ÿ?ÿ?ÿ 8 ðÀ ?ÿ?ÿüþ8008þü?ÿ?ÿ Ã Ã Ã ç ~ &lt;üþ826&lt;þ7ü?ÿ?ÿ ÃÃÃÃÃç0~ &lt;&lt;~8ç0Ã0Ã9Ç   ?ÿ?ÿ   ÿÿ8 0 8 ÿÿ ÿÿ &lt; &lt;  ÿ ÿ?ÿ?ÿ ÀàÀ ?ÿ?ÿ0&lt;&lt;ðð&lt;&lt;0  ? ð?À?À ð ? 8&lt;?3Ã0ó0?00?ÿ?ÿ?ÿ00000   &lt; ðÀ &lt; 0 00000?ÿ?ÿ?ÿ ` 0      0 `0 0 0 0 0 0 ÿ@@@@@@@@ÿ@?`303030303030ð?à?ÿ?ÿ0À0À0À0À0À9À À?à8à0`0`0`0`0`8àÀ 9À0À0À0À0À0À?ÿ?ÿÀ3`3`3`3`3`3`À À À À?þ?ÿ Ã Ï Îà;ð303030303030?ðð?ÿ?ÿ À À À ÀÀ?? ?Ø?Ø  8 0 0 8 ØØ?ÿ?ÿÀÀ`00 ?ÿ?ÿ?à?à À ` `ÀÀ à ` à?À??à?à À ` ` ` ` à?À?À8à0`0`0`0`8àÀ?ð?ð00000pàÀÀàp00000?ð?ð?à?à À ` ` ` ` ` à Àà;ð303030303030?p` ` ` `?þ?þ ` ` `àà8 0 0 0 0 8 àààà  0 0   àààà8 0 8 8 0 8 àà  0`À
+  
+À0`  ð;ð3 3 3 3 3 3 ?ðð8`&lt;`4`6`2`3`1`1à0à0à Àþ?ÿ800000????000008?ÿþ À</td></tr>
+<tr><td>51</td><td>8X14</td><td>New Font</td><td>User</td><td>14</td><td>1</td><td>8x14.fnt</td><td>2</td><td>8X14 DOUBLE STROKE    `    ¤ ´ Ä Ô ä ô$4DTdt¤´ÄÔäô$4DTdt¤´ÄÔäô$4DTdt¤´ÄÔäô$4DTdt                      3ÿ3ÿ      ?ÿ?ÿ?ÿ?ÿ?ÿ?ÿ?ÿ?ÿ0üü00üü0|þÆ?ÿ?ÿÆÆ0&lt; À ð &lt;00 9ß q!¿6 ,                  àø8    8øà    0àüüà0 À À Àøø À À À    . &gt;         À À À À À À À À    8 8 8       0 &lt;  À ð &lt;  üþ8008þü  00?ÿ?ÿ0 0   08&lt;631ç0~0800Ã8Çþ&lt; à ð Ø Ì Æ?ÿ?ÿ À0c0c0c8cÃüþ90Ã0Ã8Ã  &gt;?ã {  ¾9ç0Ã0Ã9ç¾&lt;~0Ç0Ã0Ã8gþü    888          .8&gt;88       À`00 00000000 00`À    33Ã g ~ &lt;üþ
+ö
+ö
+
+þü?ø?ü?ü?ø?ÿ?ÿ0Ã0Ã0Ã9çþ&lt;üþ8008?ÿ?ÿ0008þü?ÿ?ÿ0Ã0Ã0Ã0Ã0Ã0?ÿ?ÿ Ã Ã Ã Ã Ã üþ8011??ÿ?ÿ À À À À?ÿ?ÿ  00?ÿ?ÿ00    0 0 0 0 ÿÿ?ÿ?ÿ À Àð&lt;&lt;0?ÿ?ÿ0 0 0 0 0 0 ?ÿ?ÿ &lt; ð ð &lt;?ÿ?ÿ?ÿ?ÿ 8 ðÀ ?ÿ?ÿüþ8008þü?ÿ?ÿ Ã Ã Ã ç ~ &lt;üþ826&lt;þ7ü?ÿ?ÿ ÃÃÃç&lt;~0&lt;&lt;~8ç0Ã0Ã9Ç   ?ÿ?ÿ   ÿÿ8 0 0 8 ÿÿ ÿÿ &lt; &lt;  ÿ ÿ?ÿ?ÿ ÀÀ ?ÿ?ÿ0&lt;&lt;ðð&lt;&lt;0  ? ð?À?À ð ? 8&lt;?3Ã0ó0?00?ÿ?ÿ?ÿ00000   &lt; ðÀ &lt; 0 00000?ÿ?ÿ?ÿ À ` 0   0 ` À0 0 0 0 0 0 0 0 ?ÿ      ?ÿ</td></tr>
+<tr><td>52</td><td>5x7</td><td>New Font</td><td>User</td><td>7</td><td>1</td><td>5x7.fnt</td><td>1</td><td>5X7 SINGLE STROKE     ~  À Å Ê Ï Ô Ù Þ ã è í ò ÷ ü$).38=BGLQV[`ejoty~¡¦«°µº¿ÄÉÎÓØÝâçìñöû 
+#(-27&lt;AFKPUZ_dinsx}       _  $**#db6IV P      &quot;AA&quot;  &gt;&gt; @0     ``   &gt;AAA&gt; B@ BaQIF AIM3&#x27;EEE9&lt;JII0q	6III6II)     @4  &quot;A  A&quot;Y&gt;A]YN||III6&gt;AAA&quot;AAA&gt;IIIA			&gt;AAQq AA  @@@?&quot;A@@@@&gt;AAA&gt;			&gt;AQ!^	)F&amp;III2?@@@? @   ccxaQIECAAA AAA@@@@@AAA xx HH0 8DDH 0HH 8TTX ~	 8DT0 p  ú    @@&gt; (D    |xx |x 8DD8 | | | HTT$ ?D  &lt;@@&lt; @ &lt;@8@&lt;D((Dp DdTL  UUUUU   *****</td></tr>
+<tr><td>53</td><td>Luminator</td><td>New Font</td><td>User</td><td>5</td><td>1</td><td>L5vw.fnt</td><td>1</td><td>5X SINGLE STROKE       i       £ ¨ ­ ² ³ µ · ¼ Á Ã Æ È Í Ñ Ô Ø Ü á å é í ñ õ ö ø û ÿ	&quot;&amp;*-159&gt;CGKPTX]afkpuz£§«¯³·¼   
+
+
+	
+
+
+
+
+
+
+
+
+
+
+
+	
+
+
+	
+	
+
+                                    </td></tr>
+<tr><td>54</td><td>Luminator</td><td>New Font</td><td>User</td><td>5</td><td>1</td><td>L5dvw.fnt</td><td>2</td><td>5X DOUBLE STROKE       `          £ ¥ ¨ « ° ¶ ¹ ¼ ¾ Ä Ê Î Ó Ø Þ ã é î ô ú ü ÿ!&#x27;-27=CGLRW^ekqw}¢¨®³¹¾ÃÇÎ   
+
+
+	
+
+	
+
+
+
+
+
+
+
+
+
+
+	
+	</td></tr>
+<tr><td>55</td><td>Luminator</td><td>New Font</td><td>User</td><td>6</td><td>1</td><td>L6dvw.fnt</td><td>2</td><td>6X DOUBLE STROKE       `          ¢ ¥ ¨ « ° ¶ ¹ ¼ ¾ Ã É Í Ó Ù ß ä ê ð ö ü þ	
+$*05:@FJOUZahntz ¦¬²·¼ÁÆÊÑ   //???????$*?*363%*(!!&gt;&gt;&gt; 8000?!!?&quot;?? 2;)-&#x27;&amp;3!%?
+	??7%=?%%=19
+?%%?/))? ;6&quot;&quot;6)-?!)-/&lt;&gt;&gt;&lt;??%%??!!3??!!???%%!???!):????!??!0 ???3!??   ?????????!!???		?!1.??	?&amp;7%-;???  ?0????#66#&lt;&lt;!19-&#x27;#??!!!0!!!??````?!!!!!?</td></tr>
+<tr><td>58</td><td>Luminator</td><td>New Font</td><td>User</td><td>7</td><td>1</td><td>L7dvws.fnt</td><td>2</td><td>7X DOUBLE STROKE X5    ~  À Ã Å Ê Ï Ô Ù Þ à ã æ ë ð ò õ ÷ ü
+#(-/159=BGLQV[`ejosx}¤©­²·¾ÄÊÐÕÚßäèíñõùý	
+ $(,047;@EJOSX]bg   __$**3fc6IV P&gt;AA&gt;&gt;&gt;p0```0&gt;A&gt;B@bsYOF&quot;cI6/oIy1&gt;Iy2qy6I6&amp;OI&gt;66v66cc6QY&gt;AYU_|~~|I6&gt;Ac&quot;A&gt;IIA		&gt;ASrAA `@?6c@@@&gt;A&gt;	&gt;A1^f&amp;oI{2?`??`?00c66cxxaqYMGCAAA0AAA@@@@AAA$TTxDD88DDD8DD8TTX~	HTT&lt;x} @@=(D|xx|x8DD8|||HTT$?D&lt;@@&lt; @ &lt;@8@&lt;D((DpDdTL  UUUUU   *****</td></tr>
+<tr><td>59</td><td>Luminator</td><td>New Font</td><td>User</td><td>8</td><td>1</td><td>L8vw.fnt</td><td>1</td><td>8X SINGLE STROKE  4    ~   À Ã Ä É Î Ó Ù Þ à ã æ ë ð ò ö ø ý
+#(-.048&lt;AFKPUZ^bglosx|¤©®³¸½ÃÈÍÒ×Ûàäèìðôøü 	
+#&#x27;*.38=AEJOTY   ¿ÿÿÿÿÿDJÿR&quot;Ã#ÄÃv` &lt;BB&lt;&quot;&quot;&gt;`ÀÀ ~~ÿÂ¡BvÿOp~rñ	vvN~$d(DD(¹~¹¥¿üüÿv~Bÿ~ÿÿ		~rÿÿÿ@ÿ$Bÿÿÿÿÿ~~ÿ			~¡A¾ÿ)IFrÿ?@@?ÿ`8`ÿÃ$$ÃðÁ¡ÿÿ ÿÿÿÿH¨¨ðÿpppÿp¨¨°þ	¨¨xÿðú@zÿ Pÿøððøðppø((((øø¨¨Hþxx8@@8xpxP P  xÈ¨ÿ ÿ ÿUUUUU ÿ ÿ ªªªªª</td></tr>
+<tr><td>60</td><td>Luminator</td><td>New Font</td><td>User</td><td>8</td><td>1</td><td>L8dvw.fnt</td><td>2</td><td>8X DOUBLE STROKE       `          ¥ ¨ « ® ´ º ½ Â Ä Ê Ð Ô Ú à æ ì ò ø þ	&quot;(.4:?DJPTY_dkrx~£ª±·½ÂÈÍÔØß   ßßÿÿÿÿÿ$ÿ$ÿ$DJÿÿR&quot;Ãã0ÇÃ`ö®@ &lt;~~&lt;&quot;&quot;~~à`ÀÀ`0~ÿÿ~ÿÿÂã±BÃÿvÿÿOÏùp~ÿùráñvÿÿvNÿ~66æf8lÆÆl8ÑÙ~ÿ¹¥¾üþþüÿÿÿv~ÿÃBÿÿÿ~ÿÿÿÿ		~ÿsòÿÿÿÿÿÿ@Àÿÿÿ6ãÁÿÿÿÿÿÿÿÿ0ÿÿ~ÿÿ~ÿÿ		~ÿ¡¾ÿÿ9ïÆFÏûrÿÿÿÿ?`À`?ÿ00ÿÃç&lt;&lt;çÃøøÁá±ÿÿ0`ÿÿÿÿ</td></tr>
+<tr><td>61</td><td>Luminator</td><td>New Font</td><td>User</td><td>9</td><td>1</td><td>L9vw.fnt</td><td>1</td><td>9X SINGLE STROKE      	 ~  À Ì Ø ä ð ü ,8DP\ht¤°¼ÈÔàìø(4@LXdp| ¬¸ÄÐÜèô $0:FT`p~¨´ÂÎÚæðü*68BLN^jt¤®ºÄÒÜæðüþ
+                                       L ÿ   d B %  H ¤ B Æ). À@             8 D       D 8             |          `                  @     @       |   |  ÿ     A!  î 0 ( $ &quot;ÿ   á ðH$&quot;! À  ñ 	   î î  þ       P          Ð      ( D      ( ( ( ( (    D (   q    È$$$Äøü &quot; ! ! &quot;üÿ î þ ÿ  |ÿÿ      þ!!! âÿ    ÿ  ÿ  ÿ  ÿ  ( D ÿ     ÿ    ÿÿ     ÿ þ þÿ      þ!A ~ÿ  1 Q   â  ÿ   ÿ     ÿ ? @    @ ?ÿ  @ @ ÿ  D 8 8 D    ð   A!	  ÿ           @     ÿ               ÿÿ PPPPàÿ à à   àÿ àPPPP` þ     PPPP ðÿ     àô À    ôÿ   P ÿð     `  àð     à à àð P P P P     P P P Pðð        PPPP   ü   ð     ð p    p ð   à   ð   @  0@@@ ðP0  þ  ï   þ       </td></tr>
+<tr><td>62</td><td>Luminator</td><td>New Font</td><td>User</td><td>9</td><td>1</td><td>L9dvw.fnt</td><td>2</td><td>9X DOUBLE STROKE      	 `       ¤ ° ¼ È Î Ö Þ ê ö ü
+&quot;*6BNZfr~ ¬¸ÄÔàìø&amp;2:DPZhv¦²¾ÊØæô &quot;,:DR      ÿÿÿÿÿÿ Dÿ Dÿ D  ÿÿ  b Ã ã 0  Æï9o Æ@    | þ þ | D ( þ þ ( D   ~ ~   À À      À ` 0    þÿÿ þÿÿ Ãa1 ÿ î 0 ( $þÿ   ñ à þÿó â  áù   îÿÿ î ÿ þ Ì Ì Ì Ì  8 l Æ $ $ $ $ $ $ Æ l 8   ±¹   þÿ»«¿ &gt;üþ # #þüÿÿÿ î þÿ ÿÿÿ þÿÿÿÿ    þÿ óò  ÿÿ  ÿÿÿÿ  ÿ ÿÿÿ 8 lÇÿÿ   ÿþ   þÿÿÿ  8 àÿÿ þÿÿ þÿÿ     þÿA ÿ~ÿÿ 1 qß ó â  ÿÿ   ÿÿ  ÿ ÿ ?  À À  ?ÿ ÿ ` 0 ` ÿÿÇ l 8 lÇ  ðð  Áqÿÿ    0 ` Àÿÿ ` 0    0 `ÿÿ</td></tr>
+<tr><td>63</td><td>Luminator</td><td>New Font</td><td>User</td><td>10</td><td>1</td><td>L10vw.fnt</td><td>1</td><td>10VW ONT              
+!~  ¾ À Æ Ö ä ò &quot;04BFT`jv¦²¾ÊÌÐÚäîø&quot;0&gt;LXdpz¢²ÂÐÞìú&quot;.&gt;N\lr~¨´ÀÌØäîø*6BLV`jt¦°¼ÆÈÒÞÿ     $ $ ÿ $ $ ÿ $ $ &quot;&quot;ÿ&quot;&quot; Ä B %   $ R !î)Vè   ü ü !   ?   !    þ                @      ü
+!B üÿ  A!!!!Þ 0 ( $ &quot;ÿ  áàP($&quot;Á  ñ 	  Þ!!!!Þ     þ°     P  P P P P P  P    á   ðÄ$$( ðü &quot; ! ! ! &quot;üÿ!!!!!Þþÿ üÿ!!!!ÿ ! ! !  þ!!âÿ        ÿÿÿ   ÿ 0 H ÿ     ÿ      ÿÿ      @ ÿþþÿ ! ! ! ! ! þþÿ ! ! a ¡!!!!!!Æ   ÿ   ÿ    ÿ ÿ     ÿÿ   @ @  ÿ  x x    à   A!	ÿ      @ ÿ           ÿÿPPPPàÿàà àÿàPPPP` þ    PPPðÿ     àô   ôÿ ` ÿð    `  àð     àààð P P P     P P Pðð       PPP  þ  ð    ð ð     ðð  à  ð  À À 0@@@ðP0  ÞÏÞ        </td></tr>
+<tr><td>64</td><td>Luminator</td><td>New Font</td><td>User</td><td>10</td><td>1</td><td>L10dvw.fnt</td><td>2</td><td>10X DOUBLE STROKE     
+ ~   À Æ Ê Ø è ø&quot;*:JPZ^lz¬ºÈÖäòöü ,&lt;JXft¨´ÀÎÚêø&quot;0&gt;JXhx¦°¾ÈÖàðþ
+&quot;.&lt;HTXdptª¶ÂÎÚæò&amp;26BR      ??ÿÿÿÿÿÿÿ Ìÿÿ Ì Ìÿÿ Ì &gt;2ÿÿ2ò àÃ ` 0 Æï9oÆ    üþþ ü Ì xÿÿ x Ì 0 0 0þþ 0 0 0  0 0 0 0 0   À ` 0    üþc3þ üÿÿ Ãc333ÿÎ p x l fÿÿ `¿¿333óãþÿ333çÆ  ãó   Îÿ333ÿÎ333ÿþ Ì Ì    p Ø Ì Ì Ì Ì Ì Ì Ø p    cs  þÿ3{K &gt;øü f c füøÿÿ333ÿÎþÿÿÿÿþÿÿ333ÿÿ 3 3 3 þÿ33óòÿÿ 0 0 0ÿÿÿÿ  ÿÿÿÿ x Ìÿÿ    ÿÿ  8 8 ÿÿÿÿ  8 àÿÿþÿÿþÿÿ 3 3 3 ? þÿCÿþÿÿ s ó³?¿333çÆ  ÿÿ  ÿÿ   ÿÿ  ? à à ? ÿÿ À p p Àÿÿ Ì x x Ì   ðð   Ãc3ÿÿ    0 ` Àÿÿ ` 0    0 `     ÿÿÐPPPðàÿÿ00ðààð0 àð00ÿÿàðPPp` 0 0þÿ 3 7 6 pPPððÿÿ 0 0ðàöö  ööÿÿ ` ðÿÿðð ` 0 à 0ààðð   0 0ðààððàðð   ð ` ` ð  ðððà 0 0 0  `ðÐÐÐ 0 0þþ 0 0ðð  ðð ðð  ð ððð ÀÀ ðð0àà00p@@ðð0°°pp0 0þÿßßÿþ 0 8 &lt;   0 0  </td></tr>
+<tr><td>65</td><td>Luminator</td><td>New Font</td><td>User</td><td>11</td><td>1</td><td>L11dvw.fnt</td><td>2</td><td>11X DOUBLE STROKE      }   ¾ Ä È Ö æ ö (8HNX\jxª¸ÆÔâðôú&quot;0@N\jx¢°¼ÊØæö .&lt;JZhx¨¶ÀÎØæð *8FTbpt¦´ÂÐÞìú
+&amp;6DR`nr      ÿÿÿÿÿÿÿþþþþ&gt;&amp;ÿÿ&amp;æÆà p Þÿ{ß@À   üþþü ðþþ ð ` ` `üü ` ` `    0 0 0 0 0    À ` 0  üþÃc3þüÿÿ Ãc333ÿÎ p x l fÿÿ `??333óãþÿ333çÆ  Ãã 3  ß###ß?cccÿþ    p Ø Ø p    Ãã 3  þÿsûËÿ ~øü Æ Ã Æüøÿÿ333ÿÎþÿÿÿÿþÿÿ333ÿÿ 3 3 3  þÿccçæÿÿ 0 0 0ÿÿÿÿ     ÿÿÿÿ p Øÿÿ     ÿþ  p p þÿÿÿ  pÀÿÿþÿÿþÿÿ c c c  &gt;þÿÿþÿÿ ããw&gt;?333çÆ   ÿÿ   ÿÿ   ÿÿ  À  À  ÿÿÀ à àÀÿÿ Ø p p Ø   ðð   Ãó?ÿÿ   0 ` À ÿÿ À ` 0  0 ` À     ÿÿ °ðàÿÿ000ðààð0000 àð000ÿÿàð°°°ðà 0 0þÿ 3 3 6`ðððÿÿ 0 0 0ðàöö   ööÿÿ à°ÿÿðð   0ðà 0ðàðà 0 0 0ðààð000ðàðð    ð ` ` ð   ðððð ` 0 0 0 ``ð°°°°  0 0 0þþ 0 0 0ðð   ðð ðð   ð ððð ÀÀ ðð0à Àà0pððð00°°ðpp `þÿßßÿþ `</td></tr>
+<tr><td>66</td><td>Luminator</td><td>New Font</td><td>User</td><td>12</td><td>1</td><td>L12dvw.fnt</td><td>2</td><td>12X DOUBLE STROKE      }   ¾ Ä È Ø è ø$,&lt;LR\`n|¤²ÀÎÜêøü*8HVdrª¸ÄÒàîþ(6DRbp °¾ÈÖàîø(8HXhx¬°ÄÔäô$4DTdt¤¨¸      ÿÿÿÿÿÿÿÿÿÿþþþþ&lt;~fÿÿfæÆÀ ð &lt;ßósß 	    ðüü ð ðþþ ð ` ` `üü ` ` `    ` ` ` ` `    À ð &lt;  üþÇc7þüÿÿ  
+Ãc?ccÿ p x l fÿÿ `??333óãþÿcccçÆ  Ãã 3  ¿ócó¿&gt;cccÿþ  @ à°° à @  
+
+Ã c ? þÿó
+û
+
+ÿ þøü Æ Ã Æüøÿÿcccÿþÿÿÿÿþÿÿcccÿÿ c c c  þÿccçæÿÿ ` ` `ÿÿÿÿ     ÿÿÿÿ ðÿÿ     ÿþ  p p þÿÿÿ &lt; ðÀÿÿþÿÿþÿÿ c c c  &gt;þÿ
+ÿþÿÿãcw&gt;&gt;cccçÆ   ÿÿ   ÿÿ   ÿÿ ? ÿ   ÿ ?ÿÿÀÀÿÿ ð ð   ðð   Ãó?ÿÿ   &lt; ðÀ  ÿÿ À ` 0  0 ` À     ÿÿ °°°°°ðàÿÿ000pàÀàð0000p`Ààp000ÿÿàð
+0
+0
+0
+0
+ðà 0 0 0þÿ 3 3 6`ðððÿÿ ` 0 0 0ðàöö      ööÿÿ Àà0ÿÿðà 0 0ðà 0 0ðàðà p 0 0 0ðààð0000ðàðð°°°°ð à àð°°°°ðððà p 0 0 0 0 `à
+ð
+°
+°
+°
+°°  0 0 0ÿÿ 0 0 0ðð    ðððð    ðððð  ðð0`ÀÀ`0ð
+ð
+
+
+
+ðð00
+0
+0°°pp `þÿ¿¿ÿþ `</td></tr>
+<tr><td>67</td><td>Luminator</td><td>New Font</td><td>User</td><td>13</td><td>1</td><td>L13dvw.fnt</td><td>2</td><td>13X DOUBLE STROKE     
+ }  ¾ Ä È Ö æ ö$,&lt;LR\`n|¤´ÂÐÞìúþ 0&gt;N\jx¢°¾ÊØèô .&lt;LZjx¨¸ÊÖäðþ(8HXhx¬¼ÀØêú
+*:JZj~ ´ÄÈØ      ÿÿÿÿÿÿÿÿÿþþþþ&lt;~fÿÿfæÆÀ ð &lt;ßsó@À   ðüüð ðþþ ð ` ` `üü ` ` `    ` ` ` ` `    À ð &lt;  üþÃgþüÿÿ  Ãc?ccÿ à ð Ø Ì Æÿÿ ÀcccãÃþÿcccçÆ  Ã c ? ÿcccÿ~ÿÃÃÃÿþ  @ à°° à @  Ã c ? üþãó7þüøü Æ Ã Æüøÿÿcccÿþÿÿÿÿþÿÿcccÿÿ c c c  þÿÃÃÇÆÿÿ ` ` `ÿÿÿÿ     ÿÿÿÿ à°ÿÿ    ÿþ  p p þÿÿÿ &lt; ðÀÿÿþÿÿþÿÿ c c c  &gt;þÿÿþÿÿãccw&gt;&gt;cccçÆ   ÿÿ   ÿÿ   ÿÿ ÿ  ÿ ÿÿ  ÿÿ¸ðð¸   &lt;ðð &lt;  Ãc3ÿÿ   &lt; ðÀ  ÿÿ À ` 0 ` À     ÿÿ@`````àÀÿÿ```àÀÀà````àÀÀà```ÿÿÀà````à
+À ` ` `þÿ c g f
+Àà````ààÿÿ À ` ` `àÀìì      ììÿÿÀ`0ÿÿàÀ ` ` `ÀÀ ` ` `àÀàÀ à ` ` ` `àÀÀà````àÀàà````àÀÀà````àààÀ à ` ` ` à À	Àà`````@ ` ` `þþ ` ` `àà    àààà    àààà    àà `ÀÀ` àà    àà``````ààà` `þÿ¿¿ÿþ `</td></tr>
+<tr><td>68</td><td>Luminator</td><td>New Font</td><td>User</td><td>14</td><td>1</td><td>L14dvw.fnt</td><td>2</td><td>14X DOUBLE STROKE      }   ¾ Ä È Ø è ø (0@PVfjz¦¶ÆÖæö 0&lt;L\l|¬¼ÌÜìø*&lt;L\l|®ÀÐâò,6DPbtª¼Îàòö6L^p¦¶ÈÚò,&gt;BT      3ÿ3ÿ?ÿ?ÿ?ÿ?ÿ?ÿ?ÿ?ÿ?ÿ0üü00üü0|þÆ?ÿ?ÿÆÆ0&lt; À ð &lt;009ó0ó3?6?&#x27;    ðü&lt;00&lt;üð0àüüà0 À À Àøø À À À  &gt;   À À À À À À À À0 0 0 &lt;  À ð &lt;  üþ;10Ã8gþü00?ÿ?ÿ0 0 &lt;&gt;310Ã0g0&gt;0800Ã8Çþ&lt; à ð Ø Ì Æ?ÿ?ÿ À80c0c0c0cÃüþ90Ã0Ã8Ã   ?Ã?ã 3  ¾9ç0Ã0Ã9ç¾&lt;~0Ç0Ã0Ã8gþü  &gt; À`00 000000 00`À    33Ã g ~ &lt;üþ81ã3ó373þü?ø?ü?ü?ø?ÿ?ÿ0Ã0Ã0Ã9çþ&lt;üþ8008?ÿ?ÿ0008þü?ÿ?ÿ0Ã0Ã0Ã0Ã00?ÿ?ÿ Ã Ã Ã Ã  üþ8011??ÿ?ÿ À À À À?ÿ?ÿ00?ÿ?ÿ00  0 0 0 0 ÿÿ?ÿ?ÿ Àà00?ÿ?ÿ0 0 0 0 0 0 ?ÿ?ÿ &lt; ðà ð &lt;?ÿ?ÿ?ÿ?ÿ 8 ðÀ ?ÿ?ÿüþ8008þü?ÿ?ÿ Ã Ã Ã ç ~ &lt;üþ826&lt;þ7ü?ÿ?ÿÃÃÃÃç0~ &lt;&lt;~8ç0Ã0Ã9Ç   ?ÿ?ÿ   ÿÿ8 0 0 0 8 ÿÿ ÿÿ &lt; &lt;  ÿ ÿ?ÿ?ÿ ÀàÀ ?ÿ?ÿ0&lt;&lt;ðð&lt;&lt;0  ? ð?À?À ð ? 8&lt;?3Ã0ó0?00?ÿ?ÿ000   &lt; ðÀ &lt; 0 000?ÿ?ÿ À ` 0 ` À0 0 0 0 0 0 ?ÿ       ?ÿ@?`3`3`3`3`3`à?À?ÿ?ÿ0`0`0`0`8àÀÀ?à0`0`0`0`0`8àÀÀ8à0`0`0`0`?ÿ?ÿÀ?à3`3`3`3`3`;àÀ À À À?þ?ÿ Ã Ã Ç ÆÀ;à3`3`3`3`3`?àà?ÿ?ÿ À ` ` ` à?À??ì?ì &gt; 0 0 0 0 0 ?ìì?ÿ?ÿÀ`00 ?ÿ?ÿ?à?À à ` `ÀÀ à ` `?à?À?à?À à ` ` ` ` ` à?À?À?à0`0`0`0`0`?àÀ?à?à`````àÀÀà`````?à?à?à?À à ` ` ` ` à ÀÀ;à2`2`2`2`2`&gt;àÀ ` ` `?þ?þ ` ` `à?à0 0 0 0 0 ?àààà  0   àààà0 0 0   0 0 0 àà  0`À
+  
+À0`  à;à3 2 2 2 3 ?àà8`8`&lt;`4`6`2`3`1à1à0à À Àþ?ÿ0000????0000?ÿþ À À</td></tr>
+<tr><td>69</td><td>Luminator</td><td>New Font</td><td>User</td><td>15</td><td>1</td><td>L15dvw.fnt</td><td>2</td><td>15X DOUBLE STROKE      }  ¾ Æ Ê Ú ê ú
+&quot;*2BRXhl| ²ÄÖèú04:LXjz®ÀÒäö*&lt;Pbv¬¾Òäø
+0DXjt ¬ÀÒäö,&gt;PTfx|¦¸ÊÜî &amp;8Pdv¢´        gÿgÿÿÿÿÿÿÿÿÿ0?þ?þ00?þ?þ00|0þ0Æÿÿ0Æ?Æ0&lt; À ð &lt;00?qó`sa¿fNxÀ?o    ðüx``xüð0àüüà0 À À Àøø À À À@ | &lt;  À À À À À À À À` ` 0 &lt;  À ð &lt;  ü?þsa`Ã`cp7?þü` ```ÿÿ` ` ` x|fca`Ã`g`&gt;`8p``Ã`Ãqç?&gt;àðÿÿÿ8ÿpÃ`Ã`Ã`ÃqÃ?ü?þq`Ã`Ã`ÃqÇ?   Ã c 3  ?¾qç`Ã`Ã`Ãqç?¾|8þqÇaaapÇ?þü00@ |0&lt;0 À`00`@000000@`00`À    ggÃ g ~ &lt;ü?þpcãgóf7gþüðøøðÿÿ`Ã`Ã`Ã`Ãsç?~&lt;ü?þp```p8ÿÿ````0üøÿÿ`Ã`Ã`Ã`Ã`Ã``ÿÿ Ã Ã Ã Ã Ã  ü?þp``aa?ÿÿ À À À À Àÿÿ```ÿÿ``` &gt; p ` ` ` p ?ÿÿÿÿÀ`00`@ÿÿ` ` ` ` ` ` ` ÿÿ &lt; ðÀÀ ð &lt;ÿÿÿÿ  xà ÿÿü?þp```p?þüÿÿ Ã Ã Ã Ã ç ~ &lt;ü?þpdlx0þ_üÿÿÃÃÃÃÃ0ç`~@&lt;&lt;0~pç`Ã`Ã`ÃqÇ?    ÿÿ    ÿ?ÿp ` ` ` p ?ÿÿÿÿ x p x  ÿÿÿÿ àà ÿÿ`x&lt;pÀÀp&lt;x`   &lt; ðÀÀ ð &lt;  p|ocÃ`ó`?```ÿÿ```   &lt; ðÀ &lt; 0 ```ÿÿ  À ` 0 ` À ` ` ` ` ` ` ÿ@@@@@@@@ÿ&lt;À~àf`f`f`f`f`?àÀÿÿ````````0À ?Àpà````````0À 0À````````ÿÿ?Ààf`f`f`f`f`wà3À ` ` `þÿ c c g f3Àwàf`f`f`f`f`à?àÿÿ À ` ` ` àÀìì &gt; p ` ` ` p ?ììÿÿ  
+À0``0@ÿÿàÀ ` ` `ÀÀ ` ` `ÀàÀ à ` ` ` àÀ?Àpà``````pà?Ààà`````àÀÀà`````àààÀ à ` ` ` ` à À3Àwàf`f`f`f`f`~à&lt;À ` ` ` `þþ ` ` ` `à?àp ` ` ` p ?àààà 0 ` 0  ààà?àp ` ` ? ? ` ` p ?àà@``À1    1`À@`3àwàf f f f f à?àp`p`x`l`d`f`b`c`aà`à`à Àü?þp```  ```p?þü À</td></tr>
+<tr><td>70</td><td>Luminator</td><td>New Font</td><td>User</td><td>16</td><td>1</td><td>L16dvw.fnt</td><td>2</td><td>16X DOUBLE STROKE      }   ¾ Æ Ê Ú ê þ$*2:Nbhx| ¬¾Ðâô*&lt;@FXhz®ÀÒäö,@Rfx°ÂÔèú 4H\p¢°ÂÒæú&quot;6J^r²¶Îâö
+2FZn°ÄØìð        ÏÿÏÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ0?þ?þ00?þ?þ0 x`üaÎaÿÿÿÿas? Àð&lt; À ðà&lt;àà&gt;?áãÀãÁÿÇ| 1ß Î    ð?üðÀÀð?üð0`À?ü?üÀ`0øøÀ ü &lt;  À À À À À À À ÀÀ À À ð &lt;  À ð &lt;  ?üþæÃÁÀÃàgþ?üÀÀÿÿÿÿÀ À ðøÌÆÃÁÀÇÀ~À&lt;0pàÀÁÁáþ&gt;|Àà°ÿÿÿÿ ÿ`ÿÀÃÀÃÀÃÀÃáÃ??üþãÁÁÁá&gt;   ÿÿÃ c 3  &gt;&lt;~ãÇÁÁÁãÇ~&gt;&lt; |`þÁÁÁÁàÇþ?ü00À ü0&lt;0 À`00`@````````@`00`À     ÏÏÃ ç ~ &lt;?üþàÇÃÏãÌgÏþüÿðÿøÿøÿðÿÿÿÿÁÁÁÁãÇþ&gt;|?üþàÀÀÀàp0ÿÿÿÿÀÀÀÀàþ?üÿÿÿÿÁÁÁÁÁÀÀÿÿÿÿ  ?üþàÀÃÃÃÿÿÿÿÿÿÿÿÿÀÀÀÀÿÿÿÿÀÀÀÀ8 x à À À À à ÿ?ÿÿÿÿÿÀ`00`ÀÿÿÿÿÀ À À À À À À ÿÿÿÿ &lt; ðÀÀ ð &lt;ÿÿÿÿÿÿÿÿ &lt; ðÀ &lt; ÿÿÿÿ?üþàÀÀÀàþ?üÿÿÿÿÇ þ |?üþàÀÈØðþßüÿÿÿÿ
+1aÇÀþ| |`þáÇÁÁÁã&gt;    ÿÿÿÿ    ?ÿÿà À À À à ÿ?ÿ ÿÿ &lt; ð ð &lt;  ÿ ÿÿÿÿÿ&gt;  ÀÀ &gt; ÿÿÿÿÀð&lt;&lt;pÀÀp&lt;&lt;ðÀ   &lt; ðÿÀÿÀ ð &lt;  àðüÏÃÃÀóÀ?ÀÀÿÿÿÿÀÀÀÀÀ   &lt; ðÀ &lt; ð À ÀÀÀÀÀÿÿÿÿ   À ` À  À À À À À À À À ÿÿÿÿyýÀÌÀÌÀÌÀÌÀÌÀÌÀÀÿÿÿÿÿÀÀÀÀÀÀÀÀÀÀáÀ? ? áÀÀÀÀÀÀÀÀÀÀÀa! ? áÀÀÀÀÀÀÀÀÀÀÀÿÿÿÿ? íÀÌÀÌÀÌÀÌÀÍÀo/  À À À Àÿþÿÿ Ã Ã Ï Î&#x27;oÀÌÀÌÀÌÀÌÀÌÀìÀÀ?Àÿÿÿÿ À À À ÀÀÿÿ ÿÌÿÌ&gt; ~ à À À À À à Ì?Ìÿÿÿÿ  
+À0``0ÀÿÿÿÿÿÀÿ À À À?? À ÀÀÿÿ ÿÀÿÀ À À À ÀÀÿÿ ? áÀÀÀÀÀÀÀÀÀáÀ? ÿÀÿÀÀÀÀÀÀÀÀÀÀÀÀÀÀÀÿÀÿÀÿÀÿÀ À À À À À gïÀÌÀÌÀÌÀÌÀÌÀÌÀýÀy À À À Àÿþÿþ À À À À?ÀÀà À À À À à À?ÀÀÀ0 ` À À ` 0 ÀÀ?ÀÀà À à ~ ~ à À à À?À@ÀÀa3    3 aÀÀ@#ÀgÀÎ Ì Ì Ì Ì Æ À?ÀàÀàÀðÀØÀÈÀÄÀÆÀÃÀÁÀÁÀ?üþàÀÀÀÀ@ þþ @ÀÀÀÀàþ?ü</td></tr>
+<tr><td>71</td><td>F16test</td><td>New Font</td><td>User</td><td>16</td><td>1</td><td>F16test.fnt</td><td>2</td><td>16X TEST PATTERNS       &#x27;    &quot; 2 B R b r                  UUªªUUªªUUªªUUªªÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ  ÿÿ  ÿÿ  ÿÿ    ÿÿ  ÿÿ  ÿÿ  ÿÿUUUUUUUUUUUUUUUUªªªªªªªªªªªªªªªªÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ</td></tr>
+<tr><td>72</td><td>N7dvw</td><td>New Font</td><td>User</td><td>7</td><td>1</td><td>LN7dvw.fnt</td><td>2</td><td>7X DOUBLE STROKE       `            ¢ ¥ ª ° ² µ · ½ Ã Ç Í Ó Ù Þ ä ê ð ö ø û ü 
+$)/57&lt;BGNTZ`flrx~£©®¯³¸   __$** 6IV P&quot;AA&quot;&gt;&gt;&gt;@0```0&gt;AA&gt;B@BcqYOF&quot;cII6/oIy1&gt;IIy2qy
+6II6&amp;OII&gt;66@v6  QY |~~|II6&gt;AAc&quot;AA&gt;III		&gt;AI{: `@?6cA@@@~~&gt;AA&gt;		&gt;AQ/^9oF&amp;oII{2?@@?0`000c66cxxaqYMGCAAA0`AAA @@@@AAA</td></tr>
+<tr><td>74</td><td>VFont</td><td>New Font</td><td>User</td><td>7</td><td>1</td><td>Vfont.fnt</td><td>1</td><td>5X7 VARIABLE FONT    ß ¢§¬±¶»ÀÅÊÏÔÙÞãèíò÷ü$).38=BGLQV[`ejoty~¡¦«°µº¿ÄÉÎÓØÝâçìñöû 
+#(-27&lt;AFKPUZ_dinsx} ¥ª¯´¹¾ÃÈÍÒ×Üáæëðõúÿ	&quot;&#x27;,16;@EJOTY^chmrw|¤©®³¸½ÂÇÌÑÖÛàåêïôùþ
+!&amp;+05:?DIVFONT       _  $**#db6IV P      &quot;AA&quot;  &gt;&gt; @0     ``   &gt;AAA&gt; B@ BaQIF AIM3&#x27;EEE9&lt;JII0q	6III6II)     @4  &quot;A  A&quot;Y&gt;A]YN||III6&gt;AAA&quot;AAA&gt;IIIA			&gt;AAQq AA  @@@?&quot;A@@@@&gt;AAA&gt;			&gt;AQ!^	)F&amp;III2?@@@? @   ccxaQIECAAA AAA@@@@@    xx HH0 8DDH 0HH 8TTX ~	 8DT0 p  ú    @@&gt; (D    |xx |x 8DD8 | | | HTT$ ?D  &lt;@@&lt; @ &lt;@8@&lt;D((Dp DdTL  UUUUU   *****     &gt;AA&gt;  B@ rIIF AIM2 
+ &#x27;EE9 &gt;II0 y 6II6 II&gt;      @4  &quot;A  A&quot; Y     ~		~ II6 &gt;AA&quot; AA&gt; IIA 		 &gt;AQ2   AA  @@? &quot;A @@@ &gt;AA&gt; 		 &gt;Q!^ )F &amp;II2   ?@@?  @   ccxaQIECAAA AAA@@@@  &gt;AA&gt; B@  rIIF AIM2 
+ &#x27;EE9 &gt;II0 y 6II6 II&gt;     @4   &quot;A  A&quot;Y&gt;A]YN ~		~ II6 &gt;AA&quot; AA&gt; IIA 		 &gt;AQ2  AA   @@? &quot;A @@@ &gt;AA&gt; 		 &gt;Q!^ )F &amp;II2   ?@@? @   ccxaQIECAAA AAA @@@@</td></tr>
+<tr><td>75</td><td>VFont</td><td>New Font</td><td>User</td><td>7</td><td>1</td><td>Vfontcc.fnt</td><td>2</td><td>5X7 VARIABLE FONT    ß ¢§¬±¶»ÀÅÊÏÔÙÞãèíò÷ü$).38=BGLQV[`ejoty~¡¦«°µº¿ÄÉÎÓØÝâçìñöû 
+#(-27&lt;AFKPUZ_dinsx} ¥ª¯´¹¾ÃÈÍÒ×Üáæëðõúÿ	&quot;&#x27;,16;@EJOTY^chmrw|¤©®³¸½ÂÇÌÑÖÛàåêïôùþ
+!&amp;+05:?DIVFONT       _  $**#db6IV P      &quot;AA&quot;  &gt;&gt; @0     ``   &gt;AAA&gt; B@ BaQIF AIM3&#x27;EEE9&lt;JII0q	6III6II)     @4  &quot;A  A&quot;Y&gt;A]YN||III6&gt;AAA&quot;AAA&gt;IIIA			&gt;AAQq AA  @@@?&quot;A@@@@&gt;AAA&gt;			&gt;AQ!^	)F&amp;III2?@@@? @   ccxaQIECAAA AAA@@@@@    xx |TT( 8DDH |DD8 |TTD | 8DT0 || D|D   @@&lt; |(D |@@@||| | 8DD8 |8DT$X |4HHTTT$| &lt;@@&lt; @ |  |D((Dp DdTL  UUUUU   *****     &gt;AAA&gt; B@ BaQIF AIM3&#x27;EEE9&lt;JII0q	6III6II)     @4  &quot;A  A&quot; Y     ~		~ II6 &gt;AA&quot; AA&gt; IIA 		 &gt;AQ2   AA  @@? &quot;A @@@ &gt;AA&gt; 		 &gt;Q!^ )F &amp;II2   ?@@?  @   ccxaQIECAAA AAA@@@@ &gt;AAA&gt; B@ BaQIF AIM3&#x27;EEE9&lt;JII0q	6III6II)     @4   &quot;A  A&quot;Y&gt;A]YN ~		~ II6 &gt;AA&quot; AA&gt; IIA 		 &gt;AQ2  AA   @@? &quot;A @@@ &gt;AA&gt; 		 &gt;Q!^ )F &amp;II2   ?@@? @   ccxaQIECAAA AAA @@@@</td></tr>
+<tr><td>77</td><td>Luminator</td><td>New Font</td><td>User</td><td>16</td><td>1</td><td>16tnvw.fnt</td><td>3</td><td>16X TRIPLE STROKE      }	  ¾ È Î æ þ0HRdv ª¼ÂÚî ,BXl²¸Ðäö
+&quot;:Pd|¨¼Ôêü$8Rj®ÂÖì4Nd|¢´ÈÜð,@Tfz¨¼Âàø&quot;6J^pºÎâö
+$          çÿçÿçÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ88ÿÿÿ88ÿÿÿ889ø{ü{þssÿÿÿÿÿÿss?Î àp8 ?¿ÿÿáãÃÿÇ?þü páÿ  0 8   ø?üþðàààÀÀàààðþ?üørvþü ø p p øüþvrÀÀÀøøøÀÀÀà ð ~ ~  ÀÀÀÀÀÀÀÀÀà à à À à p 8    À à p 8øþþðààðþþøàààÿÿÿÿÿÿà à à ðøüîçãáÇàïà~à~à80ppàáÇáÇáÇóïþ~&gt;&lt;àðøÿÿÿÿÿÿ1ÿqÿqÿáÇáÇáÇáÇóÇÿ??üþþóãããw&gt;    ÿÿÇÿç w ?  &gt;&lt;~ÿÿóïáÇáÇáÇáÇóïÿÿ~&gt;&lt;8|xþyþñïáÇáÇáÇáÇñÇþþ?üqÀqÀqÀð ð þà&gt;àà              Ààp88pàÀàààààààààÀàp88pàÀ &lt; &gt; ?  îîïÿ þ |?øüàÏÇßçßçÜçÜçÜçßîüøÿüÿþÿþÿþÿþÿüÿÿÿÿÿÿáÇáÇáÇóïþ~&gt;&lt;?üþþðààààðxx8ÿÿÿÿÿÿààààðxþ?üðÿÿÿÿÿÿáÇáÇáÇáÇàààÿÿÿÿÿÿÇÇÇÇÇ  ?üþþðààããó?ÿÿÿÿÿÿÀÀÀÀÀÿÿÿÿÿÿàààÿÿÿÿÿÿààà&gt; ~ ~ ð à à ð ÿÿ?ÿÿÿÿÿÿÿàp88pàÀÿÿÿÿÿÿà à à à à à à ÿÿÿÿÿÿ  8 p à p 8 ÿÿÿÿÿÿÿÿÿÿÿÿ øàÀ &gt; ÿÿÿÿÿÿ?üþþðààààðþþ?üÿÿÿÿÿÿÏþþ ü?üþþðàäìøpÿþÿþßüÿÿÿÿÿÿ9ÏpþàþÀ|8&lt;x~pþàïáÇáÇó&gt;    ÿÿÿÿÿÿ    ?ÿÿÿð à à à ð ÿÿ?ÿÿÿÿ8 p à p 8 ÿÿÿÿÿÿÿÿ      ÿÿÿÿÿàp88pàÀàp88pà ?  ÿÀÿÿ ÿÀ ÿ  ?ðøüîçãáÇàçàwà?ààÿÿÿÿÿÿàààààà    8 p àÀ  ààààààÿÿÿÿÿÿ          à à à à à à à à à à ÿÿÿÿyýÀýÀìÀÄÀÄÀìÀÀÿÀÿÿÿÿÿÿÿsáÀáÀóÀ?  óÀáÀáÀáÀss3 ? óÀáÀáÀsÿÿÿÿÿÿ? íÀÌÀÌÀíÀoo&#x27; ÀÀÿüÿþÿÿÇÇÏÎ&#x27; ooÍÀÌÀÌÀÍÀ? ÿÿÿÿÿÿÀÀÀÿÀÿÿ ÿÎÿÎÿÎ &lt; | ð à à ð Î?ÎÎÿÿÿÿÿÿ À8àppà8ÀÿÿÿÿÿÿÿÀÿÀÿÀÀÀÀÀÀÀÿÀÿÿ ÿÀÿÀÿÀÀÀÀÀÀÿÀÿÿ  óÀáÀáÀáÀóÀ ÿÀÿÀÿÀÀÀÀÀÀ  ÀÀÀÀÀÿÀÿÀÿÀÿÀÿÀÿÀÀ À ÀÀ # gïÀÌÀÌÀÌÀÌÀýÀy1 ÀÀÀÿüÿüÿüÀÀÀÀ?ÀÀð à à à ð À?ÀÀÀÀ?Àp à À à p ?ÀÀÀÀ?ÀÀð à ð ~ &gt; ~ ð à ð À?ÀÀÀÀáÀs?   ? sáÀÀÀ#ÀgÀïÀÎ Ì Î ç ÿÀÀ?ÀñÀñÀùÀéÀíÀåÀçÀãÀãÀáÀÀÀþÿÿÿÿðàà` þþþ `ààðÿÿÿÿþ</td></tr>
+<tr><td>78</td><td>Standard</td><td>New Font</td><td>User</td><td>7</td><td>1</td><td>7vw.fnt</td><td>1</td><td>7X SINGLE STROKE X4    ~   À Ã Ä É Î Ó Ø Ý Þ á ä é î ð ó õ ú þ	
+!&quot;$(,05:&gt;BFJNRVZ]aeinsw{¢§¬±¶»¿ÄÈÌÐÔØÜàäåéíîó÷ûÿ!&amp;*/49&gt;   _$**#db6IV P&quot;AA&quot;&gt;&gt;@0`` &gt;AA&gt;B@rIIFAIM2
+&#x27;EE9&gt;II0y6II6II&gt;@4&quot;AA&quot;Y&gt;AYU^~		~II6&gt;AA&quot;AA&gt;III		&gt;AQ2AA @@?&quot;A@@@&gt;AA&gt;		&gt;Q!^)F&amp;II2?@@? @   ccxaQIECAAA AAA@@@@AAAxxHH08DDH0HH8TTX~	8DT0pz @@&gt;(D|xx|x8DD8|||HTT$?D&lt;@@&lt; @ &lt;@8@&lt;D((DpDdTL  UUUUU   *****</td></tr>
+<tr><td>79</td><td>Luminator</td><td>New Font</td><td>User</td><td>7</td><td>1</td><td>L7vw.fnt</td><td>1</td><td>7X SINGLE STROKE X4    ~   À Ã Ä É Î Ó Ø Ý Þ á ä é î ð ó õ ú þ	
+!&quot;$(,05:&gt;BFJNRVZ]aeinsw{¢§¬±¶»¿ÄÈÌÐÔØÜàäåéíîó÷ûÿ!&amp;*/49&gt;   _$**#db6IV P&quot;AA&quot;&gt;&gt;@0`` &gt;AA&gt;B@rIIFAIM2
+&#x27;EE9&gt;II0y6II6II&gt;@4&quot;A&quot;AY&gt;AYU^~		~II6&gt;AA&quot;AA&gt;III		&gt;AQ2AA @@?&quot;A@@@&gt;AA&gt;		&gt;Q!^)F&amp;II2?@@? @   ccxaQIECAAA AAA@@@@AAA$TTxDD88DDH8DD8TTX~	HTT&lt;x} @@=(D|xx|x8DD8|||HTT$?D&lt;@@&lt; @ &lt;@8@&lt;D((DpDdTL  UUUUU   *****</td></tr>
+<tr><td>80</td><td>GTI-7DVW</td><td>New Font</td><td>User</td><td>7</td><td>1</td><td>7DVW.fnt</td><td>1</td><td>7X DOUBLE STROKE       `          ¢ ¥ ¨ « ° ¶ ¹ ¼ ¾ Ä Ê Î Ô Ú à å ë ñ ÷ ý ÿ
+%+16;AGKPV[biou{¡§­³¸¾ÃÈÌÓ   __$**3fc6IV P&gt;AA&gt;&gt;&gt;&gt;@p0```0&gt;AA&gt;B@BcqYOF&quot;cII6/oIy1&gt;IIy2qy
+6II6&amp;OII&gt;66@v66cc6QY&gt;AYU_|~~|II6&gt;AAc&quot;AA&gt;IIA		&gt;AI;zAA `@?6cA@@@&gt;AA&gt;		&gt;A1^9oF&amp;oII{2?@@?0`000c66cxxaqYMGCAAA0`AAA@@@@AAAAA</td></tr>
+<tr><td>81</td><td>GTI-8DVW</td><td>New Font</td><td>User</td><td>8</td><td>1</td><td>8DVW.fnt</td><td>1</td><td>8X DOUBLE STROKE       `          ¥ ¨ « ® ´ º ½ Â Ä Ê Ð Ô Ú à æ ì ò ø þ	&quot;(.4:?DJPTY_dkrx~£ª±·½ÂÈÍÔØß   ßßÿÿÿÿÿ$ÿ$ÿ$DJÿÿR&quot;Ãã0ÇÃ`ö®@ &lt;~~&lt;&quot;&quot;~~à`ÀÀ`0~ÿÿ~ÿÿÂã±BÃÿvÿÿOÏùp~ÿùráñvÿÿvNÿ~66æf8lÆÆl8ÑÙ~ÿ¹¥¾üþþüÿÿÿv~ÿÃBÿÿÿ~ÿÿÿÿ		~ÿsòÿÿÿÿÿÿ@Àÿÿÿ6ãÁÿÿÿÿÿÿÿÿ0ÿÿ~ÿÿ~ÿÿ		~ÿ¡¾ÿÿ9ïÆFÏûrÿÿÿÿ?`À`?ÿ00ÿÃç&lt;&lt;çÃøøÁá±ÿÿ0`ÿÿÿÿ</td></tr>
+</tbody></table>
+<p class="note">12 additional rows not shown.</p>
+</section>
+<section id='Graphics'><h2>Graphics</h2>
+<p><strong>Rows:</strong> 136 • <strong>Columns:</strong> 11</p>
+<table>
+<thead><tr><th>GraphicID</th><th>GraphicName</th><th>GraphicDescription</th><th>GraphicHeight</th><th>GraphicWidth</th><th>GraphicAllowMod</th><th>GraphicCType</th><th>Graphic</th><th>RedGraphic</th><th>GreenGraphic</th><th>BlueGraphic</th></tr></thead>
+<tbody>
+<tr><td>21</td><td>#EFFDOT#</td><td>#Used to draw Effect Zones</td><td>1</td><td>5</td><td>0</td><td>1</td><td>                             </td><td></td><td></td><td></td></tr>
+<tr><td>22</td><td>7bus</td><td>NEW GRAPHIC</td><td>7</td><td>27</td><td>1</td><td></td><td>NEW GRAPHIC                ?!?{_{?;?;?;?;!?{^x88  </td><td></td><td></td><td></td></tr>
+<tr><td>23</td><td>Air</td><td>G16X AIRPORT (NEG.) </td><td>15</td><td>34</td><td>1</td><td></td><td>G16X AIRPORT (NEG.)     ÿ  &quot;?þ~¿ccpx|~??þ</td><td></td><td></td><td></td></tr>
+<tr><td>25</td><td>battleship</td><td>NEW GRAPHIC</td><td>16</td><td>194</td><td>1</td><td></td><td>NEW GRAPHIC             _   Âü ü ü ü ü øù þ þ ü@øÿ ÿ þ ü þ ù ùøÿÿþÿàÿ ø þ ú û ù û ú ú ü þ ú ú ú ü ü ü þ ÿüÿüÿüÿüÿüÿüÿüÿÿ þ ÿ þÿÿÿðþþÿÀÿÀÿþÿøÿøÿúÿþÿîÿúÿèÿøÿèÿðÿÀÿÿ ÿÿÀÿÀþ ÿÿÿþ@þ þ þ þ þ þ þ þ þ þ þ &gt;    </td><td></td><td></td><td></td></tr>
+<tr><td>26</td><td>Bus</td><td></td><td>16</td><td>40</td><td>1</td><td></td><td>BUS GRAPHIC                (ü÷ôôÿôô÷ü</td><td>BUS GRAPHIC                 (ü÷ôôÿôô÷ü</td><td>BUS GRAPHIC                 (ü÷ôôÿôô÷ü</td><td>BUS GRAPHIC                 (                                    </td></tr>
+<tr><td>27</td><td>Busprof</td><td>NEW GRAPHIC</td><td>16</td><td>80</td><td>1</td><td></td><td>NEW GRAPHIC             &amp;   P0 ?øøøøøo÷÷oøøøoø÷÷oøDDøDDø` </td><td></td><td></td><td></td></tr>
+<tr><td>28</td><td>Firework</td><td>NEW GRAPHIC</td><td>16</td><td>32</td><td>1</td><td></td><td>NEW GRAPHIC                   H$ .R&quot;  xÔ *É â </td><td></td><td></td><td></td></tr>
+<tr><td>29</td><td>Flag1</td><td>AMERICAN FLAG</td><td>13</td><td>72</td><td>1</td><td></td><td>AMERICAN FLAG         
+  &quot;   HU*U*U*U*U*U*U UUUUUUUUUUUUUUUUUUUU</td><td></td><td></td><td></td></tr>
+<tr><td>30</td><td>Flag2</td><td>AMERICAN FLAG</td><td>14</td><td>70</td><td>1</td><td></td><td>AMERICAN FLAG           !   FU*U*U*U*U*U*U UUUVZjªªª*ª*ª*ª*ª*¬*´*Ô+T-T5T</td><td></td><td></td><td></td></tr>
+<tr><td>31</td><td>Football</td><td>NEW GRAPHIC</td><td>16</td><td>44</td><td>1</td><td></td><td>NEW GRAPHIC                ,ø  À`0ÄIBe ¦0B#QÁ y </td><td></td><td></td><td></td></tr>
+<tr><td>32</td><td>Goalpost</td><td>NEW GRAPHIC</td><td>16</td><td>44</td><td>1</td><td></td><td>NEW GRAPHIC                ,ÿÿÿÿÿÿÿÿ</td><td></td><td></td><td></td></tr>
+<tr><td>33</td><td>Mickii</td><td>MICKII</td><td>16</td><td>48</td><td>1</td><td></td><td>MICKII PHIC               0      &gt;?0¿CS&gt; &lt;¨¨ S&lt;C~0¿? ? &gt;       </td><td></td><td></td><td></td></tr>
+<tr><td>34</td><td>Music</td><td>NEW GRAPHIC</td><td>18</td><td>58</td><td>1</td><td></td><td>NEW GRAPHIC                :    8 8     ¸ 8  &#x27;Ã pÃ pÃ p  ?        </td><td></td><td></td><td></td></tr>
+<tr><td>35</td><td>Nascar</td><td>NEW GRAPHIC</td><td>16</td><td>136</td><td>1</td><td></td><td>NEW GRAPHIC             K                          À???;}ÀïÀÇÀïÀ}à;àüü\NFFPX_  ÀÀ;}ïÇï} ;  ÿ ÿ þ þ ü ø   </td><td></td><td></td><td></td></tr>
+<tr><td>36</td><td>Olyrings</td><td>NEW GRAPHIC</td><td>16</td><td>94</td><td>1</td><td></td><td>NEW GRAPHIC             -   ^   ¨   SBBÊ ¨   ¨BÊSB  CBBÊ ¨   ¨BÊSB    ¨                    </td><td></td><td></td><td></td></tr>
+<tr><td>37</td><td>Parkride</td><td>BUS</td><td>16</td><td>66</td><td>1</td><td></td><td>BUS GRAPHIC             (   B&lt; ê é y y y y y é ê &lt;     ?üïé	é	/	/	/	/	/ù/	/	/	//IéIéï?ü</td><td></td><td></td><td></td></tr>
+<tr><td>38</td><td>Phone1</td><td>PHONE</td><td>12</td><td>38</td><td>1</td><td></td><td>PHONE APHIC                &amp; ïïïïççïïïï </td><td></td><td></td><td></td></tr>
+<tr><td>39</td><td>Santa</td><td>NEW GRAPHIC</td><td>16</td><td>126</td><td>1</td><td></td><td>NEW GRAPHIC             =   ~ &#x27;è&#x27;è?é?
+&#x27;þ$þ&#x27;¤? &gt;$&#x27; @3     &amp; ?Àà°  3    &amp; ? Àà 3    &amp; ? Àà 3    &amp; ?`ÀÀ     </td><td></td><td></td><td></td></tr>
+<tr><td>40</td><td>Ship</td><td>NEW GRAPHIC</td><td>16</td><td>54</td><td>1</td><td></td><td>NEW GRAPHIC  (NEG.)     ÿ  6 P @ ðèìôòèìô  </td><td></td><td></td><td></td></tr>
+<tr><td>41</td><td>Smile</td><td></td><td>16</td><td>36</td><td>1</td><td></td><td>NEW GRAPHIC                $àð$L333L3$ðà</td><td>NEW GRAPHIC                 $àð$L333L3$ðà</td><td>NEW GRAPHIC                 $àð$LL$ðà</td><td>NEW GRAPHIC                 $           0 0     0 0          </td></tr>
+<tr><td>42</td><td>SNOWflae</td><td>NEW GRAPHIC</td><td>16</td><td>38</td><td>1</td><td></td><td>NEW GRAPHIC                &amp; À AÂÿÿAÂ  À   </td><td></td><td></td><td></td></tr>
+<tr><td>43</td><td>Sunrise</td><td>NEW GRAPHIC</td><td>16</td><td>48</td><td>1</td><td></td><td>NEW GRAPHIC                0H @@( ? ÿÿÿÕ?  &gt;9h@  </td><td></td><td></td><td></td></tr>
+<tr><td>44</td><td>THUMBSUP</td><td>TXA&amp;M</td><td>16</td><td>28</td><td>1</td><td></td><td>TXA&amp;M APHIC                @0N@Q! À @?À</td><td></td><td></td><td></td></tr>
+<tr><td>45</td><td>Turkey</td><td>NEW GRAPHIC</td><td>16</td><td>44</td><td>1</td><td></td><td>NEW GRAPHIC                , ,ÀÀÀÀÓÌ@@¸Â` p  </td><td></td><td></td><td></td></tr>
+<tr><td>46</td><td>Turkey2</td><td>NEW GRAPHIC</td><td>16</td><td>44</td><td>1</td><td></td><td>NEW GRAPHIC                , ,ÀÀÀÀÌÓ@@ºÅ` p  </td><td></td><td></td><td></td></tr>
+<tr><td>47</td><td>Txa&amp;m2</td><td>TXA&amp;M2</td><td>16</td><td>42</td><td>1</td><td></td><td>TXA&amp;M2 PHIC                *ÝÅà ¿ý¿ý àÅß</td><td></td><td></td><td></td></tr>
+<tr><td>48</td><td>Walt</td><td>WALT</td><td>16</td><td>70</td><td>1</td><td></td><td>WALT RAPHIC            !   Fü   ü   ü   à   ü   ü               </td><td></td><td></td><td></td></tr>
+<tr><td>49</td><td>Wheelchr</td><td>WHEEL CHAIR</td><td>16</td><td>34</td><td>1</td><td></td><td>WHEEL CHAIR  (NEG.)     ÿ  &quot; ?cþÇÿÆÏÆÆÆÀÆ f &gt;   0 ` 0 </td><td></td><td></td><td></td></tr>
+<tr><td>50</td><td>Xmascane</td><td>NEW GRAPHIC</td><td>16</td><td>44</td><td>1</td><td></td><td>NEW GRAPHIC                ,      4 : .   ( p  À 
+  ( p     </td><td></td><td></td><td></td></tr>
+<tr><td>51</td><td>Xmastree</td><td>CHRISTMAS TREE</td><td>16</td><td>34</td><td>1</td><td></td><td>CHRISTMAS TREE             &quot;  àøüÿþÿÿÿþüøà  </td><td></td><td></td><td></td></tr>
+<tr><td>52</td><td>SCRT</td><td>NEW GRAPHIC</td><td>7</td><td>16</td><td>1</td><td></td><td>NEW GRAPHIC             
+   ..</td><td>NEW GRAPHIC              
+    </td><td>NEW GRAPHIC              
+    </td><td>NEW GRAPHIC              
+    </td></tr>
+<tr><td>53</td><td>NL</td><td></td><td>13</td><td>34</td><td>1</td><td></td><td>NL                    
+      &quot;ÿÿ &lt; ðÀÿÿ      ÿÿ   </td><td>NL                    
+       &quot;ÿÿ &lt; ðÀÿÿ      ÿÿ   </td><td>NL                    
+       &quot;ÿÿ &lt; ðÀÿÿ      ÿÿ   </td><td>NL                    
+       &quot;                              </td></tr>
+<tr><td>54</td><td>OL</td><td></td><td>13</td><td>34</td><td>1</td><td></td><td>OL                    
+      &quot;þÿÿþ    ÿÿ    </td><td>OL                    
+       &quot;þÿÿþ    ÿÿ    </td><td>OL                    
+       &quot;þÿÿþ    ÿÿ    </td><td>OL                    
+       &quot;                              </td></tr>
+<tr><td>55</td><td>IL</td><td></td><td>15</td><td>28</td><td>1</td><td></td><td>IL                          `ÿÿ`    ÿÿ` ` ` ` </td><td>IL                           `ÿÿ`    ÿÿ` ` ` ` </td><td>IL                           `ÿÿ`    ÿÿ` ` ` ` </td><td>IL                                                   </td></tr>
+<tr><td>56</td><td>GRN</td><td></td><td>13</td><td>54</td><td>1</td><td></td><td>GRN                   
+      6þÿÃÃÇÆ    ÿÿ cãã&gt;    ÿÿ &lt; ðÀÿÿ</td><td>GRN                   
+       6þÿÃÃÇÆ    ÿÿ cãã&gt;    ÿÿ &lt; ðÀÿÿ</td><td>GRN                   
+       6þÿÃÃÇÆ    ÿÿ cãã&gt;    ÿÿ &lt; ðÀÿÿ</td><td>GRN                   
+       6                                                  </td></tr>
+<tr><td>57</td><td>SHS</td><td></td><td>13</td><td>54</td><td>1</td><td></td><td>SHS                   
+      6&gt;cccçÆ    ÿÿ ` ` `ÿÿ    &gt;cccçÆ</td><td>SHS                   
+       6&gt;cccçÆ    ÿÿ ` ` `ÿÿ    &gt;cccçÆ</td><td>SHS                   
+       6&gt;cccçÆ    ÿÿ ` ` `ÿÿ    &gt;cccçÆ</td><td>SHS                   
+       6                                                  </td></tr>
+<tr><td>58</td><td>CGS</td><td></td><td>13</td><td>54</td><td>1</td><td></td><td>CGS                   
+      6þÿ    þÿÃÃÇÆ    &gt;cccçÆ</td><td>CGS                   
+       6þÿ    þÿÃÃÇÆ    &gt;cccçÆ</td><td>CGS                   
+       6þÿ    þÿÃÃÇÆ    &gt;cccçÆ</td><td>CGS                   
+       6                                                  </td></tr>
+<tr><td>59</td><td>CS</td><td></td><td>13</td><td>36</td><td>1</td><td></td><td>CS                    
+      $þÿ    &gt;cccçÆ</td><td>CS                    
+       $þÿ    &gt;cccçÆ</td><td>CS                    
+       $þÿ    &gt;cccçÆ</td><td>CS                    
+       $                                </td></tr>
+<tr><td>60</td><td>X</td><td></td><td>13</td><td>20</td><td>1</td><td></td><td>X                     
+      ¸ðð¸</td><td>X                     
+       ¸ðð¸</td><td>X                     
+       ¸ðð¸</td><td>X                     
+                       </td></tr>
+<tr><td>61</td><td>UVA</td><td></td><td>13</td><td>56</td><td>1</td><td></td><td>UVA                   
+      8ÿÿ   ÿÿ     ÿ  ÿ     øü Æ Ã Æüø</td><td>UVA                   
+       8ÿÿ   ÿÿ     ÿ  ÿ     øü Æ Ã Æüø</td><td>UVA                   
+       8ÿÿ   ÿÿ     ÿ  ÿ     øü Æ Ã Æüø</td><td>UVA                   
+       8                                                    </td></tr>
+<tr><td>62</td><td>CS_SMALL</td><td></td><td>7</td><td>16</td><td>1</td><td></td><td>CS_SMALL                     &gt;ccc .kk: </td><td>CS_SMALL                      &gt;ccc .kk: </td><td>CS_SMALL                      &gt;ccc .kk: </td><td>CS_SMALL                                 </td></tr>
+<tr><td>63</td><td>NL_MED</td><td></td><td>10</td><td>44</td><td>1</td><td></td><td>NL_MED                
+      ,  ÿÿ  8 pÀÿÿ    ÿÿ         </td><td>NL_MED                
+       ,  ÿÿ  8 pÀÿÿ    ÿÿ         </td><td>NL_MED                
+       ,  ÿÿ  8 pÀÿÿ    ÿÿ         </td><td>NL_MED                
+       ,                                        </td></tr>
+<tr><td>64</td><td>NL_SMALL</td><td></td><td>7</td><td>19</td><td>1</td><td></td><td>NL_SMALL                     0 @@@@   </td><td>NL_SMALL                      0 @@@@   </td><td>NL_SMALL                      0 @@@@   </td><td>NL_SMALL                                    </td></tr>
+<tr><td>65</td><td>NOTSERV</td><td></td><td>16</td><td>84</td><td>1</td><td></td><td>NOTSERV                     T    F I I 1  IIA  &gt;A)AF&gt;   @   A  AA &gt;AA AA&quot; I I A       </td><td>NOTSERV                      T    F I I 1  IIA  &gt;A)AF&gt;   @   A  AA &gt;AA AA&quot; I I A       </td><td>NOTSERV                      T    F I I 1  IIA  &gt;A)AF&gt;   @   A  AA &gt;AA AA&quot; I I A       </td><td>NOTSERV                      T                                                                                </td></tr>
+<tr><td>66</td><td>NIS_SML</td><td></td><td>10</td><td>44</td><td>1</td><td></td><td>NIS_SML               
+      ,              Î x xÎ              </td><td>NIS_SML               
+       ,              Î x xÎ              </td><td>NIS_SML               
+       ,              Î x xÎ              </td><td>NIS_SML               
+       ,                                        </td></tr>
+<tr><td>67</td><td>NIS_MED</td><td></td><td>10</td><td>44</td><td>1</td><td></td><td>NIS_MED               
+      ,              Î x xÎ              </td><td>NIS_MED               
+       ,              Î x xÎ              </td><td>NIS_MED               
+       ,              Î x xÎ              </td><td>NIS_MED               
+       ,                                        </td></tr>
+<tr><td>68</td><td>NIS_SM</td><td></td><td>7</td><td>19</td><td>1</td><td></td><td>NIS_SM                          cwwc    </td><td>NIS_SM                           cwwc    </td><td>NIS_SM                           cwwc    </td><td>NIS_SM                                      </td></tr>
+<tr><td>69</td><td>OL_MED</td><td></td><td>10</td><td>44</td><td>1</td><td></td><td>OL_MED                
+      ,   üþþ ü  ÿÿ              </td><td>OL_MED                
+       ,   üþþ ü  ÿÿ              </td><td>OL_MED                
+       ,   üþþ ü  ÿÿ              </td><td>OL_MED                
+       ,                                        </td></tr>
+<tr><td>70</td><td>OL_SML</td><td></td><td>7</td><td>22</td><td>1</td><td></td><td>OL_SML                       &gt;AA&gt; ```     </td><td>OL_SML                        &gt;AA&gt; ```     </td><td>OL_SML                        &gt;AA&gt; ```     </td><td>OL_SML                                         </td></tr>
+<tr><td>71</td><td>IL_MED</td><td></td><td>10</td><td>44</td><td>1</td><td></td><td>IL_MED                
+      ,    ÿÿ  ÿÿ              </td><td>IL_MED                
+       ,    ÿÿ  ÿÿ              </td><td>IL_MED                
+       ,    ÿÿ  ÿÿ              </td><td>IL_MED                
+       ,                                        </td></tr>
+</tbody></table>
+<p class="note">86 additional rows not shown.</p>
+</section>
+<section id='LoadModules'><h2>LoadModules</h2>
+<p><strong>Rows:</strong> 6 • <strong>Columns:</strong> 3</p>
+<table>
+<thead><tr><th>LoadModID</th><th>LMDescription</th><th>LOD</th></tr></thead>
+<tbody>
+<tr><td>2</td><td>(Eh0142-0.lod)</td><td> P            Q 	
+
+ !&quot;#$%&amp;&#x27;()*+,-./0123456789:;&lt;=&gt;?@ABCDEFGHIJKLMNOP        0       1       1       0                                                
+ÉÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍ»
+º                                      º
+º            P/N 412014-002            º
+º            Copyright 1990            º
+º        Gulton Industries, Inc.       º
+º                                      º
+ÈÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍ¼
+
+
+ÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ` ^` ` ¦` &amp;` &quot;` `  ` ` ` ` 
+` ` ` þ` ú` ö` ò` î` ê` æ` â` Þ` * ` Ö` Ò` Î` *~` Æ` +` +¢` +ª` +Ü` ,¼` +ª` ª` ¦` ¢` ÿÿÿÿ |   N`Fü Aù  ¸#È  ¨#È  ¬Aù  ¸#È  °#È  ´Aù  ¸#È    ü )è ü Ø ü î ü ð#È  ¤¹    vü    9    vgS¹  xfa 29    gS¹  ¬fa &lt; y   ±ù  ¤gÆ&quot;X±ü  ¸l#È   `
+#ü  ¸   N`¦Fü&#x27; (y  ¤(Ë¹ü  ¸l#Ì  ¤`
+#ü  ¸  ¤NsFü&#x27; (y  ¬(Ë¹ü  ¸l#Ì  ¬`
+#ü  ¸  ¬NsFü&#x27; (y  ´(Ë¹ü  ¸l#Ì  ´`
+#ü  ¸  ´Nsü    |ü    +¹    7ü   3ü   øü 
+  ×ü   ü   ü   ü    ü    ü    ü    ü   ü    ü    3ü    ºNupÀ  	#À  aZ o&lt; Å  pÀ  	ü    ü    #À  a*a  æ9   oü   9   oü   Nuz t 49  ö&amp;y  úa 7    g  ¢ y  ü    ü    t 49  öü a /n ga /&amp;  þfÐ`hm
+  `föR`ò  ügº  þlN  òmà  óo&gt;  úg(  õf.9   	f9   ga&quot;À  `¬À  ` T`X`Nu9    f
+Û9  z `Û9  z Nu&amp;y  a ¹   ¹    |   3ü    $9   Ögü    |p (k , 	fjt 49   9   ÖfJ9   Öfa 62   g:`p#À  a 6^   g&amp;ù   t 49   a 5¼y    $n$p`p`
+pü    |#À  t 49   a 6&#x27;y   &#x27;y   |   |  «  
+y   $f«  
+p &quot;k +  
+g
++  
+f`+  
+g+  
+fp`Ð) Ð) Ðy  $3À  &amp;aNu3ü    &amp;y  p + °y  &amp;n è+ þ f  &quot;k +  
+g+  
+f &#x27;y  
+ `L+  
+g&#x27;k  |   `6+  
+g«  
+&#x27;y  
+ )   f F`&amp;ë  
+&#x27;k  |   `+  
+g
+)   f &quot;k é   #0) 
+g   0) g  ²) g  a .Ê  g ÿJCù  29  Eñ &amp;y  « #ë   Aù  Eù  #Ê  ,k %hÿþÿü&#x27;H t 49   ü ÂHB  gÐ`ü    &quot;a &#x27;Þ&#x27;y   `4ü    &quot;a &#x27; `&amp;0) f) gü    &quot;a -ü`ü    #`    g þCù  #É  rGù NJ| 9  #SFoNKSFnú&amp;y  +  Gù àNKNu|   Aù  ,k k ÿün ÿý1n 
+ÿþ9  &quot;r t 9  #Äü  RA²Bmö`t 9  #Äù  &amp;3Â  (Gù \NJGù NKNu&amp;y  a ¬3ü    $9   Ögü    |p (k , 	f6t 49  a 2ú   gt 49  a 2 y    $n p`
+pü    |#À  t 49  a 2þ«  
+&#x27;y   &#x27;y  
+ aRp &quot;k +  
+g
++  
+f`+  
+fÐ) Ð) Ðy  $3À  f
+ü    Nuü   ) a@Nu+  
+g&#x27;k  «  
++  
+g| þ `&#x27;k  ë  
+|   |  Nu&amp;y  p + °y  oS f
+ü    Nua+ þ fd&quot;k +  
+g+  
+f  &#x27;k  `&lt;+  
+g&#x27;k  `,+  
+g«  
+&#x27;k  )   f  b`ë  
+&#x27;k  )   f  Ja /  g ÿ  g ÿCù  #É  ¤Gù ÊNJSEoNLSEnú&amp;y  +  Gù 
+*NLNu|   09  °+ n f+  Gù 
+*NJ` p ) @ +  Gù PNJGù 
+*NLNuü   NuEù   49   Åü  02 3À   Áü  Cò  3é   #É  )   
+fGù `Gù NJNuGù NJGù NKNu0&lt;5S@füGù ´NJNuNDNuEù  bAù  #È  rvCù  9  ×aFvCù  a&lt;vCù  &quot;a2Gù NJRy  (rNKRy  (R oðGù \NKGù NKNur 0ù  ÃÀt ò  RAA mòü ÿRAA môNu&amp;y  a X¹   |   p
+9   Ð9  #À  3ü    $t 49   a /à   g
+y    $f9 	  o¼` :&#x27;y   |   |  «  
+3ü    Eù  bAù  #È  r9   f
+Cù  `  ² f
+Cù  `  ¢ f
+Cù  &quot;`   f
+Cù  2`   fCù  :`F f` f` 	f  9  ×r 0ù  ÃÀü ÿRAA môGù NJRy  (`DGù pa þNJRy  (pa þNKRy  (R   oì`9  ×a þtGù NJRy  (p &amp;y  +  
+f(Ðy  $3À  &amp;Gù 
+NK`t Gù \NJGù NKNu&amp;y  p + °y  &amp;n 0+ þ g &amp;&quot;k é   #0) 
+g  0) g  ®) g~a ((  gÊCù  29  Eñ &amp;y  « #ë   Aù  Eù  #Ê  ,k %hÿþÿü&#x27;H t 49   ü ÂHB  gÐ`ü    &quot;a !&gt;&#x27;y   `4ü    &quot;a ! `&amp;0) f) gü    &quot;a &#x27;\`ü    #`  R  g ÿCù  #É  rGù NJRy  (| 9  #SFoNKRy  (SFnô&amp;y  +  Gù 
+NKNuGù ^NJNu3ü    (29  Cù P i $y  0g
+°AgÐü `òª   
+3ü    #È  rGù NJRy  (@ mg@g@ÿoGù \NKGù NKNuGù ÌNKNuü   ù    Gù ^NKNuAù P$h &amp;h Iù   &quot;Px |ÿ~ÿ&lt;|  r 01 g ,t :2  g &quot;°Ef2 @ gB `æKò  )@v z 30  ÿgÊü ²Ef3  0gC `Þ@ f  Ü`Kó0 )@z Å  Å Å Å Å Å @
+¼  @¼ @@ ÿoJ@ÿo&amp;@ÿod@0f8ü   ´ @
+9@3Î  `z3Î  ö3À  øAô@ #È  úò   ×´ @
+9@Fÿÿg9``3Î  þ3Î   &lt;`69   f,ô @
+9@Gÿÿg9p`3Î  *3Î  .&gt;`ô @
+D  RN¼ü n
+2Âü ` þ´Aù   9   f09  Áü  Cð  #É  Gù )¼NJy  ømGù bNJFÿÿg1¹  þ`Gù ZNJGÿÿg21¹  *p09  .3À  ,Áü  Cð  #É  2ù    7Gù ,NJNu9   g&lt;9   g2Aù  ¼Eù  ¼ tNGAù à NqAù  ¼Eù  ¼ tNGNuGù  R9  Ö f4   y   øg
+y  øfp`pa &lt;Cù  2` \ f  Ú¹     fü    Cù  Ø`t  fCù  à`f  fCù  è`X  fCù  ð`J  f 2Cù  øaX9   fD Å  p(Gù  Øa °Cù  :v a RCC (mô`  Ða9   fGù ¸`Gù ¨NJNuR9  °9  gù   p ³    R@@ mòNu°9  ×f    fÅ  `  n 
+f  `  \ fCù   `: fCù       ` fDCù  &quot;Å     v a  ²RCC môv Å  ÖGù  ÖCù  a  Gù ¸`Gù NJAù   09  ,3À  .Áü  Cð  #É  2p p0 f&quot;p )   
+g6ù   `,0 
+ gÅ  Å Å Å Å Å  
+¼  @  @ào¬ü    |Nutr 10 Iù  bAó0 Eô °g,NG°g$Aù  R gÀ   Eñ0 NGEÐAù   NG`¸NuAù  ²&quot;y   hf&lt;( 
+ f4&lt; ³ ( ³ ( ³ °( f( 6 n( 0 mGù ÆNJ`| 4 `î| 3 `æNu y  ( R   
+oa 8Nu@ ` y  |   ü    Aù  Eù   ü  ²0ü  0ü  Ê0ü  0ü ü hü Sü 
+ü Ia òNu y  ( R   oa ÌNu@ &amp;y  ¨`&gt;&amp;y  ¤ y   Df EÓ¼ 0 #Ë  ¤p
+~a  D a õX`z|   #Ë  ¨ü   Aù  Eù   ü  ²0ü  0ü  Ê0ü  0ü ü hü P$Û#Ë  ¤ü 
+Eù  p ³ ³ ³ ³ ³ ³ ³ 
+  a  Nut v x z | a ~ f¶@lÈÀÊÀØHDÚD8&lt;  HD´mÜHD8HD`x NuNVÿ2&lt;  C÷ 2&lt; ÈE÷ I×r(K÷ Å  Ör 3  am
+ zn   RA²@mâr x z 1 ¼  P(A  gv ´50 g8RC¶EmôP R5P(PP@ RD6RC¶@l10 ´5P fð@ RDR5P(`äRERA²@mªSEr 650 8RC¶En´50 mô`ì¸Ag&amp;µ @  5@(µ(@((5@PµP@PPRA²EmºAù P h $a  ªF  m  r 4¸5  g0mæ64¸5  g$nÚt 4AB mÎü ÔA¸5  g
+n6`â2`Þx ~ 5 P5 (4@ t RB´Fn(2  RA²@l  g1   gì¶1 gÜSGo ÿ~RD`Ìr ¼   RA²@oôù   ÖNqNq9  ÖN^Nu|ÿ ûfT`ô òfX`ê þgä ýg   íft  ndÄü ÐÂ`  mV nPRk&quot;RF¼@l6ah é` kaX Õ2` `Ú ûo. üg&gt; ýg6 þg2` üg( þg&quot;4 a P0` ÿ\ òm  óoT`X`|ÿNqNu /o 9o @o Fo
+Æ &lt;  `  NuHçàø0&lt;  Cù   a 
+îLßNsHçÿþ0&lt; Cù   a 
+ÖLßÿNsv (*,.&amp;CIù   Kù  L$T4, 6l ´Kn(2  RB :fð´KnaL ÿo  n
+Xã\¸KoÆ `.SGka*`ø    fz v - Çü  Gù   ­ 0­ 0NuaéaØP REÜNu2  RB /o 9o @o Fo
+Æ &lt;  `  NuNqNqNqNsNqNqNqNu0&lt;  Aù   y    f,(y  ¨¹ù  ¬g&amp;\¹ü  ¸l#Ì  ¨`
+#ü  ¸  ¨NJNu(y  °¹ù  ´g &amp;\¹ü  ¸l#Ì  °`
+#ü  ¸  °NJ`ü    Nup t ~Eù  b9  ×  
+g
+  ga ðêCù  a6#Ä  Cù  2  Ã  Ö  fCù  `Cù  &quot;a#Ä  Nur v x z | 1 a þÔ f¶@lÈÀÊÀØHDÚD8&lt;  HDRA²mÖHD8HD`x Nur 49  (vEù  #Ê  3ü    3ü 
+  a Za tNux `xÿv`&amp;vxÿ` x¡`x¢`x£`x¤`x¥`
+x¦`x§`x¨vAù   Eù  v ü  ¶0ü  0ü @ Ê0ü  0ü 49   &quot;y  Ãra  êa Nu&quot;y  é   
+Gù °NJNu&quot;y  )  f$)   g)  f)  lR) Gù Z`é   
+Gù °NJNu&quot;y  |   )  
+fGù Z`Gù  NJNu&quot;y  |   Gù ZNJNu0&lt;  2&lt; 49  v Aù   &quot;y  rEù  #Ê  3ü    3ü -  a#É  rÔA3Â  a &quot;Nuü :z &lt;a2&lt;à^a,a(a$A  g
+8aSDfø
+EÿÿREa
+ü 
+ü 
+NuÚFè  0 9o Ç  0 9o ÇNuy   gaV`¹    vGù ZNJNua l y  9 ð  g| 4 `Cù   i   g| 4 `| 2 Gù ÆNJNuy   fa î y  Cù @r  g g. n  l6&lt; `0(  ¨n ¡m `&lt; `(   g&lt; `&lt; Âü xÒÁr 9    vfJ f  &gt; f  6  f  .9  °9  Nf  (  g&amp; g&lt; n  lJ&lt; `D&lt; ¹    v`6(  n  m ` &lt; `(  n m z`&lt; Âü ÒÁ&amp;QNJNu y  Cù p r 9  Àü ( A 0ÐA@  m ìØ@  n ìÐÀü ÒÀ&amp;QNJNqNu  X : X X X   X ¦ X X X  ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° °  ü ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° °  ü ° ° ° ° ° ° ° T ¤ Oþ P ¨ z ° Oþ ¶ ° ¨ P PZ PZ ° PD ° ° ° ° °   È È È È È È È È È È È È È È È È È È È È È È È È È È È È È ü È È È È È È È È È È È È È È È È È È È È È È È È È È È È È ü È È È È È È È È È È È È È È È È È È È È È È È È È È È È È ü ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° °  ü ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° X PZ ü ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ¨ ° ° ° ° P ü ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ¨ ° ° ° ° P ü 6 Oþ ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ¨ ü ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° °  ° ° ° ¬ ü ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° Z ° ° ° Z ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° °  ° ´ ü 6 Oþ ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ¨ ü È È È È È È È È È È È È È È È È È È È È È È È È È È È È È ü ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ¶ ° ° ° ° ° ° PD ° ° ° ° ° ° ZAù   0 
+Â9  t gF$Q4) ü   °   2 
+  gRB´i g3B Nu3|   a Gù jNJGù ®NJNu gl0   f0 Nu9  $i 4) °   RB´i g3B Nu3|   a  y  9 ð  g| 4 9  Nq`j  Gù ÆNJNu  g0$i 4) ´i g²   RB3B Nu3|   a ~Gù DNJNu g($i 4) ´i l²   RB3B Nu3|   a ôNu fNuAð  9   g*(  fJR9  9 
+  mB¹   ¹   `((  g R9  9   mù   ù   ü    9   g*(  gJR9  9 
+  mB¹   ¹   `((  f R9  9   mù   ù   ü    9    g,ü    9   gGù 	
+(y  °¹ù  ´gNL`NJ9    g(&amp;y  +   gSB `ü    Gù NJ(  BZ  ( NuNq0&lt;  Aù   ¼  9  t   
+Á  t0 NuAù   0&lt;  ¼   ¼   ¼ 0 ¼ 0 ¼  ¼  ¼   ¼   ¼  ¼  ¼ Z ¼   ¼ ° (  g¼ Ì `¼ » ¼ f ¼ @ ¼   ¼ À ¼ 0 ¼   
+ü    tNu9  t ý 
+¼   ¼  Á  t¹    vNu9  t þ 
+0  gø¼ 0 ¼ P   Á  t 
+¼  Nu9  t ï 
+Á  tNuNq0&lt;  Aù   9  t ý 
+¼   ¼ P   Á  t 
+ù    vv &amp;y  (k , Æüü#Ã  x¼  Nu9  t ï   Á  t 
+¼  #ü  X   ¬ü   ü    NuNq&amp;&lt;   SjüAù   0&lt;  9  t ß 
+¼   ¼     Á  t 
+¼  NuAù   0&lt;  9  t ß 
+¼ &quot; ¼ @ Á  tü    NuAù à p ¼ @| ÿ | ÿ  |   | T &quot;|   &amp;|   (| ð *| °  è    ¨  | P 
+|  |  Ð ü    +NuHçàÀAù à  ü   +LßNs49  *2Âü  2
+À À À À À 
+¼ ´y  ,g42`Ê3Â  .Åü  Cò  #É  2NuHç Gù à «    Gú NqNJLß NsAù à Eù   9   +g
+ü   +`9    +g(  gÐ ü    +a ÿP49  .Åü  02 3À  .Áü  Cò  #É  2)  
+g|  ) S o@ 49  .´y  ,m¼`L3é   0ü   Lü   iü   p(i ,   Vm  [n@ &quot;|   &amp;|   (| ð *`¨  | T &quot;|   &amp;| b (|   *| °  è    NuHç øGù ?`&quot;Hç øGù Cò`Hç øGù Fp`
+Hç øGù A|Aù à ¨    ¨  ¨  NJLß NsHçøøAù à 9  h9  ig(  g  ²  g$  g(  g,  g@  gD`lü   i`bü   i`Xü   i`Bü   i69  ,9  h `4ü   i`ü    iü   L| T &quot;¨  `| õ *  3`|  *|   (|   &amp;C | °  è    `¨    Gù HîNJLßNsHçøøAù à 9  o9  pg  g  d  g  g`0ü   p`&amp;ü   p`ü    pü   L| T &quot;¨  |  *|  (|   &amp;C | °  è    `¨    Gù KNJLßNsEù  &amp;y  k ÿü#Ê  ,k n ÿý5n 
+ÿþ&amp;y  *k ¹    Vr 2- ^Aü A mA or3Á  JÂí 
+p ÀSAnú0. a  k $y  t 49   ü a   ga Ø&#x27;H @ NuCù  
+|   a ®z v x p j  ðl  ÈCù  
+|   ¶m là¸y  NlØºm 
+lÒ  `fa °y  TnÀy  Rk¸Àü r 44  24 Cô  Bù  L09  Lt S@oá`öE  lÔù  J`C  gmçº`èº09  JS@oà`öRESAn¼09  PS@k
+REÔù  J`ò9   Hf ÿ&lt;09   a ` ÿ.g   ñg R  óg&lt;  ôg  v  õg  Ú  ög  Ü  ÷g  ä  øg  ê  ùg  ê  úg  ò` 9    Vga XáX@ g: $y  Àù  JÔÀáX@ g6 x C` þ 9    Vga Cù  
+p   ÿg   fé   : $y  Àù  JÔÀ`é    ÿg  mé  6 x C`é  a Þ` þ4áX` þ*áXa bp ` þ(áXa b` þ` þ&quot;y  Xÿý` ýô&quot;y  XÿþXÿÿCù  
+|   a |` ýÒ9    VgaJ.   f  Ú0- 
+Eo4ù    V3Å  X3À  \#Ê  ^Eù  Öz Cù  ÖÀù  JÅS@nú` ý|¹    V$y  ^E  gH| &lt;9  \ºFl&quot;2Âù  JERFü ÚFÚy  XÌù  JÔÆ`
+:2Âù  JCù  ÖSAnøNu:9  XNu9    Vg
+E  ga ÿv 6- my  Nkü `v x C` üäa  9    Vga ÿX|&#x27;H @ Eù  Nu&quot;zÌNqü   H`&quot;z¸Nqü    H3À   Àü (q  r 1 3Á  N^Aü A mA or3Á  Lr 1 3Á  P1 3Á  R1 3Á  TNujü  ül2  òm  óoT`æX`â  ífÜp @ nÀü ÐÀ`Ê   `ÆNuvj&quot;  íg  üo  :`  6C oU`  (   m    n  °f  
+HBf
+HBSfÚ| NuHBSgÆü ÐÃ|Nu2+ AmAÿn
+9    f6Hç p ) n ) °) n Q0  Aù  b0  R) `S) p Lß Nu2+ AmAÿn9    f Hç 8|   |   p 9   f9  Iù  2`TIù  :9     g.)   g)  g)  g`  ¦+  gØÀ9  `9  À  ü    @ &quot;r &amp;y  +ÿÿ gft Eù  b) °) l4  2   fR R`èS @ ) S °) o4  2   fS R`è@ +  ÿÿg+ ÿÿgRü B Lß NuEù  `*Eù  &lt;&amp;y  2Cù  .¹    Z¹    W`Eù  &amp;y  Cù   k ÿü#Ê  ,k n ÿý5n 
+ÿþ*k ¹    Vr - p - 	ÂÀ3Á  &lt;  ÀSnú k $y  t 4ü a ý ga ýP&#x27;H @ NuCù  |   a þ&amp;z v p j  ðlDCù  |   º- lâ¶- 	lÜ  `fa ý¢@ ßnÌ@  mÆ  lR`  mÀR`°g ¾  ñg   óg8  ôg&gt;  õg@  ög  ¤  ÷g  ¤  øg  ¤  ùg  ¤  úg  ¬` ê` ÿ\` ÿT9    Vga Cù  p   ÿg   fé   : `é    ÿg  mé  6 `é  - $y  ÔÅÀÃÔÀa ý` þê` þî` þÚ` þÒ(y  Xÿý` þÂ(y  XÿþXÿÿCù  |   a üÄ` þ 9    VgaR+  
+gù    WÅ  Zù    V3Å  Xp - Elp 3À  \#Ê  ^Eù  Öz .   f  ¼` þB¹    V$y  ^E  g4| &lt;9  \ºFl2ERFü ÔÆÚFÚy  X`:2Iù  ÖÜSAnúNu:9  XNu9    Vg
+E  g(a ÿv - 	gSCü p - $y  ÔÅÀÃÔÀ` ýºv - 	gSCü p - (y  Øù  XÀÃØÀ#Ì  ^` ýa  n  õg ý9    Vga ÿ2|&#x27;H @ 4. $zæNqÄü 2   f2 r  0Eð   Vf&quot; Ff Of Nf Tf
+&amp;y  a èNujü  ülN  òm  õg,  óoT`àX`Ü  ífÖp @ nÀü ÐÀ`Ä   `Àp   ÿg²°Cg®W&lt; õNuEù  &amp;y  k ÿü,k n ÿý5n 
+ÿþ*k rPp0ÀSAnú k Eù  t 49  ü a ùæ ga ù&#x27;H @ Nuz (&lt;0000ü    °v p j  ðl  ` nì  ,g:  0mà  9o  Dg  dfÎRCC nü   °`¼RCC ná `®S9   °fá&lt; Dà$ÄR`g     ñg    óg&lt;  ôg  B  õg  B  ög  B  ÷g  B  øg  B  ùg  B  úg  F`  Z` ÿ&lt;` ÿ4` ÿ,` ÿ$` ÿ` ÿØ  ` ÿØ  Ø  ` þø` þô` þð9   °fá&lt; Dà$ÄR|&#x27;H @ Eù  Nu 9  ë  
+    g2Cú~Nq i a  À   g#È  
+ü   |9    *g«  
+Nu 9  ë  
+    g*Cú6Nq i a  x   g#È  9    *g«  
+Nu 9  ë  
+    g*CúöNq i a8   g#È  9    *g «  
+`CúÌNq i #È  ü    |Nurx &quot;H ûgV ògZ ýg   íg\ þg4  m nvRjü ûoP üg^ ýg` þfZ²gnn\R`¨²lTR` r á`ááá`v  n$Æü ÐÃ`¦ òm  óoT`X`` ÿtRRDD dmAúþNq&quot;h p  INu Iü ü    *a öÐ  üo  gÝy  $ü   *a öt  þfØp INu:9  E  g,2 KpIú ìNq´g
+S@fø$H6`$ Jf PRSAfØNupIú ÂNq´gS@føRSAfè:&gt;A`&quot; Lf `
+ Jf P&gt;AR&amp;HSA:2 JpIú Nq´g&amp;S@føSAfêpIú ~Nq2 J´gSAføS@fî` ÿTASA,HG  g J 0m
+ Zn PRSGfèA  g ÿ&amp; N 0m
+ Zn RSAfè` ÿ !%&#x27;+,-./1:;IJLT_MNVWXYZRKBDPGSAQOUCHEF3245697809    Lg` n9  H9  JR9  6y    4y À  4n9  6gÞ` Ô3ü    4 y  @&quot;y  DSy  2y    2m8 !9   6frÿ`±gÚ#È  @#É  DÀ  HÁ  Jü    6`3ü   2 y  8&quot;y  &lt;ØRy  P09  R°y  Po  Zy  0y   0nhp r 9   6g² gÂ#È  8#É  &lt;$y  @°y  Fny  Dlp Àü 42  Aò ²y  Fny  Dlr Âü 42 Cò ` ÿ&amp;3ü    0y   .y   .n` ÿ|3ü    03ü    .3ü    P`  Xa 
+3ü    43ü   23ü    03ü    P3ü    .09  .2 Ãü 3Á  ,Aù  &lt;Eù  ¸Áü Cò  ` ÿ
+3ü    ,ü    6Aù à | T &quot;|   &amp;|   (| ð *| °  è    ¨  Nu g0&lt;@ `0&lt;  Ðy  ,Ðy  .Ðy  0Ðy  2Ðy  4ü    LAù à  |   &amp;|   (| ú *| °  è  è    Nu9    Lg` n9  H9  JR9  6y    4y    4m9  6gÞ` Ô3ü À  4 y  @&quot;y  DRy  2y   2n8 !9   6frÿ`±gÚ#È  @#É  DÀ  HÁ  Jü    6`3ü    2 y  8&quot;y  &lt;ØRy  P09  R°y  Po  [y  0y    0mhp r 9   6g² gÂ#È  8#É  &lt;$y  @°y  Fny  Dlp Àü 42  Aò ²y  Fny  Dlr Âü 42 Cò ` ÿ&amp;3ü   0y   .y    .m` ÿ|3ü   03ü   .3ü    P`  Xa 
+¤3ü À  43ü    23ü   03ü    P3ü   .09  .2 Ãü 3Á  ,Aù  &lt;Eù  ¸Áü Cò  ` ÿ
+3ü    ,ü    6Aù à | T &quot;|   &amp;|   (| ð *| °  è    ¨  Nu g0&lt;@ `0&lt;  Ðy  ,Ðy  .Ðy  0Ðy  2Ðy  4ü    LAù à  |   &amp;|   (| ú *| °  è  è    Nu9    Lg` v09  H29  JR9  6y   4y p  4n9  6gÞ` Ü3ü    4 y  @&quot;y  DRy  2y   2n8029   6frÿ`±AgÚ#È  @#É  D3À  H3Á  Jü    6`3ü    2 y  8&quot;y  &lt;ØRy  P09  R°y  Po  ¨y   0y  0nhp r 9   6g² gÀ#È  8#É  &lt;$y  @°y  Fny  Dlp Àü 42  Aò  ²y  Fny  Dlr Âü 42 Cò  ` ÿ$3ü    03ü    Py   .y   .nAù  &lt;` ÿn3ü    03ü    .`  Xa &amp;3ü    43ü    23ü    03ü    P3ü    .09  .2 Ãü 3Á  ,Aù  &lt;Eù  ¸Áü Cò  ` ÿ3ü   ,ü    6Aù à | T &quot;|   &amp;|   (| ð *| °  è    ¨  Nu g0&lt;@ `0&lt;  Ðy  ,Ðy  .Ðy  0Ðy  2Ðy  4ü    LAù à  |   &amp;|   (| ú *| °  è  è    Nu9    Lg` v09  H29  JR9  6y   4y    4m9  6gÞ` Ü3ü h  4 y  @&quot;y  DSy  2y    2m8029   6frÿ`±AgÚ#È  @#É  D3À  H3Á  Jü    6`3ü   2 y  8&quot;y  &lt;ØRy  P09  R°y  Po  ¨y   0y    0mhp r 9   6g² gÀ#È  8#É  &lt;$y  @°y  Fny  Dlp Àü 42  Aò  ²y  Fny  Dlr Âü 42 Cò  ` ÿ$3ü  03ü    Py   .y   .nAù  &lt;` ÿn3ü  03ü    .`  Xa ¨3ü h  43ü   23ü  03ü    P3ü    .09  .2 Ãü 3Á  ,Aù  &lt;Eù  ¸Áü Cò  ` ÿ3ü   ,ü    6Aù à | T &quot;|   &amp;|   (| ð *| °  è    ¨  Nu g0&lt;@ `0&lt;  Ðy  ,Ðy  .Ðy  0Ðy  2Ðy  4ü    LAù à  |   &amp;|   (| ú *| °  è  è    Nu9    Lf R9  h  3Aù à C ü    L|   &amp;|   (| õ *| °  è    r v ü    i9   jf
+Ã Ã  `Ã Ã 9  T9  U49  V&quot;y  XR o&gt;r 49  VRB´y  \mt R   fp `  opÀ  T3Â  Va ¨#É  XÁ  U1 fÃ r 9  ^9  _49  `&quot;y  bR   fp `B  o&lt;pR o,r 49  `RB´y  fm
+t ü   i3Â  `a 6#É  bÁ  _À  ^1 fÃ Ã  hNua Pv z Kù  :m nºy  .gü   j`Aù à | T &quot;`  ¨ü    j y  2p (h , 3À  \3À  fr Á  Ut 3Â  Va   #É  XpÀ  T1 fÃ pÀ  ^r Á  _t 3Â  `a  l#É  b1 fÃ Ã  hËü E@ 3Å  ,E Aù à  è  ü   iü    L|   &amp;|   (|  *| °  è    NuKù  &lt;x 5  ¸y  Fny  Dlx Èü $y  @&lt;2@ Cò` Nu9    Lf  Ò9  oÃ    Aù à C ü    L|   &amp;|  (|  *| °  è    r ü    p  9  k9  l9  m9  nS k  g`,p`(RAA m
+r ü   pa JÁ  lÂ  mÄ  nÀ  kf `Ã  ff `Ã Ã  oNu&amp;y  2+   
+g«   
+ù   +a ¹   +v z Aù à Kù  :m2 n,ºy  .g4 9    Wg9    ZgÃ `Ã `ü   p| T &quot;``Ã r Á  la  zÂ  mÄ  npÀ  kgÃ  fgÃ Ã  oC Ëü E@  è  ü   pü    L|   &amp;|  (|  *| °  è    NuKù  &lt;5  `m  `ô 0ftO²9  Zmx `Nu&amp;y  2p (k , 3À  R(k 0, &quot;zÖNqÀü #ñ    @r 1 3Á  D1 3Á  F+  
+g  ü9   +f ²«  
+a Ì¾¹   |   3ü    $9   Ögü    |p (k , 	fjt 49  .9   ÖfJ9   Öfa íê   g:`p#À  a î   g&amp;ù   t 49  .a íty    $n$p`p`
+pü    |#À  t 49  .a íÎ&#x27;y   &#x27;y   |   |  ü   6y   $f«  
+9    +f  ¸+ þ f  &quot;k +  
+g+  
+f  À&#x27;y  
+ `V+  
+g&#x27;k  |  |   `:+  
+g«  
+&#x27;y  
+ )   fd`,ë  
+&#x27;k  |  |   `
++  
+g  
+)   f6a æÌ&amp;y  2  g ÿ^9  9@ +  `Tü   Zù    W`ü    Z¹    W|   Aù  &lt;,k 1n 
+ÿþ. @ÿý@ r ¼   RAA mòNu y  |   Gù  NJNu y  (   l
+R Gù  `p è   
+Gù °@ NJNu y  |   Gù NJNu y  (   l
+R Gù `p è   
+Gù °@ NJNu</td></tr>
+<tr><td>3</td><td>(Eh0893-0.lod)</td><td> ô    Hç¤  ó´                                                EH0893-0.LOD  04-19-95 FAST REPROGRMMING FOR FLASH SPB        
+                                                              
+                                                              
+                                                              
+                                                              
+                                                              
+                                                              
+Hç &lt;(| YT*| ]%#ü    V` y V`B( 
+ y V`|  N¹ Ä^N¹ p$@&amp;| Â$ü Ò$Ë$Ë$Ë$Ë$Ë$Ë$Ë$Ë$p&lt;$@$p`$@$Ë$Ë$Ë$Ë$Ë$Ë$Ë$B9 ]$¼ (¼ 0  TNqNqNqNqNqNqJB9  ]$gNù âB9 ]$¼ (¼    TNqNqNqNqNqNqJB9  ]$fB9 _2`ü   _2|øÿt $| ï¤`/N¹ » XXRJfî`þLß&lt;NuNVÿüHç0&lt;*| Ux@À=@ÿþ$y V`(y Vh&amp;y Vl* Æ9 S®   ÿ g  &quot; | N¹ ´4j ÿý|  |  Fîÿþ  g  6 |  y V|R¹ V| 
+fB  UXp |  `B Fîÿþ g  H | ,  y VR¹ V  
+g 9 V°¹ V\e UXp |   y VBFîÿþ g  ¢ | 9 G UÐf: y VpR¹ Vp 
+fvB  UXp ü S UÐ9 D VÐf\|  `T y VÔR¹ VÔg 9 VÔ°¹ Y0c29 1 VÐf UXp` UXp  UXp ü D VÐ|  `B Fîÿþ g  Ö | 9 G Utfb+  :f#ü cÜ V y VR¹ V`   y VR¹ V  
+g 9 V°¹ Vxex y VBü S Ut UXp	`^ë  V9 : Vf$#ü cÜ V y VR¹ V¹ Vü G UttN$| S¸&amp;U`p°ftY`XµËeð Nf UXp FîÿþB§/. N¹ ±òLî&lt;ÿäN^NuNVÿü/
+$| V`$¼   #Ò Vh rÐ#À VlHy ZHx @N¹ ÄP R| @  R| ð  R|   R|   Rh ÿÿ | ü  S® Ry S® 
+|øÿ$_N^Nu o | &quot; | 8 | @ |  ¯ o  o  NuNVÿðHç &lt;(| ¿*| ^Íp-@ÿðp	-@ÿôp
+-@ÿøB®ÿüN¹ ¹Æ$@ 
+g Hx 
+B§Hx &lt;/
+N¹ ¼ø/
+N¹ ¼ÌOï `43ü  ^ô3ü  ^ö#ü ß ^øHx B§Hy ^äHx N¹ ÀpOï ¼ »&amp;| Yh7|  | A p&#x27;@ Hx Hx /Hx N¹ Àp&amp;k  gt` 0e 9c üfì þfæ ýfà 1f 2f¼ f`@ 9f:¼ Ì`4 2f¼ 4g(¼ `&quot; 4f 8f¼ ` 9f
+ 6f¼ »/ Hx &#x27;Hx /9 Vla þOï   |  9   S® y V`y S® 
+|øÿ#ü d VxHx N¹ ½ÖHx N¹ » P#ü cÜ Vü S Utü S UÐ y Vl|  HnÿðN¹ À°X$ p	°f&gt; 
+g(/
+N¹ ¼ÌX`Hy ß¶Hx NHy ß¸Hx NOï 9  ^ÌgÚN¹ 	Ð`®p°f n9 VHHÀr:°Agr!°AgVr@°Ag  r#°Ag  Ê`  
+g0B§Hx &lt;/
+N¹ ÃPOï `Hy ßºHx NHy ß¼Hx NOï 9  ^ÌgÚ` ÿ&lt;J9 ^Ìf ÿ2Hy VHx NHy ß¾Hx NOï N¹ ` ÿ9  ^Ìf Hy VHx NHy ßÀHx NOï ` þâHy VHx NHy ßÂHx NOï ü Y V` þº9  ^Ìf Hy VHx NHy ßÄHx NOï ` þHy VHx NHy ßÆHx NOï ü N V` þh9  ^Ìf þ\Hy VHx NHy ßÈHx NOï ` þ&lt;ü S Ut` þ0Lî&lt;ÿÜN^NuNVÿôHç&lt;&lt;&amp;| 
+d(| \¾Kîÿö$| _8%| cÜ %| ^Ð Aîÿõ%H %| YX %| YR &quot;%| YS &amp;|  *|  +Bj ,Bj .B* 0B* 15|  Hx Hx /
+Hx N¹ ÀpOï $| ^ÐJ9 YSf ôp áHr ÐAf ä°9 \õf Öp 9 Vr 9 \ÿ&quot; ÐÐÐ | bv$0 p  | ^ÔAð  $Hp Sr°b Ð0;Nû  &amp; D  À~2LòNnpp×Ä/B§B§B§B§/
+NOï ` &lt;pÝÄp 9 \?À/9 _4/ 9 _3/ 9 _5/ p 9 \?/ /
+NOï ` þpÐÄp 9 R À/9 \ô/ 9 \ü/ 9 \¿/ p 9 R / /
+NOï ` ÀppÑÄp 9 S¯À/9 ] / 9 \þ/ 9 \/ p 9 S¯/ /
+NOï ` ~pÑÄp À/ 9 ]/ p 9 \&gt;/ /
+N¹ &amp;Oï ` NpÕÄ/B§B§B§B§/
+NOï ` 4  g6xp 9 \þr 9 \ÿ&quot; ÐÐÐ | btÑÀ$H9 S¯9 S¯`4xp 9 \ür 9 \ÿ&quot; ÐÐÐ | btÑÀ$H9 R 9 R  gx/* /9 ^ü/
+N¹ Ó/ / /
+/ N¹ VOï `  p 9 _3r 9 \ÿ&quot; ÐÐÐ | btÑÀ$H/* /9 ^ü/
+N¹ Ó9 \?9 \?/ / /
+Hx N¹ VOï `09 \&gt;/ B§Hy eHx N¹ VOï `Hy   B§N¹ ÐPHx N¹ ¼Lî&lt;&lt;ÿÔN^NuNV  Hç&lt;8$. *. &amp;n (| Y$LpÕÀBJgTî R9  \õfü H`S  gÃRJfî| P E Cn  DD Hx Hx /Hx N¹ ÀpOï /. Hy ßÊ rÐ/ N¹ Ó@ y V | W Hx Hx /Hx N¹ ÀpLî&lt;ÿäN^NuNV  Hç88$. (. $n //
+N¹ à  Yf
+$| ßÎ  (| Y&amp;Lp×ÀB `Ã SJfôn  | W Hx Hx /Hx N¹ Àpp / Hy ßØ rÐ/ N¹ ÓOï $@ y V | W Hx Hx /Hx N¹ ÀpLîÿèN^NuNVÿÜHç&gt;0&quot;n Gîÿò(. ` ae zb
+  àÀ`ÃSJfàü  R® BCîÿòGîÿèB®ÿü(. `*EîÿèzNt `
+¶fzY`R´®ÿüeð NfÃR®ÿüSJfÒB$| ô &quot;j $`  ÔRGîÿÞ| xNzU`b Uf é	zL`P 9c_   zUp°c8ÁRp°f.Eîÿèt `
+²fxY`R´®ÿüeð Nf üg þfò` üg þf YfNx Aîÿò`&lt;GîÿÞ R$@zYt `  g
+`R  gø°gzN`R´eà Yf`R . °dº ýf ÿ(pNLî|ÿÀN^NuNVÿð/&quot;.  .  n CîÿðBBî ù \õ `ü  SJfö`ØSJfø9 \¾ `ü  SJföt9 \¾`BSJføHnÿðB§N¹ Ð$.ÿìN^NuHç 0$/ &amp;o $| _8ü  YR3Â YXB9 Y%| _  %K %| Y %| YX %| YR &quot;Bj Hx Hx /
+Hx N¹ ÀpHx N¹ »ìOï #ü _  Vp | ü G UÐ y Vl|   y V`|  |øÿHx N¹ ½ÖXLßNuNVÿôHç8&lt;p-@ÿôp-@ÿøB®ÿüp 09 Y   r°b@Ð0;Nû      ,#ü ßÜ ^ü`&quot;#ü ßà ^ü`#ü ßä ^ü`
+#ü ßê ^üHx N¹ ¼Hx N¹ ¼Hx N¹ ¼Oï ü D VÐtNxN |  9  S® y V`y S® 
+*| W(| X#|øÿHnÿôN¹ À°X&amp; p°fv1$| W&amp;| X&quot;`  àv2$| Vä&amp;| W`  ÎHy VtHx N¹ ¿JP9 
+ Vtfü 
+ù VttN`  ¨9 
+ Vtf9  ^Ìfù Vtü 
+tN`  9 &gt; Vtf9  ^Ìf
+ù VttN`d9 &lt; Vtf9  ^ÌftN`L9  VtftYxN`09 [ VtfxY`&quot;9 K Vtf Yf Yfù VttN`tNù VtµËe ÿ0BHx N¹ ½ÖX 1fÃ VÐ#ü W VÔ#Ì Y0`Ã VÐ#ü Vä VÔ#Í Y0 |  y Vl|   y V`|  |øÿ` þLî&lt;ÿØN^NuHçÀÀ | `þLßNsHçÀÀJ9 ]%f   | `þü  ]$ßü   LßNsNV  Hç8&lt;*| ÔtNB(| a¬$| \@Hy ßðN¹ &quot;À \¿Hy ßöN¹ &quot;À \Hy ßüN¹ &quot;À _5Hy àN¹ &quot;À ]Hy àNÀ \ÿHy àNOï À ]J9 \ÿg Ø9 ]°9 \ÿe È9 ÿ ]g ¼p 9 ]r 9 \ÿr&lt;²o ¢Hy àNÀ ]#Hy àNPÀ ]&quot;J9 ]#g ¨J9 ]&quot;g 9 ]&quot;°9 ]#e B&amp;| _R¹ ]# LTy ]&quot; Hy à NÀ \üHy à&amp;NÀ \ôJ9 \üg.J9 \ôg&amp;9 \ô°9 \üeR¹ \ü KTy \ô `tYHy à,NÀ \þHy à2NÀ ] J9 \þg.J9 ] g&amp;9 ] °9 \þeR¹ \þ KTy ]  `tYHy à8NÀ _3Hy à&gt;NÀ _4J9 _3g.J9 _4g&amp;9 _4°9 _3eR¹ _3 KTy _4 `tYHy àDNÀ \òHy àJNÀ \óJ9 \òg*J9 \óg&quot;9 \ó°9 \òeR¹ \òy \ó `tY/ 9 ]&quot;/ 9 ]#/ Hy _N¹ ðOï 0  YftYHy àPNÀ ]Hy àVNPÀ \ýJ9 ]g J9 \ýg x9 \ý°9 ]e fR¹ ]y \ý Hy à\NÀ VJ9 VftY9 V°9 ]e9 V°9 \ýctYy V | R Hx Hx /
+Hx N¹ ÀpOï J* f  ô|  | W | H | 0 Hx Hx /
+Hx N¹ Àp| P y \ü Cy \ô D|  y \¿ | 1 Hx Hx /
+Hx N¹ Àp| P y \þ Cy ]  D|  y \ | 1 Hx Hx /
+Hx N¹ ÀpOï 0| P y _3 Cy _4 D|  y _5 | 0 Hx Hx /
+Hx N¹ ÀpOï `tY/ 9 ]/ 9 \ÿ/ Hy a¬N¹ ðOï   YftYHy àdNXÀ ]g(9 þ ]b9 ]°9 \ÿe9 ]°9 ]btYü N ]¤ YgHx N¹ » Hx N¹ » Hx N¹ ½N`þLî&lt;ÿäN^NuNVÿôHç  $| [Ü5| 
+ %n  Aîÿö%H /
+N¹ nXJª gHnÿöN¹ r$ `t LîÿìN^NuNVÿôHç 0Gîÿö$| [Ü5| 
+ %n  Aîÿö%H /
+N¹ n Ae Kb  `¼  Lî ÿìN^Nu/ o t  HffR`&gt; 0e 9b é$    `  Ae Fb é$       	Ôf¾`&quot; 0e 9b åÔÔ   ÔfÞ $NuHç80&quot;o / &#x27; ÿ$IxNB`$&amp;JT°cxY* k  C RT´eØ YgÊxN$I°/ e&quot;B` JT( ¶exYR´eì* °/ #cxYLßNuNVÿüHç 8 n &quot;h &amp;|   &amp;k `EODTgbp ×ÀXRGLfì$k &amp;k `H n -h ÿü`4(nÿüRr`
+°gr ` vfðp°fR`Ú  e _cò` pgÆRµËc´BLî ÿðN^NuNVÿÐHç8&lt;N¹ Á&amp;JgHx N¹ ½NX9 \ÿp Ð | _¬ÑÀ*H`  p r 9 \ÿ&quot; ÐÐÐ | btÑÀ&amp;H0HÀ(@ f|   B« `R´g|   B« `BEîÿÐv `ÜRp °nôBEîÿÐ ae zbZ `| # /
+N¹ òX&#x27;@ R´9 ]c ÿnHy TN¹ ÃÚXHx N¹ ½Ö` ÿ6Lî&lt;ÿ´N^Nu/ o t  HffR`&gt; 0e 9b é$    `  Ae Fb é$       	Ôf¾`&quot; 0e 9b åÔÔ   ÔfÞ $NuHç0&lt;*| ]$| ]Ô&amp;| ^N¹ !¤#À X4fHx N¹ ½NXN¹ Á&amp;JgHx N¹ ½NXy ] | R Hx Hx /Hx N¹ ÀpOï +  d+ `vB(KpÙÀ`p  | e  R´eìp  | eB0   9 S° ]Äf&lt;3ü  Yü 
+ \õü  \¾ü  \?ü  R ü  S¯ü  \&gt;` p 09 Y   r°b  öÐ0;Nû    4 4ü  \¾ü  \?ü  R ü  S¯ü  \&gt;`  ¸ü  \¾&amp;y ]ÄHy àj0/ Hx Hx aN¹ %,(@/N¹ $âÀ \?Hy à0/ Hx 
+Hx aN¹ %,(@/N¹ $âOï (À R Hy à0/ Hx Hx aN¹ %,(@/N¹ $âÀ S¯Hy à²0/ Hx Hx aN¹ %,(@/N¹ $âOï (À \&gt;Hx N¹ ¼3ü  \Ôp#À \ÖHx Hx Hy \ÄHx N¹ Àp&amp;|   #ë  UÔ` y UÔEODTfB¹ UÔ`p Ñ¹ UÔ y UÔXRIMfÔHx N¹ Â:#À \ÀHx ÌHx &#x27;Hx /9 VhN¹ Oï ( |  9  S® y V`y S® 
+|øÿ#ü aò V\Hx N¹ ½ÖB9 aôN¹ -¦ü N eü N _ #ü   \ø/9 \øN¹ F\PJ f8N¹ ¹Æ&amp;@ gHx Hx &lt;Hx &lt;/N¹ ¼ø`&lt;;|  ;|  +| àÊ `;|  ;|  +| á  Hx B§/
+Hx N¹ ÀpOï N¹ 3(MpÙÀ&amp;y ^È#ü ]@ V|#ü aÀ V |  y Vh|   y V`|  |øÿ k (    ÿÐ/ Hx N¹ ÃöPr²f&amp;| þ p 0/ Hy á8Hy aÀN¹ ÓOï `  %| aÀ %| ]x  rÐ%@ %| ]  %| \ &quot;%| \ &amp;|  *B* +5|  ,Bj .|  0B* 15|  Hx Hx /
+Hx N¹ ÀpOï y ]x J9 \g| ý  | áD&quot;| aÀ&quot;Ø2Ø;|  ;|  (¼ aÀHx Hx /
+Hx N¹ Àp#ü ]@ V|%| ]@ N¹ &amp;PHx N¹ ÂOï JfHx N¹ »ìXN¹ -¦Hx N¹ ÂXJf$Hx N¹ »ìX y \ø    fN¹ ÂHx B§N¹ ºDP` þBLß&lt;NuNVÿüHç&lt;&lt;&amp;| ô -Sÿüx #ü ]Ä S´#ü U| Y8#ü ]Ð S°#ü UÈ Y4BBp 0ÐÐ®ÿü @6g :Eÿ p 0@ g@ g@ f  ø0/ 0/ N¹ %ÈP*@ 
+g  àHx 0/ 0/ N¹ &amp; Oï &amp;@ g  ÂB§0/ 0/ N¹ &amp; Oï (@ g  ¦Hx N¹ ¹$@4%M %K %L 
+5C ê  %ê  %B* Hy áJ/
+N¹ $@ #Hy áP/
+N¹ $Oï @ $E f*3Ã Yë  \õ 9 S´°¹ S°b y S´X¹ S´` 9 Y8°¹ Y4b y Y8X¹ Y8 RRBB e þÒ nÿüh  þfrHx Hx Hx N¹ &amp; Oï &amp;@ gVHx N¹ ¹$@4¼ Bª %K Bª 
+5|  ê  %ê  %B* #Ê eT 9 Y8 UÌb y Y8X¹ Y8 R#ù S´ S°#ù Y8 Y4 9 S° ]Äg#ù ]Ä ^Èü Y YÚ`, 9 Y4 U|g#ù U| ^È`
+#ù eT ^Èü N YÚ#ü ]Ä S´#ü U| Y8 Lî&lt;&lt;ÿÜN^NuNVÿìHç 0$n &amp;| ]p 0/ /. Hy áVHnÿöN¹ Ó7| 
+ Aîÿö&#x27;H Aîÿì&#x27;H Hx Hx /Hx N¹ ÀpJ.ÿìf0*   ÿ    ft`Rt`NBEîÿì`Bp rA°grB°grP°grF°grC°g`  `  `  `
+  `  RJfºLîÿàN^NuHç 0&amp;o $y ^ÈBy VX0/ /N¹ ?Z%K |   Hx CN¹ :¤Oï $ p°dt LßNuHç88$/ &amp;/ $(/  $o (p &amp;@(| ]¨9|   am ko Am* Kn$B )D Hx Hx /Hx N¹ ÀpOï &amp;l  f0 
+g,&amp;| e p 0æÀ  rá)Á`ÚJfú¼ þ&amp;| e  LßNu/&quot;/  | ô  h `´fJ( gpÑÀ ÿfê ÿfp ` $NuHç0 &amp;/ &quot;/  | ô  h `$´Afp ( ì   °f
+(   ?gpÑÀ4fØJBfp ` Lß NuHç &lt;&amp;| 1¢(| 3*| Â$y ^È* þ gª  %j  fNp * r°b îÐ0;Nû    XB||p *   ýg  þg`&amp;Hx ÿHx NP` Ôê  %Hx ¦Hx NP` ¾Hx ¦Hx NP` ®p * g  ÿg &amp;` &quot;p * r°g  ýg º  þg À` òp * r°b Ð0;Nû    N ² Æ ü ² ü Æ::pê  %B* * %  @  @fHx ¢Hx NP` N` B§Hx NHx N¹ »ìOï #ü ]@ V|#ü aÀ V |  y Vh|   y V`|  |øÿHx N¹ ½ÖB§Hx NOï ` °B* Hx ¢Hx NP` *  dR* Hx ¢Hx NP` B* ê  %Hx ¦Hx NP` fHx ¤Hx NP` Vê  %B* N` FHx B§N¹ ºDHx §Hx NOï ` (*  dR* Hx ¡Hx NP` B* ê  %Hx ¦Hx NP` òB* Hx ¡Hx NP` ÞHx ¦Hx NP` ÎB§Hx NP` À* %    f*  d
+R* N`  ê  %Hx ¦Hx NP` Hx ¦Hx NP` zp * r°g  þg  `  p * r°blÐ0;Nû  R R R R R R b R   b R R R R b &gt;Hx B§N¹ ºDHx §Hx NOï ` B* Hx ¡Hx NP` úHx ¦Hx NP` êHx ¦Hx NP` ÚN` ÔHx ¦Hx NP` Äp *    ¡r°b Ð0;Nû   ¬ ¬H¸2~Hp * r°g  ýg.  þg^`rp *   f
+N¹ 4` fHx ¦Hx NP` V*  dR* Hx ¡Hx NP` :B* ê  %Hx ¦Hx NP`  ê  %Hx ¦Hx NP` 
+Hx ¦Hx NP` úp * r°g  ýg.  þg^`rp *   f
+N¹ 8|` ÊHx ¦Hx NP` º*  dR* Hx ¢Hx NP` B* ê  %Hx ¦Hx NP` ê  %Hx ¦Hx NP` nHx ¦Hx NP` ^p * gr°g  ýg&amp;  þg0`DN¹ A` 8B* Hx ¢Hx NP` $Hx ¤Hx NP` ê  %Hx ¦Hx NP` þHx ¦Hx NP` îp * r°g  ýg2  þg&lt;`Pp *   fB§Hx NP` ºHx ¦Hx NP` ªHx ¥Hx NP` ê  %Hx ¦Hx NP` Hx ¦Hx NP` tp * r°g  þg$`(p *   fN` NHx ¦Hx NP` &gt;N` 8Hx ¦Hx NP` (p * r°g  ýg2  þg&lt;`Pp *   fB§Hx NP`  ôHx ¦Hx NP`  äHx §Hx NP`  Ôê  %Hx ¦Hx NP`  ¾Hx ¦Hx NP`  ®p *   þf  ê  %Hx ¦Hx NP`  p *   þf  zê  %Hx ¦Hx NP`fp *   ýg  þg`&quot;Hx ÿHx NP`Dê  %Hx ¦Hx NP`0Hx ¦Hx NP`&quot;p *   þfê  %Hx ¦Hx NP`NLß&lt; NuHç0&lt;(| /¦*| 0BB#ü aô VTHx p 9 V/ p 9 V/ N Hx p 9 \ô/ p 9 \ü/ N Hx p 9 ] / p 9 \þ/ N Hx p 9 _4/ p 9 _3/ NOï 0 Hx p 9 \ó/ p 9 \ò/ N Hx 9 ]/ Hy eN¹ 1Oï  Jg  ¬#ü aô VTB¹ VPHx p 9 V/ p 9 V/ NHx p 9 \ô/ p 9 \ü/ NHx p 9 ] / p 9 \þ/ NHx p 9 _4/ p 9 _3/ NOï 0Hx p 9 \ó/ p 9 \ò/ NOï $y VTBB* Bª #ü U| Y8ü Y YÚ&amp;| ]Ä`&amp;$S  fÀ* #f*  %fJgê  %X·ù S°eÒ&amp;| U|`&amp;$S  fÀ* #f*  %fJgê  %X·ù Y4eÒLß&lt;NuHç80$/ &amp;/  (/ JgT$y VT&quot;| bl`&lt;µÉb&lt;p 9 \ÿ&quot; ÒÒÒ | btÑÁ&amp;H+   gk  %k  \R´oÀ#Ê VTLßNuHç&lt;&lt;$/ ,(/ (*/ $*| VT$UJg  Ê(| bl&amp;p 9 \ÿ&quot; ÒÒÒ | btÑÁ&amp;H`  µÌb&gt;+   gr´g*`  * °+ f * °« g`\´fµÌcö*`d\`&lt;3ü  ]3ü  ]#ü á^ ] Hx Hx Hy ]Hx N¹ ÀpOï *`$\R¶o ÿz´f`\´fµÌcö*`*p Lß&lt;&lt;NuHç&lt;&lt;(/ (*/ ,*o $(| ^D | R Hx Hx /Hx N¹ ÀpOï ,  d, `vp  @B4B&amp;Lp×À$Mt `°g `
+Rp °dêJfp `&amp;Lp×À$Mt `ÛRp °dôLß&lt;&lt;NuHç00$/ &amp;/ Hx B§N¹ ºD&amp;y ^È$| ]Ôü  \C B %| ]@  rÐ%@  rÐ%@ %K %| \ &quot;Bj Hx Hx /
+Hx N¹ ÀpOï LßNuHç 0$/ &amp;o $| ]Ôü  \3Â ] B9 ]t%| ]@ %K %| ]t %| ]  %| \ &quot;Bj Hx Hx /
+Hx N¹ ÀpHx N¹ »ìOï #ü ]@ V|#ü aÀ V |  y Vh|   y V`|  |øÿHx N¹ ½ÖXLßNu/
+$| ]ÔB9 \3ù ]r ] ü  ]t%| ]@ %| ]t %| ]  %| \ &quot;Bj Hx Hx /
+Hx N¹ ÀpHx N¹ »ìOï #ü ]@ V|#ü aÀ V |  y Vh|   y V`|  |øÿHx N¹ ½ÖX$_NuHç 8$| YÚ&amp;| S´(| Y8&quot;| ^È Yf* 9 S° ]Äc SX&quot; °¹ S°e:&amp;¼ ]Ä¼ N`. 9 Y4 U|c¼ Y TX&quot; °¹ Y4e(¼ U|`¼ Y Q(  %g&lt; ÿ`B / Hx a ýPLß NuNVÿäHç0&lt;Kîÿð&amp;y ^ÈBy ]rBC$k 
+`/
+0/ a ýÚPRy ]rC pÕÀ0°k f
+*   ÀgÔ0+   ÿ    f &gt;p 0+ à@ÿðk  y \õ p 0+    r°b Ð0;Nû   **tEõ( ü ÿRp°nô9 
+ \õf$| á`$| á|  p 9 _3r 9 \ÿ&quot; ÐÐÐ | btÑÀ(H/, /
+ 
+X/ N¹ Ó/
+0/ a üôRy ]rC |  p 9 \ür 9 \ÿ&quot; ÐÐÐ | btÑÀ(H/, /
+ 
+X/ N¹ Ó/
+0/ a ü¤Oï (Ry ]rC |  p 9 \þr 9 \ÿ&quot; ÐÐÐ | btÑÀ(H/, /
+ 
+X/ N¹ Ó/
+0/ a üPOï Ry ]r` ÜtEõ( ü ÿRp°nô9 
+ \õf$| á`$| á |  p 9 _3r 9 \ÿ&quot; ÐÐÐ | btÑÀ(H/, /
+HnÿæN¹ ÓHy á¦0/ Hx Hx aa îÔ(@9 \¾9 \?9 \?/ / /Hnÿæ/
+N¹ 7ØOï 0|  p 9 \ür 9 \ÿ&quot; ÐÐÐ | btÑÀ(H/, /
+HnÿæN¹ ÓHy á¾0/ Hx 
+Hx aa îX(@9 \¾9 R 9 R / / /Hnÿæ/
+N¹ 7ØOï 0|  p 9 \þr 9 \ÿ&quot; ÐÐÐ | btÑÀ(H/, /
+HnÿæN¹ ÓHy áÖ0/ Hx Hx aa íÜ(@9 \¾9 S¯9 S¯/ / /Hnÿæ/
+N¹ 7ØOï 0|  Hy áî0/ Hx Hx aa í(@9 \&gt;/ B§/Hy e/
+N¹ 7ØOï $a û«  %B§Hx a ùÖLî&lt;ÿÌN^NuHç8&lt;&amp;/ 0(/ ,&amp;o $(o (*o  $MX`ü  SJfö`ÛSJfø9 \¾`ü  SJfö/
+B§a ùöRy ]r$y ^Èü N Y(By VX0/ /N¹ ?ZOï 9 Y Y(f%L |   Hx KN¹ :¤XLß&lt;NuHç0&lt;(| :¤*| VX$| aô&amp;y ^È k ( 	ü N Y(BUBy ]r|   «  %`Jg
+\ fò$* pÀgBJg&gt;Hy â0/ p / Hx aa ì&lt;&#x27;@ 0/ /+ N¹ ?ZOï &#x27;k  Hx SN`  ² g:Hy â0/ Hx Hx aa ëú&#x27;@ 0/ /+ N¹ ?ZOï &#x27;k  Hx SN`p g:Hy â0/ Hx Hx aa ëº&#x27;@ 0/ /+ N¹ ?ZOï &#x27;k  Hx SN`0+   #g+  #gpÀg
++ #  `+ #  / N¹ &gt;XU c  k (  fü Y Y(B« Hx SNXJUfX+   $g+  $gpÀg
++ $  `+ $  / N¹ &gt;XU c  k (  fü Y Y(B« Hx SNXJUf8Hy â*0/ Hx Hx aa êÈ&#x27;@ 0/ /+ N¹ ?Z&#x27;k  Hx SNOï a øL«  %B§Hx a ÷PLß&lt;NuHç&gt;&lt;*/ (&amp;y ^È(k $| \| 9 Y Y(gü N Y(p ` ¶Jl 
+g rJl g jJ, g ~5S %k  %k  B+ ` Xp 0æÀ d+   rá)Á dü ù dB9 d5|  5S %k  %k  %k  %| e  %| d $k   -E /y \&gt; 0k ! 1Hx Hx /
+Hx N¹ ÀpOï &#x27;j  J* .g  ¼p , r , 	ÀÁ | dª ,  ù d dü ú d5|  %| d %| YÜ (Hx Hx /
+Hx N¹ ÀpOï R+  p , Ñy ]r9  YÞgë  %9 Y ef 9   YÞBCx , éLBB` | YÜHp  0/ a õÚPC B ´Deàj , + þ f þ¢` B+ `  Ð5|  5S %k  %k  %k  %| e  %| YÜ (k   -E /y \&gt; 0k ! 1Hx Hx /
+Hx N¹ ÀpOï &#x27;j  J* .g`R+  p , Ñy ]r9  YÞgë  %9 Y ef 9   YÞBCx , éLBB` | YÜHp  0/ a ôöPC B ´Deàj , + þ f ÿ*` 4J, g , KfvB+ ` 5|  5S %k  %k  %k  %| e  %| d $k   -E /y \&gt; 0k ! 1Hx Hx /
+Hx N¹ ÀpOï &#x27;j  J* .g  ¢R+  p , Ñy ]r9  dgë  %9 Y ef 9   d Cf4p 9 d @ g&amp;*| dt , p , 	ÄÀ`
+ `fRSBJBfò`4 KgBCx , éLBB` | dHp  0/ a óÀPC B ´Deàj , + þ f þèü N Y( Lß&lt;|NuHç08&amp;/ &amp;| aô$y ^È`  ¨Àg  J« g  B§0/ /+ + / a æbOï (@ fHy â60/ Hx Hx aa æBOï (@%L 49 VX0/ /* N¹ ?ZP9 Y Y(f6 j (  fJBgBª Hx Sa ûtXü Y Y(%j  Hx Sa û\X\f ÿVLßNuHç&lt; (/ z :æ  rá)v1 o `  1f  p   íg  ýg  ü  ûgN  ògN  üg  Þ`J`.ºf&amp;Àg&quot;ü Y Y(Ry VXS ep ÐÑÀ`
+RS dÌv2`  T`  X`     ðf´fÀgü Y Y(Ry VX`Rv2`fp    ír°bJÐ0;Nû  * @ @ @ @ 8 &amp; &quot; &quot; &quot; &quot; &quot; &quot; &quot; 4 &lt; VT`&amp;X`&quot;p ÐÑÀ`T`X`v1`   ðfR þf þîLß &lt;Nu/ o t  HffR`&gt; 0e 9b é$    `  Ae Fb é$       	Ôf¾`&quot; 0e 9b åÔÔ   ÔfÞ $NuHç0&lt;(| Cj*| 1¢$| ]x&amp;| ]¨7|  p áHr ÐA y ^È°h gHx ÿHx ` °9 \õgHx ÿHx ` îHx PHx N¹ ¹àPp 9 Vr 9 \ÿ&quot; ÐÐÐ | bv$0 ü Y ]¤p 9 \¾ | ]|ÑÀ$Hp Sr	°b DÐ0;Nû   2 p ® îT888 pp×Ä/B§B§B§B§/
+NOï ` $pÝÄp 9 \?À/9 _4/ 9 _3/ 9 _5/ p 9 \?/ /
+NOï `  æpÐÄp 9 R À/9 \ô/ 9 \ü/ 9 \¿/ p 9 R / /
+NOï `  ¨ppÑÄp 9 S¯À/9 ] / 9 \þ/ 9 \/ p 9 S¯/ /
+NOï `fpÑÄp 9 \¾À/ 9 ]/ p 9 \&gt;/ /
+N¹ D,Oï `4pÕÄ/B§B§B§B§/
+NOï `/9 \ÀHx N¹ ¹àPHx ÿHx `2Hx N¹ ¼Hx B§N¹ ºD/9 \ÀHx N¹ ¹àOï Hx ¨Hx NPLß&lt;NuNV  Hç&lt;8$. *. &amp;n (| ^$LpÕÀBJgTî R9  \õfü H`S  gÃRJfî| P E Cn  DD Hx Hx /Hx N¹ ÀpOï /. Hy âB rÐ/ N¹ Ó@ y V | W Hx Hx /Hx N¹ ÀpLî&lt;ÿäN^NuNV  Hç88$. (. $n //
+N¹ Dæ  Yf
+$| âF  (| ^&amp;Lp×ÀB `Ã SJfôn  | W Hx Hx /Hx N¹ Àpp / Hy âP rÐ/ N¹ ÓOï $@ y V | W Hx Hx /Hx N¹ ÀpLîÿèN^NuNVÿÜHç&gt;0&quot;n Gîÿò(. ` ae zb
+  àÀ`ÃSJfàü  R® BCîÿòGîÿèB®ÿü(. `*EîÿèzNt `
+¶fzY`R´®ÿüeð NfÃR®ÿüSJfÒB$| ô &quot;j $`  ÔRGîÿÞ| xNzU`b Uf é	zL`P 9c_   zUp°c8ÁRp°f.Eîÿèt `
+²fxY`R´®ÿüeð Nf üg þfò` üg þf YfNx Aîÿò`&lt;GîÿÞ R$@zYt `  g
+`R  gø°gzN`R´eà Yf`R . °dº ýf ÿ(pNLî|ÿÀN^NuHç  $o B9 ]$ü  ]%NqNqNqNqNqNqJB9 ]%9 ]$LßNuHç8&lt;N¹ Á&amp;JgHx N¹ ½NXN¹ Iü @  Hx B§N¹ ºDPN¹ IâB§Hx N¹ À4P*@$Mp * rR°g4rW°g  rE°g  ÆrC°g  ÚrA°g  îrS°g brP°g ú` ^* g V ÿg Np Ð@ | _¬00  HÀ&amp;@ fB* | P ` .´f &quot; /cB* ` C (JpÙÀ`Û SJ fö| P ` ø* g ê ÿg â* / b Ø/
+N¹ NÞXN¹ Ox| P ` Ä* / * / N¹ MÈP@ ` ¨* D/ * C/ N¹ MÈP@ ` * C°* Db z* Dg r ÿg j* Cg b ÿg Z* / b Pj C * C`p Ð@ | _¬Jp  fB `R´* Dcà/
+N¹ NÞXN¹ Ox| P ` * C°* Db  þ* Dg  ö ÿg  î* Cg  æ ÿg  Þ* / b  Ô* C`\xNp Ð@ | _¬00  HÀ&amp;@ g(´f$* ¶f(JpÙÀxY`
+°gxN` SJ fî Yf/ / N¹ MÈP`xR´* Dc`n* C°* Db^* DgX ÿgR* CgL ÿgF* / b&gt;j C /
+N¹ NÞX* D°* Cc* D/ * CR / N¹ MÈPN¹ Ox| P `| E /
+N¹ ¼¼X` ý@Lß&lt;Nu#ü    _l#ü    S &quot;y _l | N8p ØR   mô&quot;y S  | Np ØR   môNuNVÿüHç?&lt;(| _¬KîÿþBC&amp;LBB6ÃRBB möBB4&lt;  :Eÿ0HÀ$@`\6
+JgN ÿfB  f:`L=Cÿü`Fp ÐAô &amp;HJSg0/ 0/ / N¹ J¦Oï 6`6B0 lR`Rp ÕÀ0HÀ°dB B0 o ÿU  g9Uþ`9nÿüþLî&lt;üÿÔN^NuHç&lt;0&amp;/  (/ $*/ &amp;| S 0  ð 2  ð °f
+¶Dm 46`0  ÿ2  ÿ°l46`40HÀ$@ºf* /b&quot;` ÿg SJ fòB§0HÀ/  SNP0`B§0HÀ/  SNP0Lß&lt;Nu&quot;o  o `
+ ÿgpFNu³ÈcòpTNuNVÿ8Hç?&lt;BCBE(| _®t&gt;gG0 lRC`RER ÿeè¶En&lt;6&lt;  :&lt;/ÿ`
+&lt;6&lt;0 :&lt;?ÿJFfB0HÀ/ 0HÀ/ a ÿP  Tg 0HÀ&amp;@/ y _lNXJ f
+/ y _lN3Ã aª`  ÄBFt(| _®Eîÿ8Kîÿÿ`V&gt;¾CmF¾EnB0HÀ&amp;@´f6g. /b(p T&quot;
+°nÂÄ`Û SJ föBTRF`
+BT`BT`RRT ÿdµÍc¦0HÀ&amp;@/ y _lNXJ f/ y _lNX3Ã aªEîÿ8`/
+/ / N¹ MOï p ÕÀ SFJ@nÚLî&lt;üÿN^Nu/
+&quot;/ 09 aªHÀ$@p Aò R&quot;Hµü    eµü  /ÿb³ü  /ÿc$pF`*µü  0 eµü  ?ÿb³ü  ?ÿcpF`pF`
+/	/
+a þ.P$_NuHç8&lt;&amp;/ $(/  &amp;o (tP09 aªHÀ$@p Ð@ | _¬00  HÀ(@/ /
+R y S NP  EftE`/ /
+R y S NP  EftE SJ fÞ | aª*H0r ÒA | _¬1 : gB§/ y S NP  EftELß&lt;NuHç80&amp;/ (/ Jg ÿfpE`PJg ÿfpE`BtPp Ð@ | _¬Að  &amp;H`&amp;0HÀ$@ 
+gBSB§/
+ y S NP  EftETR¶cÖLßNuHç  Eï t R¼ P |  R¼   R¼ Ð R¼ p R   gô R gB R¼ ÿ|øÿLßNu/
+Eï  R¼ P |  R¼ @ R¯  R¼ p R   gô R g   R¼ ÿ|øÿpE`   R¼ ÿ|øÿpP$_NuHç08$o | W Ep * Ð@ | _¬00  HÀ&amp;@ g&gt;°* f6´* f.(JpÙÀvN`
+°gvW` SJ fî Nf| N E`2a ü* / a ýhX  Tfê 
+rÐ/ * / * / a ý®Oï LßNuNVÿÐHç8&lt;*| _¬4-þB0 mB?ÿn
+4&lt;  6&lt;/ÿ`B  mB/ÿn
+4&lt;0 6&lt;?ÿ`a û¤0HÀ$@ ÿg  ¸p $@(MIìþ&amp;M`´Sn¶Sm0HÀ$@`T·Ìeê 
+f&lt;0HÀ/ 0HÀ/ a ûBP  Tg  v0HÀ$@/
+ y _lNXJ f^/
+ y _lN`RGîÿÐ /c/ / a ý`6t `Ú SBJ@nö`a û / a üPX  TfìHnÿÐ/ / a üLî&lt;ÿ´N^NuNV  Hç 8(| V$| R¤t Eê 
+B*ÿöRp°nð$| Tt BRp°lö¼ NB§Hx N¹ À4P$@&amp;J0+ HÀr
+°b  ¦Ð0;Nû     * : ^ h r |   /
+N¹ Q `x/
+N¹ R8`n Yfj/
+N¹ SÚ`^ YfZ&amp;| âT`/RHx N¹ ¿PJfì`&lt;/
+N¹ U`0/
+N¹ X:`&amp;/
+N¹ ^`/
+N¹ oä`/
+N¹ p&quot;`/
+N¹ prX/
+N¹ ¼¼X` ÿ0LîÿðN^NuHç&lt;&lt;&amp;o $*| S $k (k ü : k &quot;/ /
+NT k :t 4à/ /
+NTÖ/ /
+NOï TÖ k `/ /
+NPTÖ SJ fèFR/ /
+NPTü 
+ü 
+BLß&lt;&lt;NuHç&lt;&lt;(o $$l *l &amp;l &amp;BHx :/
+N¹ Ó&lt;P$@ 
+f  `  ÖR//
+N¹ SDP  l &quot;Jf  º¸, +e¸, *c  `  ¦T//
+N¹ SD z áMTÔ//
+N¹ SDOï  p @ l 0ºl .eºl ,c  `\TÔ//
+N¹ SDP  l ¶, 1e¶, 0c  `2//
+N¹ SDP ÃTÔ SJ fä//
+N¹ SDPÔ Jg  Lß&lt;&lt;NuHç0 &quot;o  o Br 0d  `  9c Ad  ` Fc  `_ Jgé ÖSJl¼Lß Nu/&quot;/  o pJgt è`  
+e 7` 0ÂSJlÖ$NuNVÿüHç0&lt;&amp;n (| ¿Kîÿý | â\Cîÿþ2Ø6+ JClDC$| â^`/
+RHx NPJfðC n4`t$| âb`/
+RHx NPJfðSBJBnâ$| âf`/
+RHx NPJfð0HÀrdN¹ ÎÒ6 HÀr
+N¹ Î  0HnÿýHx N0HÀr
+N¹ ÎÒ  0HnÿýHx NHnÿþHx NOï $k tg&amp; 
+g 
+gHnÿý`HnÿþHx NPRBB HoÖ$| âh`/
+RHx NPJfðLî&lt;ÿäN^NuNVÿøHç8&lt;&amp;n Kîÿú+ &amp;+ $| R¤BJg ´* f¶ª f&#x27;j   ÿg ¢R` Rp
+ÕÀp°bÐ| 1ÿÿ$| ô  ae
+ kb   Ae Kb Ap å @$r`p $@p*`  ´| 1ÿÿ(Jp   þg   ûg&amp;  òg2  ýgN  ügL  ígN`V¶fp $@R`rp ár Ð*(J``p ár Ðár Ðár Ð*(J`&gt;p `8| 1ÿÿ`p ÐÕÀ`   ðfR| 2ÿÿHnÿÿHnÿú/
+N¹ VìOï $@¶e 
+f ÿF. Yÿÿf  &#x27;L &lt; ÿ$| R¤BJfB(`´c(Rp
+ÕÀp°bâ ÿf $| R®p*¼ Rp
+ÕÀp°bðtx `R åÐÐ | R¤ÑÀ$Hk  %k  %k  `B« Lî&lt;ÿÜN^NuHç  $o &quot;o  o ` $ 1f  p   íg  ýg&amp;  ûg&amp;  òg2  üg  ø`Jp ÐÕÀ¼ 2`  æp `  òp ár Ð `  Þp ár Ðár Ðár Ð `  ¼   ðfR¼ 2`  p    ír°b  zÐ0;Nû  * n n n n H &amp; &quot; &quot; &quot; &quot; &quot; &quot; &quot; 8 h 4T`TX`Pp ÐÕÀ`Fp `Tp ár Ð `Bp ár Ðár Ðár Ð `&quot;¼ 1`   ðfR þf þÖR¼ Y 
+LßNuNVýÈHç?&lt;(n -l ÿü-l ÿø-| _pÿô&amp;l $ nÿø(    ÿéAó $Hì - R-@ýÜ R-@ýØ R-@ýÔ nÿø(    ÿ nÿø( 	   ÿN¹ ÏAó *H-KýÐ-KýÌ nÿü(  nýÜ nÿü( 
+ nýØ nÿü(  nýÔ, S /f8 nýÔ / , 0/ /,  HnýäN¹ gOï Aîýä-Hÿð, 0`ü  ·Íeø`ü ÿ·Êeø$l  
+f nÿü(  nýÜ|  .| þ ,` JB, .Aîýá&quot;nÿô#H B.ýáB.ÿï&amp;nýÐ nÿø(    ÿAó *HBDp 0, æ@ýã,   rá)Aýâz1` Ð 1f   ífP`.°.ýãf&quot;À.ýâg|  .S ep ÐÕÀz2`
+RS dÌ 1f /
+N¹ f¤X$@` r   ðf´.ýãfÀ.ýâg|  .z2`R 1f F/
+N¹ f¤X$@` 6p    ír°b ÈÐ0;Nû ²¼¼ ö ®®ª ªªª BªJ.ýág/N¹ ]°X&amp;@ ÿgv `6nýÎ ÿgx  nÿø(    ÿr 2N¹ ÏÐ®ýÐ-@ýÌp 0Ð®ýÌ&amp;@ nÿø(    ÿÐ®ýÌ*@` J.ýág/N¹ ]°X&amp;@ nÿô*h  nÿô  nÿô!M Gîýî nÿô!K *KKí  nÿô!M | ýá nÿüJ( g 4/
+N¹ f¤X$@` $J.ýág  æ Aîýî°gl/N¹ ]°X&amp;@6nýÎ nÿø( 	   ÿSlRâ8  nÿø(    ÿr 2N¹ ÏÐ®ýÐ-@ýÌp 0Ð®ýÌ&amp;@ nÿø(    ÿÐ®ýÌ*@` ¦ nÿô&amp;nýÎ nÿø( 	   ÿSlRâ8  nÿø(    ÿr 2N¹ ÏÐ®ýÐ-@ýÌp 0Ð®ýÌ nÿô  nÿø(    ÿÐ®ýÌ nÿô!@ ` 86nýÎ nÿø( 	   ÿSlRâ8  nÿø(    ÿr 2N¹ ÏÐ®ýÐ-@ýÌp 0Ð®ýÌ&amp;@ nÿø(    ÿÐ®ýÌ*@`  Ø nýØ nýÔ, S /f  Â nýÔ¼fp `p   g  ª nýÔ / , 0/ /,  HnýäN¹ gOï Aîýä-Hÿð`xR nýÜ`nT`jX`fp ÐÕÀ`\J.ÿïgJf
+$nýÈB.ÿï`H   ðfR`: `f, S /fJg nÿðR®ÿðS·ÍdH | ò%0  H@ WgÂ þg üf ü$J.ýág/N¹ ]°B ,)J Lî&lt;üý N^NuHç08&quot;o (| _p&amp;l $T&quot;, &amp;, $	´o$´o$`  RlRâ&amp; `ü  SJnö`ÛSJfø l B 
+LßNuNVý¨Hç?&lt;-| ô ÿü n -h ÿø n -h ÿô nÿü-h ÿð nÿü-h ÿì-| _pÿè nÿø0(   ÿÿ^l^æ=@ý° n (h ( nÿø(    ÿéAô $H n è - R-@ýÆ R-@ýÂ R-@ý¾-Lýº nÿø0( 
+  ÿÿr 2.ý°N¹ ÏAô *H nÿô(  nýÆ nÿô( 
+ nýÂ nÿô(  ný¾ n ( S /fF ný¾  @ýÓ/  n ( 0/  n /(  HnýÔN¹ gOï AîýÔ-Hÿä n h 0ýÒ`B¹Íeú`ü ÿ¹Êeø n $h  
+f&amp; nÿô(  nýÆ n |  . n | þ ,`  n B( .AîýÏ&quot;nÿè#H B.ýÏB.ÿã nÿè1ný° &amp;nýº nÿø0( 
+  ÿÿr 2.ý°N¹ ÏAó *H nÿô=h ý²p 0.ý²çÐ®ÿð(@-TÿÞl ýÑl ýÐ, l ý­p .ýÑ^l^æ=@ý®B.ýÎ n 0(   ÿÿæ@ýÍ n 0(   rá)AýÌ| 1ýËBný´BF` ¤. 1ýËf  ¨ ífZ`6°.ýÍf*À.ýÌg$ n |  .S ep ÐÕÀ| 2ýË`
+RS dÄ. 1ýËf J/
+N¹ f¤X$@` :   ðf&quot;¶.ýÍfÀ.ýÌg n |  .| 2ýË`R. 1ýËf /
+N¹ f¤X$@` ôp    ír°b Ð0;Nû Röö` ÜL p F¬^F:ÈFJ.ýÏg/N¹ f0X&amp;@ nÿè*h  ÿg| 0HÀr 2.ý°N¹ ÏÐ®ýº&amp;@ ÿg tp =@ý´` hJ.ýÏg/N¹ f0X&amp;@ nÿè*h z áMp Ú@0HÀÿÿ g&lt;0HÀr 2.ý°N¹ ÏÐ®ýº&amp;@z áMp Ú@0HÀÿÿ g =Eý´` üJ.ýÏg/N¹ f0X&amp;@ nÿè*h  nÿè  nÿè!M GîýÞ nÿè!K  nÿè (  nÿèAó *H    °d*KKí  nÿè!M | ýÏ nÿôJ( g /
+N¹ f¤X$@` xJ.ýÏg AîýÞ°g/N¹ f0X&amp;@ nÿè*h  nÿø0(   ÿÿr .ýÑ°o$ nÿø0(   ÿÿr .ýÑlRâ=@ý´` Bný´`  nýÂ ný¾ n ( S /f ö.ýÓ ný¾°fp `p   g Ú ný¾  @ýÓ/  n ( 0/  n /(  HnýÔN¹ gOï AîýÔ-Hÿä` R nýÆ` T` X` p ÐÕÀ` zp áHr ÐA=@ý²p 0.ý²çÐ®ÿð(@-TÿÞl ýÑl ýÐ, l ý­p .ýÑ^l^æ=@ý®` ,z áMp Ú@p 0çÐ®ÿì(@-TÿÞl ýÑl ýÐ~ |  ý­p .ýÑ^l^æ=@ý®| ýÎv J.ÿãgJf$ný¶B.ÿã` Ì   ðfR` ¼ `f  n ( S /fJ.ýÒg nÿäR®ÿäS.ýÒ·Íd ¶e ¶.ý­b p ÐÐ®ÿÞ @8p ÐÐ®ÿÞ @0(   ÿÿr 2r 2.ý®N¹ Î: p 0Ð®ÿÞ(@`  ¦JFm   nÿø0( 
+  ÿÿ2HÁ°ott 8.ý®` á$ p SDJDfîJný´m0.ý´HÀ&quot;á©`0.ý´HÀD&quot;à©$8.ý°`.J.ýÏgÂ` R-@ý¨ ný¨   ÿ ný¨ à$ SDJDfÎ`p 0.ý®ÙÀp 0.ý°×ÀRFSEJEg·Íe ÿTJ.ýÏg8.ý°p .ýÐÈÀ`BSDJDg ·Íeô`p 0.ý°r .ýÐN¹ Ï×À·Íc&amp;MJ.ýÎg&gt;p 0.ý²çÐ®ÿð(@-TÿÞl ýÑl ýÐ, l ý­p .ýÑ^l^æ=@ý®B.ýÎp .ýÐÜ@ þg üf úPJ.ýÏg/N¹ f0 n C , n !J Lî&lt;üýN^NuHç0&lt;*o &amp;| _p(k $S&amp;
+$+ r 2+  N¹ Î$ RJlRâr 2+  N¹ Ï$ ÕÂ` 
+R*@   ÿSJfè k B 
+Lß&lt;Nu/ o `XRp    ír°b:Ð0;Nû  &amp; 0 0 0 0 &quot; &quot;        T`X`p ÐÑÀ`   ðfR þg üf $NuNVÿìHç8&lt;(. &amp;n (n KîÿìEîÿöB`Jfü  `ÃRR´eêBp . r°gr°g$r°g:`dHnÿö/
+N¹ gèP B§/ /
+`PHnÿö/
+N¹ gèP / B§/
+`4Hnÿö/
+N¹ gèP v p  â/  Râ/ /
+`B§B§Hnÿö/N¹ h.Lî&lt;ÿÐN^Nu/
+&quot;o  o `R  gø$HB`ÀRRföBJg`B&quot;  gø$HB`RJfú$_Nu&quot;o  o / `ü  S J fö`Àfú/ `ü  S J föBNuNVÿäHç &lt;&amp;| pr(| UØ*| ^Eîÿæ%| âl %| [ø /
+NX j Jf | âr&quot;j Øfü%| âz %| \ /
+NX j Jf | â&quot;j Øfü%| â %| \ /
+NX j Jf | â&quot;j Øfü%| â %| \ /
+NX j Jf | â&quot;j Øfü%| â¦ %| \  /
+NX j Jf | â¬&quot;j Øfü%| â¶ %| \* /
+NX j Jf | â¼&quot;j Øfü%| âÄ %| \4 /
+NX j Jf | âÊ&quot;j Øfü%| âÔ %| eX /
+NX j Jf | âÚ&quot;j Øfü%| âÞ %| eb /
+NX j Jf | âä&quot;j Øfü%| âè %| el /
+NX j Jf | âî&quot;j Øfü%| âò %| ev /
+NX j Jf | âø&quot;j Øfü%| âü %| e /
+NX j Jf | ã&quot;j Øfü%| ã %| e /
+NX j Jf | ã&quot;j Øfü%| ã %| e /
+NX j Jf | ã&quot;j Øfü%| ã %M /
+NX j Jf | ã&quot;&quot;j Øfü%| ã*  
+r
+Ð%@ /
+NX j Jf | ã2&quot;j Øfü%| ã&lt;  
+rÐ%@ /
+NX j Jf | ãD&quot;j Øfü%| ãJ  
+rÐ%@ /
+NX j Jf | ãR&quot;j Øfü%| ãX  
+r(Ð%@ /
+NX j Jf | ã`&quot;j Øfü%| ãd  
+r2Ð%@ /
+NX j Jf | ãl&quot;j Øfü%| ãr  
+r&lt;Ð%@ /
+NX j Jf | ãz&quot;j Øfü%| ã  
+rFÐ%@ /
+NX j Jf | ã&quot;j Øfü%| ã  
+rPÐ%@ /
+NX j Jf | ã&quot;j Øfü%| ã¢  
+rZÐ%@ /
+NX j Jf | ãª&quot;j Øfü%| ã²  
+rdÐ%@ /
+NX j Jf | ãº&quot;j Øfü%| ãÄ  
+rnÐ%@ /
+NX j Jf | ãÌ&quot;j Øfü%| ãÖ %L /
+NX j Jf | ãÞ&quot;j Øfü%| ãâ  r
+Ð%@ /
+NX j Jf | ãê&quot;j Øfü%| ãî  rÐ%@ /
+NX j Jf | ãö&quot;j Øfü%| ãú  rÐ%@ /
+NX j Jf | ä&quot;j Øfü%| ä  r(Ð%@ /
+NX j Jf | ä&quot;j Øfü%| ä  r2Ð%@ /
+NX j Jf | ä&quot;j Øfü%| ä  r&lt;Ð%@ /
+NX j Jf | ä&amp;&quot;j Øfü%| ä*  rFÐ%@ /
+NX j Jf | ä2&quot;j Øfü%| ä6  rPÐ%@ /
+NX j Jf | ä&gt;&quot;j Øfü%| äB  rZÐ%@ /
+NX j Jf | äJ&quot;j Øfü%| äN  rdÐ%@ /
+NX j Jf | äX&quot;j Øfü%| ä\  rnÐ%@ /
+NX j Jf | äf&quot;j Øfü%| äj %| X$ /
+NX j Jf | än&quot;j Øfü%| är %| Y\ /
+NX j Jf | äx&quot;j Øfü%| ä| %| VØ /
+NX j Jf | ä&quot;j Øfü%| ä %| Y /
+N j Jf | ä&quot;j ØfüLî&lt; ÿÔN^NuHç  &quot;o t &quot;) $| T²g Jf0åH | T!©   `
+XRp°nÜLßNuHç 0&amp;o &quot;| Tr  å @ 1 °« f&quot; åAñ $H`$ê Rp°nô å @B± Rp°nÆLß NuNVÿüHç 8&amp;|   &amp;k `EODTgjp ×ÀXRGLfì$k &amp;k  n &quot;h `H n -h ÿü`4(nÿüRr`
+°gr ` vfðp°fR`Ú  e _cò` pgÆRµËc´BLî ÿðN^Nu/
+$| ^ÌBHy &quot;PN¹ ¿~Hx N¹ ½ÖHy &quot;PN¹ ¿~#À &quot;P¼ /9 ïHx N¹ ¹\Hx Hx N¹ ½jHx Hx N¹ ½jOï $N¹ qv`$_NuNVÿØHç 0$| T&amp;| ½jHy äNXN¹ ¹~/ NXHy äNHnÿØN¹ P.ÿØHHÀrz°b ¦Aù rr°SÉÿüf Ò0;Nû  Øl R f p \ z  Î ìl  Øl R f p \ z  Î ìl   â ¢!#$CGHKMPQRSTXZcghkmpqrstxz N¹ s|` ÿfN¹ xî` ÿ\N¹ {(` ÿRN¹ |ú` ÿHN¹ ~D` ÿ&gt;N¹  ` ÿ4N¹ ª` ÿ*N¹ ð` ÿ /9 ïHx N¹ ¹\Hx Hx NHx Hx NOï ` þôN¹ @` þêN¹ 2` þàN¹ Î` þÖHy äªNHy ä¬NHy ä¸NHy äÈNHy äØNHy ääNHy äôNHy åNHy åNHy å*NHy åXNHy åvNOï 0Hy åNHy å¨NPHy å²` þRHy åÄNB9 ^Ì/9 ïHx N`
+Hy åÞ` þ,Lî ÿÐN^NuNVÿèHç&gt;&lt;KîÿüHy åìN¹ THy æN¹ TPp*|` (p°l.|Hy æ N¹ THnÿèN¹ P. Xÿèg . xÿèg  &quot; ÒÐéÐ | f-p ÿøHnÿø/N¹ 4X/ HnÿüHy æ,N¹ tOï  &quot; ÒÐéÐ | f00 @ gHy æDN¹ TX &quot; ÒÐéÐ | f00 @ gHy æPN¹ TX &quot; ÒÐéÐ | f00 @ @g @Hy æZN¹ TXt&amp;| e¬z	`  °f  | ð¦HpX Hy æfN¹ t//Hx N¹ °//Hx N¹ °Oï  x$| T¤v	`  ´ª $f | ñ¦Hp8 Hy æpN¹ tP´ª f | ñ¦Hp8 Hy æN¹ tP´ª  f | ñ¦Hp8 Hy æN¹ tP´ª (f | ñ¦Hp8 Hy æ¢N¹ tPp	Öp4ÕÀR¸¹ ñro ÿvx$| V°v	`&amp;´f | ñüHp8 Hy æ´N¹ tPp	ÖpÕÀR¸¹ ñøoÒp	ÚR´¹ ðo þà &quot; ÒÐéÐ | f00 @ gxt(| T¤v	`d$l &amp;Lp×À`J * °f@JfHy æÈ`Hy æÔN¹ T | ñ¦Hp8 Hy æàN¹ t//Hx N¹ °Oï $R 
+f²p	Öp4ÙÀR´¹ ñro &quot; ÒÐéÐ | f00 @  gfHy æêN¹ TXt&amp;| V¨v	`D$S`2 * °f( | ñüHp8 Hy æöN¹ t//Hx N¹ °Oï $R 
+fÊp	Öp×ÀR´¹ ñøo´ &quot; ÒÐéÐ | f00 @ gHy æþN¹ T//B§N¹ °Oï  &quot; ÒÐéÐ | f00 @ gfHy çN¹ TXt&amp;| Tv	`D$S`2 * °f( | ñhHp8 Hy çN¹ t//Hx N¹ °Oï $R 
+fÊp	Öp ×ÀR´¹ ñdo´ &quot; ÒÐéÐ | f00 @ gfHy ç&amp;N¹ TXt&amp;| U\v	`D$S`2 * °f( | ñæHp8 Hy ç2N¹ t//Hx N¹ °Oï $R 
+fÊp	Öp×ÀR´¹ ñÊo´ &quot; ÒÐéÐ | fp  fHy ç:N¹ TX &quot; ÒÐéÐ | fJp fHy çBN¹ TX &quot; ÒÐéÐ | fJ° g&lt; &quot; ÒÐéÐ | fHp  &quot; ÒÐéÐ | fHp Hy çHN¹ tOï Hy çjN¹ TXRR 9 ïÐ¹ ï °l úÊLî&lt;|ÿÄN^NuNVÿìHç0&lt;Gîÿü(| Tp*| tHy çlN¹ THy çN¹ TPp&amp;v` êp°l.vHy ç²N¹ THnÿìN¹ P. Xÿìg Ì. xÿìg Â &quot; éÐåAô Aè ,/ &quot; éÐåAô Aè 0/ &quot; éÐåAô P/ &quot; éÐåAô Aè / &quot; çÐ | ñ¦Hp HnÿüHy ç¾NOï  &quot; éÐå @$t`/* N¹ 4X/ Hy çäNP$R 
+fâ &quot; éÐå @$4$g* å | e¨J° o çÐ | ð¦Hp Hy çîNP &quot; éÐå @$4g* å | e¨J° o çÐ | ð¦Hp Hy è NP &quot; éÐå @$4 g* å | e¨J° o çÐ | ð¦Hp Hy èNP &quot; éÐå @$4(g* å | e¨J° o çÐ | ð¦Hp Hy è$NPHy è6N¹ TXRR °¹ ñro þLî&lt;ÿÔN^NuNVÿìHç8&lt;Gîÿü(| t*| THy è8NHy èRNPp&amp;x` p°l*xHy ènNHnÿìN¹ P. Xÿìg p. xÿìg f &quot; çÐ | ð¦Hp HnÿüHy èzNOï  å | e¨ 0 grÿ°g`Hy è` Hy è`  å | e¨&amp;0 /N¹ 4X/ Hy èN//Hx N¹ °Oï v$| T¤t	`z °ª $f | ñ¦Hp( Hy è¦NP °ª f | ñ¦Hp( Hy è¸NP °ª  f | ñ¦Hp( Hy èÊNP °ª (f | ñ¦Hp( Hy èÜNPp	Ôp4ÕÀR¶¹ ñro ÿ~v$| V°t	`$ °f | ñüHp( Hy èîNPp	ÔpÕÀR¶¹ ñøoÔHy éNXRR °¹ ðo þnLî&lt;ÿÐN^NuNVÿìHç &lt;Gîÿü(| Sü*| THy éNHy éNPp&amp;t` p°l*tHy éPNHnÿìN¹ P. Xÿìg  è. xÿìg  Þ ëAô Aè / ëAô Aè / &quot; çÐ | ñhHp HnÿüHy é\N¹ t ë @ 4r²fHy éx`Hy é~NOï  ë @J´gT ë @ t/( N¹ 4X/ Hy éN¹ tP ë @$t `/* N¹ 4X/ Hy éN¹ tP$R 
+fÞHy éNXRR °¹ ñdo þöLî&lt;ÿØN^NuNVÿèHç0&lt;Gîÿü(| U@*| THy éNHy é²NPp&amp;v` B®ÿø &quot; ÐÐç @$t $.ÿø`$RR 
+fø-Bÿøp°l*vHy éèNHnÿèN¹ P. Xÿèg  Ô. xÿèg  Ê &quot; ÐÐå | ñÒHp  &quot; ÐÐçAô Aè / &quot; ÐÐçAô Aè / &quot; ÐÐå | ñÖHp Hnÿø &quot; çÐ | ñæHp HnÿüHy éôN¹ tOï   &quot; ÐÐç @$t`/* N¹ 4X/ Hy êN¹ tP$R 
+fÞHy ê$NXRR °¹ ñÊo þäLî&lt;ÿÐN^NuNVÿèHç0&lt;Iîÿü*| THy ê&amp;NHy ê&gt;NPp(v&amp;| V¤`  ÂB®ÿø$S$.ÿø`$RR 
+fø-Bÿøp°l*vHy êdNHnÿèN¹ P. Xÿèg  . xÿèg   &quot; åÐå | V Hp Hnÿø &quot; çÐ | ñüHp HnÿüHy êpN¹ tOï $k `/* N¹ 4X/ Hy êN¹ tP$R 
+fÞHy êNXRRp×À °¹ ñøo ÿ6Lî&lt;ÿÐN^NuNVÿäHç &lt;&amp;| t(| TKîÿèHy êN &lt;  è&quot;9 òN¹ Î-@ÿüHy òHnÿüHy ê¬NHy S¨Hy òHy êêNHy S¤Hy &quot;PHy ëNHy ëNNHy ëNOï 0Bt$y X0` è * °¹ S¨c * ¹ S¨`pÿ¹ S¨Ðª R*&quot;9 ò N¹ Ï*p°l*tHy ë²NHnÿìN¹ P. Xÿìg . xÿìg R * &quot;9 òN¹ Ï-@ÿä/* N¹ 4X/ HnÿäHnÿèHy ë¾NOï  * r°b 0Ð0;Nû  0 L  ° n  * &quot; çÐ | ð¦Hp Hy ëÒNP`  /* N¹ 4X/ Hy ëèNP`  ä * &quot; çÐ | ð¦Hp Hy ëþNP`  Â * &quot; çÐ | ñüHp Hy ìNP`    * &quot; çÐ | ñæHp Hy ì*NP`~Hy ì@N * &quot; éÐå | TJ° fHy ìF`Hy ìLN * &quot; çÐ | ñ¦Hp Hy ìRNOï `* * &quot; çÐ | ñhHp Hy ì\NP`
+Hy ìrNX$R 
+f þLî&lt;ÿÐN^Nu/t | UX&quot;9 ñÊ`B¨ B¨ pÑÀR´oît | T¤&quot;9 ñr`B¨ ,B¨ 0p4ÑÀR´oît | T&quot;9 ñd`B¨ B¨ p ÑÀR´oît | V´&quot;9 ñø`BpÑÀR´oôB9 _¡Hy ìN¹ TX$NuNVÿüHç 8Eîÿü&amp;| T(| tN¹ Ö$ g  Ô &quot; ÒÐéÐ | f$° f
+Hy ì`  ¸Hy ì¨NHy ìÆNHnÿü r8Ð/  r4Ð/  r0Ð/  r,Ð/  r(Ð/  r$Ð/  r Ð/ Hy íNOï , rÐ/  rÐ/  rÐ/  rÐ/  rÐ/  P/  X/ /Hy í*N r&lt;Ð/  r&gt;Ð/ Hy íFN`Hy íhNLîÿìN^NuNVÿðHç 0EîÿðGîÿðHy íxN¹ T/N¹ Hy íN¹ TOï  -fpÿ`Z 0m&amp; 9n /N¹ Ä°X$ p°n´¹ ïot  `.t` /N¹ 4X/ /N¹ ÓVPJf `R´¹ ïoØp LîÿäN^NuNVÿð/Hy íN¹ THnÿðN¹ Hy íN¹ THnÿðN¹ Ä°$ $.ÿìN^NuNVÿð/Hy íN¹ THnÿðN¹ Hy í´N¹ THnÿðN¹ Ä°$ $.ÿìN^NuNVÿðHç0&lt;$| T&amp;| Ö(| ï*| ½jHy í¶NXHy í¸NHnÿðN¹ P.ÿðHHÀrx°b ðAù r°SÉÿüf ÞÒ0;Nû È l : Xj ¦  ºÈ l : Xj ¦  ºF/BCEHRSTUXbcehrstux N$ Jg ÿ~p°g ÿv/N¹ ½2` ÿhN$ g ÿb/N¹ ¼:` ÿTN$ g ÿN/N¹ ½N` ÿ@N$ Jg ÿ8´n ÿ2a þ&amp; //N¹ ¹àP` ÿN$ g ÿ/N¹ » ` ÿN$ pÿ°f0ü  ^Ì/Hx N¹ ¹\Hx Hx NHx Hx NOï ` þÎJg þÈ´n þÂ//N¹ ¹\P` þ²N$ pÿ°f/Hx NPB9 ^Ì` þJg þ´n þ//NP` þ|N$ Jg þr´n þla þ/ /N¹ ºP` þXHy íÄNHy íÆNHy íÔNHy íàNHy íðNHy íþNHy îNHy î,NHy îBNHy îRNOï (Hy î\` ýöHy îxN`
+Hy î` ýâLî&lt;ÿØN^NuNVÿàHç0&lt;GîÿôIîÿüKîÿàHy î¢N¹ THy îºN¹ TPp(t`  ®p°l*tHy îÜN¹ THnÿàN¹ P Xg   xg   &quot; ÒÐéÐ | f&amp;-p ÿøB &quot; ÒÐéÐ | f&quot;$p &amp;.ÿø`JfRR¶bô .ÿø-@ÿðHnÿôHnÿðHnÿø/N¹ 4X/ HnÿüHy îèN¹ tOï RR °¹ ïo ÿJp°l$Hy îþN¹ THnÿàN¹ P Xg&gt; xg8Hy _¡Hy ï
+N¹ tB$| S¸$`RXJfø&amp;HnÿôHy ï4N¹ tLî&lt;ÿÈN^NuNVÿüHç0&lt;&amp;n Iîÿÿ*| ¿v$Kt`zHnÿÿHx N¹ ¿JP 
+gb gX f
+p°lSSHnÿÿHx NP g f|  ÿþHnÿþHx NHnÿÿHx NOï   m ~nÔR`tv Jf 
+fHnÿÿHx NBLî&lt;ÿäN^Nu/
+$o `/
+RHx N¹ ¿PJfì$_NuNV  Hy &quot; Hn /. N¹ Hy &quot; a ÿÀN^Nuü  ^ÌHx N¹ ¼XNuNVÿüHç88$. &amp;. (. Gîÿü(| S¨$y X0`P¸ª fH´ª fB¶ª f&lt; * °c * `
+pÿÐª R&amp;&quot;9 ò N¹ Ï&amp;HnÿüHy ï^a ÿTP$R 
+f¬LîÿäN^NuNVÿü/$. ´¹ ïn çÐ ðL` -BÿüHnÿüHy &quot;THy ïnN¹ | &lt; &quot;T$.ÿøN^NuNV  /. Hn /. N¹ N^NuNVÿÄHç?&lt;$n |  ÿÿIîÿæ*J~z
+x B¬ B n HHÀr(r2°b Ð0;Nû  f | ¢üüüN ¶ ¶ ¶ ¶ ¶ ¶ ¶ ¶ ¶ ¶üüüüüüüüVüüüüüÐrüü:ü Þ ê Ì8^lüü$üLP LR® !n  (~` ÿfSo
+-l  ` ÿXQ LJ¨ f ` lR® ` ÿ@R®  n X®  P.` ÿ,Hn Hn N¹ èP. ` ÿR®  n X® $P` ÿR® BR` þøR®  n X® &amp;P n  *f n X®  P&amp;R® `Hn Hn N¹ èP&amp; Øt`ÛR´oø` þªR®  n X®  P ` þR®  n  -fp0`p @ÿÿR® ` þvR® Hn Hn N¹ èP&amp; Eõ8 S` þVR® ` þNR®  n HHÀrL°AgrI°Ag,ri°AgBrB°Ag^`  Ô/HnÿÄ n X®  P/N¹ Í`  ´/HnÿÄ n X®  P/N¹ Í`  /HnÿÄ n X®  P0  ÿÿ/ N¹ Í`t/HnÿÄ n X®  P   ÿ/ N¹ Í`RHx 
+HnÿÄ n X®  P/N¹ Ï:`6Hx 
+HnÿÄ n X®  PHHÀ/ `Hx 
+HnÿÄ n X®  P/N¹ ÍOï R®  n  *f n X®  P&amp;`Hn Hn N¹ èP&amp; AîÿÄ,JfüFØ¶m@GîÿÄ -f. 0ÿÿfÓ¼ 0St`îÿÿRHHÀ°lðt`ÛR´oø` üÐt`ü *R´oö` ü¾R® Hn Hn N¹ èP&amp; t`ü  R´oöØ` üü 
+R*JR® ` üR® Hn Hn N¹ èP&amp; p°n üfp$°m ü^*` üXR®  n X® &amp;Pt Hn Hn N¹ èP&amp; `ÛRRJg´mò`ü  R R°mò` üR®  n R® ` n R® ÐR n ´fìR® ` ûæR® ` ûÞLî&lt;üÿN^NuHç 8(o &quot;o $T&amp;Qt  *f$R [$&quot;`&amp; åÐÐHHÁÐ   0$ R 0m 9oÚ( LßNuR9 _¨Hçÿþ/N¹ .@LßÿS9 _¨NsR9 _¨Hçÿþ/N¹ .@LßÿS9 _¨NsNsN@Nu0/ á@ | 3À S¬@ÁAøÿ@FÁNuNVÿôHç8&lt; n *h B|øÿ3ü  S¬ y _!n   r+°cNù ®Ð0;Nû ² Ò X^4
+d\*^Ú&amp;l|²	à	Jøf.PÀZ ú0ª
+¤0\Ö
+Ê 	àÊ¤$-  å | e¨J° fp+@ Nù ® |  y UxX¹ Ux |øÿNù ®$m `  , å | e¨J° g   |  y UxX¹ Ux |øÿXJf ÿÒNù ®$-  å | e¨ 0 rÿ²f  $y _J­ gJ - %@ -@ÿü @!m   nÿüB¨  nÿüp!@  nÿü!B  nÿü!j  /.ÿüN¹ ¶ÞXp+@  å | e¨!ª  5| @  y _#Ð _ y _!| _ Nù ® å | e¨J° f årÿ | e¨! Nù ®p+@ Nù ®$m `  å | e¨ÑÀ(Hpÿ°f y _(¨ XJfÜJf, y _1| @  y _#Ð _ y _!| _ Nù ®Jf*+R ` m  årÿ | e¨! X­ µí dâNù ® y _1| @  y _#Ð _ y _!| _ Nù ®$-  å | e¨J° gNù ® årÿ | e¨! Nù ®$m `&quot; å | e¨J° f årÿ | e¨! XJfÚNù ®$- f$y _`( &quot; ÒÐéÐ | eüÑÀ$HJj g j  Nù ® j   R!j   j  Nù ® - &quot; ÒÐéÐ | eüÑÀ$HJj fNù ®jÿþ gNù ® | $¹ Y,#Ê Y,|øÿNù ® - &quot; ÐÐç | U@ÑÀ-Hÿô&amp;P g0 nÿô  nÿôR¨  (  nÿô°¨ o   nÿô (  nÿô!@ `vJ­ gp$y _5|   .ÿôX/ N¹ ·bXJ­ gN%m  -j ÿü nÿü!m   nÿüB¨  nÿüp!@  nÿü!m   nÿü!j  /.ÿüN¹ ¶ÞXp+@ +K Nù ®&amp;m  - &quot; ÐÐç | U@ÑÀ-HÿôR¨  nÿô$h  
+g  j j (h B)K  nÿô!R g .ÿôX R!@ jÿý f   | $¹ Y,#Ê Y,|øÿ-j ÿüfNù ®B¬ /.ÿüN¹ ·&lt;XBª Nù ® nÿô&amp; nÿô  nÿôS¨ Nù ® - ë | SüÑÀ&amp;HR« J« f&#x27;y _ p&#x27;@ Nù ® + °¹ _f
+R« Nù ®R« J­ g  òp°« f  r k $H (  y _°¨ o  ZJ« f&#x27;j   y _%h  Jj f  &amp; R!j   j   | $¹ Y,#Ê Y,|øÿ`0* @ ªg
+/
+N¹ ·¨X$y _5|  /N¹ ·bXJ­ fNù ®%m  -j ÿü nÿü!m   nÿüB¨  nÿüp!@  nÿü!m   nÿü!j  /.ÿüN¹ ¶ÞXp+@ Nù ®p+@ Nù ® - ë | SüÑÀ&amp;H + °¹ _gNù ®S« gNù ®p°« f  `J« g  X y _ + !@  y _ P°¨ o  6$y _ y _#Ð _ y _!| _  | $¹ Y,#Ê Y,|øÿB« $S 
+g  d&amp;g R!K jÿ÷ f   | $¹ Y,#Ê Y,|øÿ&#x27;J p&#x27;@ -j ÿüfNù ® j (h BB¬ /.ÿüN¹ ·&lt;XBª Nù ®B« Nù ® - ë | SüÑÀ&amp;HJ« fNù ® k +h  Nù ® - ë | SüÑÀ&amp;HJ« f&#x27;m  Nù ®p+@ Nù ®(- f
+ y _(( $- f
+ y _$(  &quot; ÒÐéÐ | eüÑÀ$H`. y _ ( °gJj f R!j   j   j  Rp2ÕÀ´oÎNù ®(- f
+ y _(( $- f
+ y _$(  &quot; ÒÐéÐ | eüÑÀ$H`  .Jj g   jÿï f   | $¹ Y,#Ê Y,|øÿRp2ÕÀ´o ÿÐNù ®N¹ ´+@ Nù ®-m ÿü nÿü(  f/.ÿüN¹ ·&lt;X nÿü ¹ _¤#îÿü _¤Nù ®-m ÿüfN¹ ´-@ÿüfNù ®+nÿü  nÿü!m   nÿü!m   nÿüp!@  y _ (  nÿü!@  nÿü - !@ å | e¨J° fJ­ f nÿü ( årÿ | e¨! /.ÿüN¹ ¶ÞXNù ®$- f$y _$* %m  `&quot; &quot; ÒÐéÐ | eüÑÀ$H * r%@ -j ÿüJj f R!j   j   j   nÿü!m   nÿüB¨  nÿüB¨  nÿü!B  nÿü!B /.ÿüN¹ ¶ÞXNù ®-m ÿü nÿü (  y _°¨ gp+@ Nù ® nÿüJ( fp°fp+@ Nù ®/.ÿüN¹ ·&lt;Xp)°gNù ® nÿü!m   nÿü!m   y _ (  nÿü!@  nÿü ( å | e¨J° fJ­ f nÿü ( årÿ | e¨! /.ÿüN¹ ¶ÞXNù ® | $9 S¨|øÿ  m +@  m  Nù ®-m ÿü nÿü(  f  &quot; |  nÿü ( ¹ S¨+@ |øÿNù ®B­ Nù ® | +y S¤ |øÿNù ® | #í  S¤|øÿNù ®J­ f y _ (  m !@ `
+ m !m   m !m   y _ (  m !@  - &quot; åÐå | VÑÀ-HÿøJf  v nÿøJ¨ g  j nÿø ( å | e¨ 0 rÿ²f nÿø ( å | e¨B° `  8 nÿø ( å | e¨J° g    |  nÿø (  y UxX¹ Ux |øÿ nÿø$h  
+g   j (h BJ¬ g y _ ( °¬ f  b)m   nÿøR¨  nÿø!R g .ÿøX R!@ jÿß f   | $¹ Y,#Ê Y,|øÿ-j ÿüg&amp;B¬ /.ÿüN¹ ·&lt;XBª `/- /.ÿøN¹ ®P$- J­ g  $y _ å | e¨!ª  5| @  y _#Ð _ y _!| _ J­  fNù ®%m $ -j ÿü nÿü!m    nÿüB¨  nÿüp!@  nÿü!B  nÿü!j  /.ÿüN¹ ¶ÞXp+@ Nù ®JfNù ® årÿ | e¨! Nù ® - &quot; åÐå | VÑÀ-Hÿø/- /.ÿøN¹ ®ÊP(@ f|J­ g  ¼$y _5|    .ÿøX/ N¹ ·bXJ­  g  %m $ -j ÿü nÿü!m    nÿüB¨  nÿüp!@  nÿü!m   nÿü!j  /.ÿüN¹ ¶ÞXp+@ `F nÿøR¨  nÿøJ¨ g4 nÿøJf nÿø ( årÿ | e¨! ` nÿø ( å | e¨B° +L Nù ® - &quot; éÐå | TpÑÀ&amp;H(+ ¸« f  J­ fNù ®$y _5|   rÐ/ N¹ ·bXJ­ fNù ®%m  -j ÿü nÿü!m   nÿüB¨  nÿüp!@  nÿü!m   nÿü!j  /.ÿüN¹ ¶ÞXNù ®B­ &amp;+ J« gNù ¡2$k  
+fNù ¡2&#x27;R g rÐ R!@ jÿ f   | $¹ Y,#Ê Y,|øÿ-j ÿüg/.ÿüN¹ ·&lt;XBª  j (h BB¬ p¶b@ Ð0;Nû  F 
+  4 &amp; m  l `. m 0 l 0`  m   l  `  m &quot;l `ØSlúR« ,J«  g  X +  å | e¨ 0 rÿ²f +  å | e¨B° `  . +  å | e¨J° g   |  y UxX¹ Ux «  |øÿJ« (fNù ® + (å | e¨B° Nù ®R« R«  + °fB« $+ p¶bH Ð0;Nû  ` 
+  &lt; * m  SÑÂ`H m 0&quot;ÒÒ A0`6 m  &quot;åÒ A `$ /  m / &quot;N¹ ÏÐ&quot;@ _&quot;`ØSlúR« , + °« 0o&#x27;k  0¸« f  nJ« (g + (årÿ | e¨! J« g  d + å | e¨ 0 rÿ²f + `  : + å | e¨J° g  2 |  y UxX¹ Ux « |øÿ`J« (g + (å | e¨B° p°« gNù ®J« $g + $årÿ | e¨! J«  fNù ® +  å | e¨ 0 rÿ²f +  å | e¨B° Nù ® +  å | e¨J° fNù ® |  y UxX¹ Ux «  |øÿNù ® - &quot; éÐå | TpÑÀ&amp;HJ« f  J­ fNù ®$y _5|   rÐ/ N¹ ·bXJ­ fNù ®%m  -j ÿü nÿü!m   nÿüB¨  nÿüp!@  nÿü!m   nÿü!j  /.ÿüN¹ ¶ÞXNù ®B­ $+ S« « JlÔ«  + &amp; r°bFÐ0;Nû  \ 
+  &lt; * SÑÂ m `D ÐÐ @0 m 0`2 åÐ @  m  `  /  &quot;N¹ ÏÐ @&quot;m &quot;`ØSlúJ« f  nJ«  g +  årÿ | e¨! J« $g  d + $å | e¨ 0 rÿ²f + $`  : + $å | e¨J° g  2 |  y UxX¹ Ux « $|øÿ`J«  g +  å | e¨B°  + S°« gNù §8$k  
+fNù ¦²&#x27;R g rÐ R!@ jÿ f   | $¹ Y,#Ê Y,|øÿ-j ÿüg/.ÿüN¹ ·&lt;XBª R« R«  + °« fB« $+  j (h BB¬ p¶bH Ð0;Nû  ` 
+  &lt; * l  SÑÂ`H l 0&quot;ÒÒ A0`6 l  &quot;åÒ A `$ /  l / &quot;N¹ ÏÐ&quot;@ _&quot;`ØSlúR« , + °« f  nJ« (g + (årÿ | e¨! J« g  d + å | e¨ 0 rÿ²f + `  : + å | e¨J° g  2 |  y UxX¹ Ux « |øÿ`J« (g + (å | e¨B° p°« gNù ®J«  fNù ® +  å | e¨ 0 rÿ²f +  å | e¨B° Nù ® +  å | e¨J° fNù ® |  y UxX¹ Ux «  |øÿNù ®J« g + årÿ | e¨! J« (fNù ® + (å | e¨ 0 rÿ²f + (å | e¨B° Nù ® + (å | e¨J° fNù ® |  y UxX¹ Ux « (|øÿNù ®J« (fNù ® + (å | e¨ 0 rÿ²f + (å | e¨B° Nù ® + (å | e¨J° fNù ® |  y UxX¹ Ux « (|øÿNù ® - &quot; éÐå | TpÑÀ&amp;H&amp;­ &#x27;m  &#x27;m   + S&#x27;@ B« Nù ® - &quot; éÐå | TpÑÀ&amp;H - r°cNù ®Ð0;Nû   B º &#x27;m   J« g +  å | e¨B° Nù ® +  årÿ | e¨! Nù ®&#x27;m  ( + °« g + (å | e¨B° Nù ® + (årÿ | e¨! Nù ®&#x27;m  $J« f + $å | e¨B° Nù ® + $årÿ | e¨! Nù ®&#x27;m   + °« f + å | e¨B° Nù ® + årÿ | e¨! Nù ® - &quot; åÐå | VÑÀ-Hÿø!m   nÿøJf nÿø ( årÿ | e¨! Nù ® nÿø ( å | e¨B° Nù ® - &quot; éÐå | TpÑÀ&amp;H + S&#x27;@ $+ B« J« $g  X + $å | e¨ 0 rÿ²f + $å | e¨B° `  . + $å | e¨J° g   |  y UxX¹ Ux « $|øÿ(+ ´gNù ®J« (g  X + (å | e¨ 0 rÿ²f + (å | e¨B° `  . + (å | e¨J° g   |  y UxX¹ Ux « (|øÿ&amp;+ Nù «À&#x27;R g rÐ R!@ jÿ f   | $¹ Y,#Ê Y,|øÿ-j ÿüg/.ÿüN¹ ·&lt;XBª  j (h BB¬ R« R«  + °fB« $+ p¶bH Ð0;Nû  ` 
+  &lt; * l  SÑÂ`H l 0&quot;ÒÒ A0`6 l  &quot;åÒ A `$ /  l / &quot;N¹ ÏÐ&quot;@ _&quot;`ØSlúR« , + °« 0o&#x27;k  0p°« f  `J«  g  X +  å | e¨ 0 rÿ²f +  å | e¨B° `  . +  å | e¨J° g   |  y UxX¹ Ux «  |øÿ$k  
+gNù ªfNù ® - &quot; ÒÐéÐ | eüÑÀ$HJj f R!j   j  *j &amp;Ûê *ü   B%M +j &quot; &gt;;|   &lt;Bª Bª Bj  | $¹ Y,#Ê Y,|øÿ` N$- f
+p	+@ ` &gt; &quot; ÒÐéÐ | eüÑÀ$H0*       g
+p
++@ ` %m  J­ g%m  &amp;%m  *%m  &quot;Bª Bª Bª ` Þ$- f
+ y _$(  &quot; ÒÐéÐ | f*+p  ` ²$- f
+ y _$(  &quot; ÒÐéÐ | f*!­  ` $y e 
+g#Ò e+j  ` lB­ ` d$- f$y _ y _$( ` &quot; ÒÐéÐ | eüÑÀ$H-j ÿüg nÿü(  f/.ÿüN¹ ·&lt;XBª Jj g
+0* @ ªg j  g R!j  jÿU  j  ´¹ ïn é | ïÈ%p  `  Êp~%@ $¹ e#Ê e`  ´ y _ P (  y _°¨ f  B­ $y _%j   y _#Ð _ y _!| _  | $¹ Y,#Ê Y,|øÿ`Xp°­ np°­ np~+@ $- f$y _` &quot; ÒÐéÐ | eüÑÀ$H/- /
+N¹ ¸ªP`/-  m N+@ N¹ ²~Lî&lt;ÿØN^Nu/
+&quot;o  o $Q 
+g&quot;( `&quot;J$Q 
+g²ª lò&quot; $_Nu&quot;/  o &quot;P 	g$Jg²© f  	Nu I&quot;P²© f  	NuJfìp NuHç 8(| _&quot;| e(¼ eü T!| _  Tp!@  TB¨  TB TBh B¹ Y,t$| f.&amp;| ïÌ`:5|  %B Bª %k  Bª Bª %k  &amp;%k  *%S &quot;Bª .p×ÀRp2ÕÀ´¹ ïo¾J¹ ï g 9 ï&quot; ÒÐéÐ | f.ÑÀ&quot;`Bt$Q`2 
+r2Ð$5|   9 ïÐ%@ Bª p~%@ Bª Bª Rp2ÕÀ´¹ ï oÆJ¹ ï gBB9 _¨B9 _¡By S¬LßNur | T`$B¨ BB¨ B¨ B¨ B¨ B¨ B¨ Rp ÑÀ²¹ ñdoÔNur | V¤`BB¨ B¨ B¨ B¨ RpÑÀ²¹ ñøoàNuHç  r&quot;| ñÚ$| UX`&gt;$ R gt` Ð©  R P´© mîBBª Bª Bª Bª Bª RpÓÀpÕÀ²¹ ñÊoºLßNur | ñ&quot;| T¤`F&quot;#h  #h   ) S#@ B© B©  B© B© (B© $B© B© B© ,B© 0RpÑÀp4ÓÀ²¹ ñro²Nu/t | e¬`pÿ RX´¹ ðoð &lt; S¸#À Up#À Uxt  | S¸&quot;9 ð¢`BR´mø$Nu/ | X8#È _¤t` rÐ RpÑÀ´¹ òmêBB¹ X0B¹ S¨B9 RB¹ S¤B¹ RB¹ Sø$Nu@À |  y UxX¹ Ux ¯ FÀNuHç  $/ $o 9 _¨°9 _¡o
+ù _¨ _¡ | Jg y UxX¹ Ux p 09 S¬2* &lt;   °f    y _!J 3ü  S¬|øÿN¹ ²~` 
+LßNu /  o / /a ÿzPNuHç0&lt;J9 RgN¹ ´ìB9 R | Nù ³p|øÿ y UpX¹ Up$ å | e¨ÑÀ$Hpÿ°gJfB`  &amp;pÿ$ &quot; ÒÐéÐ | eüÑÀ&amp;H k $h B*k  
+g p°­ f´­ fBª /
+N¹ ·&lt;XB« p°f,%B (j ` å | e¨ÑÀ$Hpÿ°gJgpÿ$XJfÞkÿ¿ f   | &amp;¹ Y,#Ë Y,|øÿ |  9 Ux°¹ UpgNù ²  &lt; S¸#À Up#À Ux|øÿ | `  4#Ó Y,|øÿ$| _`$R R ( °« oò&amp;&#x27;J  R!K $ | &amp;y Y, f ÿÄ 9 Ux°¹ UpgNù ³p y _ h 0( &lt;@ 3À S¬ y _ ( Lß&lt;Nu y _¤ g
+#Ð _¤B(  NuHç 8&amp;| Sø(| _&quot;| S¨J9 ^Ìf  RR¹ R 9 R°¹ ò mB¹ RR¹ S¤ TJ¨ g TS¨ f&amp; S (  S!@ $y X0`$R 
+gJ* gô 
+g( * °f `B* $R 
+g * °gîü  Rp`Jgü  Rp`p Lß NuHç &lt;(| Sø*| Y,Nù ¶r$y X0 |  y X0#Ð X0g y X0!| X0 |øÿ * r°b &lt;Ð0;Nû  B h          |  y UxX¹ Ux ª |øÿJª g %j  /
+N¹ ¶ÞX`  ð * &quot; ÒÐéÐ | eüÑÀ&amp;HB« kÿû `  Ä * årÿ | e¨!  * &quot; ÒÐéÐ | eüÑÀ&amp;HB« kÿ¿ `   * &quot; ÒÐéÐ | eüÑÀ&amp;Hp°ª fP k $h Bp%@ $*  ë | SüÑÀ$HJª g*·Òf&amp; RJg R P$( ´ª o$* //* N¹ ¸ªPB«  k  g S!k  kÿU f&amp;*J¹ X0g y X0J( fNù µJg  H TJh f  &lt; T (  T P°¨ f  * T (  T P!@  T  T h   |  T *|øÿBLß&lt;NuHç08(o |  &amp;| X0 | &amp;9 S¨`J* g$* ´¬ b&amp;J$S 
+fæ 9 S¨Ñ¬ ()K &amp; 
+g%L |øÿLßNu/
+$o  | B*  j  g R!j  |øÿ$_NuHç 8&amp;o &quot;| _(Q&quot;,  Q&quot; Q!| _ `&amp;J$S 
+g²ª lò&amp;)K (g%L Lß Nu/
+$o  j J¨ fJgf R ( °ª lZ`NJf j  ( °ª oF/
+N¹ ¸f`: j  ( °ª n R ( °ª l&quot; j  ( °ª o
+/
+N¹ ¸f`/
+N¹ ¸&amp;X$_NuHç 0&quot;o &quot;) &amp;Q Q!i   i  `&amp;J$S 
+g²ª lò&amp;#K &quot;g%I Lß NuHç 0&quot;o  ) &amp;i  Q!i   i  `&amp;J$k Jª g°ª mî&#x27;I &quot;#J $Lß NuHç 8$/ $o &amp;| Y,(| _%B  T ( °ª f  2 R ( °ª mNù ¹V T( T!| _  | $&amp;|øÿ`  TJj f  : j  ( °ª n R ( °ª l  0 R!j   j   | $&amp;|øÿ`0* @ ªg/
+a þVXLßNuNVÿôp-@ÿô-n ÿø-n ÿüHnÿôN@XN^Nu &lt; ïNuNVÿðB®ÿðHnÿðN@XN^NuNVÿà/
+Eîÿàp-@ÿà%n  Bª HnÿàN@X * $_N^NuNVÿèp-@ÿèHnÿèN@X .ÿüN^NuNVÿðp-@ÿð-n ÿø-n ÿüHnÿðN@XN^NuHç0 $/ &amp;/ Jf&quot;y _` &quot; ÒÐéÐ | eüÑÀ&quot;HJ© f#B #B Lß NuNVÿÌHç  $. EîÿìJfp `  *p-@ÿì%n  %B Bª AîÿÎ%H HnÿìN@X * LîÿÄN^NuNVÿà/
+Eîÿàp	-@ÿà%n  %n  Bª p%@ HnÿàN@X * $_N^NuNVÿà/
+Eîÿàp-@ÿà%n  %n  Bª p%@ HnÿàN@X * $_N^NuNVÿðp-@ÿð-n ÿøHnÿðN@XN^NuNVÿà/
+Eîÿàp-@ÿà%n  %n  %n  %n  %n  Bª HnÿàN@X * $_N^NuNVÿðp-@ÿðHnÿðN@X .ÿøN^NuNVÿàp-@ÿà-n ÿè-n ÿìHnÿàN@XN^NuNVÿèp
+-@ÿè-n ÿüg  
+HnÿèN@XN^NuNVÿà/
+Eîÿàp
+-@ÿà%n  Bª Bª HnÿàN@X * $_N^NuNVÿìp-@ÿì-n ÿôHnÿìN@XN^NuNVÿØ/
+EîÿØp-@ÿØ%n  %n  Bª HnÿØN@X * $_N^NuNVÿðp-@ÿð-n ÿøHnÿðN@XN^NuNVÿØ/
+EîÿØp-@ÿØ%n  %n  %n  %n  Bª HnÿØN@X$_N^NuNVÿì/
+Eîÿìp-@ÿì%n  Bª HnÿìN@X * $_N^Nu o /( a ÿÊXNuNVÿè/
+Eîÿèp-@ÿè%n  Bª HnÿèN@X * $_N^NuNVÿè/
+Eîÿèp-@ÿè%n  %n  %n  %n  HnÿèN@X * $_N^NuNVÿðp-@ÿð-n ÿøHnÿðN@XN^NuNVÿðp-@ÿð-n ÿøHnÿðN@XN^NuNVÿôp-@ÿô-n ÿø-n ÿüHnÿôN@XN^NuNVÿàp-@ÿà-n ÿèHnÿàN@XN^NuNVÿð/
+Eîÿðp+-@ÿð%n  %n  HnÿðN@X * $_N^NuNVÿì/
+Eîÿìp-@ÿì%n  Bª Bª HnÿìN@X * $_N^NuNVÿðp-@ÿðp-@ÿôHnÿðN@X .ÿôN^NuNVÿà/
+Eîÿàp-@ÿà%n  p%@ Bª HnÿàN@X * $_N^NuNVÿà/
+Eîÿàp&quot;-@ÿà%n  Bª HnÿàN@X * $_N^NuNVÿà/
+Eîÿàp#-@ÿà%n  %n  Bª HnÿàN@X * $_N^NuNVÿàp$-@ÿà-n ÿèHnÿàN@X .ÿüN^NuNVÿàp%-@ÿà-n ÿè-n ÿüHnÿàN@XN^NuNVÿØp-@ÿØ-n ÿä-n ÿàHnÿØN@XN^NuNVÿä/
+Eîÿäp-@ÿä%n  %n  %n  HnÿäN@X$_N^NuNVÿà/
+Eîÿàp	-@ÿà%n  %n  Bª p%@ HnÿàN@X$_N^NuNVÿôp-@ÿô-n ÿøHnÿôN@X .ÿüN^NuNVÿà/
+Eîÿàp-@ÿà%n  %n  Bª p%@ HnÿàN@X$_N^Nu / &quot; ÐÐå | ñÒ 0 NuNVÿà/
+Eîÿàp
+-@ÿà%n  p%@ Bª HnÿàN@X$_N^NuNVÿàp-@ÿà-n ÿìHnÿàN@XN^NuNVÿØ/
+EîÿØp-@ÿØ%n  %n  Bª p%@ Bª  HnÿØN@X * $_N^NuNVÿØ/
+EîÿØp-@ÿØ%n  %n  %n  %n  p%@ Bª  HnÿØN@X$_N^NuNVÿðp-@ÿð-n ÿüHnÿðN@X .ÿøN^NuNVÿøp -@ÿøHnÿøN@X .ÿüN^NuNVÿøp!-@ÿø-n ÿüHnÿøN@XN^NuNVÿèp&amp;-@ÿè-n ÿüHnÿèN@X .ÿôN^Nup NuNVÿÀ/
+Eîÿàp-@ÿà%n  p%@ %n  Bª AîÿÂ%H HnÿàN@X n  ª  * $_N^NuNVÿä/
+Eîÿäp*-@ÿä%n  %n  %n  %n  HnÿäN@X$_N^NuNVÿÀ/
+Eîÿàp	-@ÿà%n  %n  %n  p%@ p%@ AîÿÂ%H HnÿàN@X * $_N^NuNVÿÀ/
+Eîÿàp-@ÿà%n  %n  %n  p%@ p%@ AîÿÂ%H HnÿàN@X * $_N^NuNu/$/ Jf y _ ( ` &quot; ÒÐéÐ | f 0 $Nu / &quot; éÐå | T 0 Nu / å | e¨ 0 Nu y _ ( NuNVÿÀ/
+Eîÿàp
+-@ÿà%n  p%@ %n  Bª AîÿÂ%H HnÿàN@X * $_N^NuNVÿðp(-@ÿð-n ÿüHnÿðN@XN^NuNVÿ¸/
+EîÿØp-@ÿØ%n  %n  Bª p%@ %n   Bª Aîÿº%H $HnÿØN@X n  ª  * $_N^NuNVÿè/
+Eîÿèp)-@ÿè%n  %n  %n  Bª HnÿèN@X * $_N^NuNVÿ¸/
+EîÿØp-@ÿØ%n  %n  %n  %n  p%@ %n   Bª Aîÿº%H $HnÿØN@X * $_N^NuNVÿðp&#x27;-@ÿð-n ÿüHnÿðN@XN^NuNVÿÌ/
+Eîÿìp-@ÿì%n  %n  Bª AîÿÎ%H HnÿìN@X * $_N^Nu/$/ Jf
+ y _$(  &quot; ÒÐéÐ | f 0 $NuN¹ ±N¹ ±&lt;N¹ ¯ N¹ °PN¹ °|N¹ °ÜN¹ °Hy :Hx  N¹ ÄPNuNup  @ / åÑÀ ¯ Nu o /p r t &quot;@  gø 
+n 	lì +g -ft 0gøe&amp; 	n Ð 0e 	n
+Ð&quot;@åÐ`æJgD$Nuo  Hçÿ Lï  $ãUÄãUÅ°cÁBÃCÉEH¹N¹ ÈxJGf( g  ããJFf
+ãã`2À Fÿg  Â FDGQGm ààfôJfð`^GkââQÏÿúJkÖÕd ââRFFÿm`ZdFED@N¹ È¨N¹ ÈÜãMâ/B $/C (Lß ÿ / &quot;/ ..NuÂ N¹ É
+`Ö(fò¾FfîJjê$&lt;ð B`Â$&lt;ÿà  B`´Hçÿ Lï  $* µãã°cÁBÃCN¹ Èx:,ÜGEÿg  ¨JGg  ¸À Â Hçð L :/ ÀÅÂÅÄÅÆÅB:/ Êï 
+ÖÓ:/ Êï ÖÓ:Êï ÖÓ:/ Êï 
+ÔÑ:Êï ÔÑH@:Êï 
+ÒÑGH@Þü 6HCBAHAÖÑÐ$ FþN¹ ÈÒãâ/B $/C (Lß ÿ / &quot;/ ..Nu*Gg &lt;&lt;ÿN¹ É
+`Ì. gSFããjøRF` ÿ&lt;$&lt;ð `´BB`ªHçø &quot; N¹ Ì`Hçø &quot; N¹ Ëja POLß NuHçø a  ¬N¹ Ì¬`&gt;    g&quot;n/8  /&lt;¿à  Nù Çn/8  /&lt;?à  N¹ ÅN¹ Ç:NuHçø ajN¹ ËÔ XOLß NuLï  aRN¹ Í0N¹ Ì¬/A ..NuLï  a4N¹ Í0`Lï  a$N¹ ÍhazHï  ..Nu o LÐ aNù ËX$&lt;ÿð  &amp; HCÄµ(ãf&lt; Jg,&lt; `&amp;HBêJBÿf4&lt;` &lt; Jg&lt; `À SB&lt; B2NuN¹ Ë¶aHÐ Nu mã ÿà  `B&gt;ÁBÁFÃCa@a  r,  ÇAãKâNuxé¸éºé¹é»,&lt;  ÿ.Ì½(È¹â(Î¿È¹âNuJfF  mF  ÇBJgkãã[ÎÿúZÎ Nu&lt;&lt;÷RNuJkSFããJFnFÿËmJDFââQÎÿúBF   d
+RdââRFFÿl,(&lt;ÿÿø ÆÈ¹$ãeFÿgBFxè»FèºNuBBNu$&lt;ÿà  BNuåï åï äï /o  /o  /_ Þü NuHçÿ Lï  $ÁBÃC* µBa`:G8&lt; a  ø,8&lt; a  îágÇ ãã$&amp;&lt;FÿN¹ ÈÒ` &gt;.  ÿÿHGèOÎDfJfJgRGSGãã  gôNu8&lt;ÿÅ@ÇAaÎÁBÃCÏFg¼DgÂ a¼g&quot;¾Dg.À ããNuaªJk0¾Fg,Jf(Jf$`JkDg@$&lt;ÿà  `JJfJf
+Jj&lt;XO`  ¤¼Gf´l&lt;$ &amp;HBéNFHBãÿà  bJn  $&lt;ÿà JjTB`BBXO`  tBÖÕ´\Ìÿø	Ç[ÌÿîjÖÕ	JD]ÌÿàNu/_ a/o  /o  /_ NuHçÿ Lï  $*xÿa ÿ8SGGo
+ãã&lt;SFaF N¹ È¨N¹ ÈÜãâ/B $/C (Lß ÿ / &quot;/ ..Nu ALï /W PafJk±É`³ÈegDü  NuDü NuJlÿÿÿDJlÿÿÿD°Nu&quot;/ a o HB4HÐ  _PNÐ&amp;HCãáBBf&lt; Jg*&lt; `$ ÿf4&lt;` B&lt; Jg&lt; `&lt; SB&lt; B âàBNu o LÐ 6HB o Nuaìa  _PNÐ8 m   ã`$Jg
+ PDààfö gkSDãjúD a&quot;à&quot; ãKâNuåï åï äï /o  ..NuJkSDãJDnDÿèm&quot;DRè¨BD   dâRDD ÿlãUÀÀNuBNu &lt;   ÿNuHçø &quot; a(N¹ ËÔ XOLß NuHçø &quot; N¹ Ëja XOLß NuBBvJjDÃ BNu la(BJfJkJCjDNu&quot;&lt;   NuN¹ Ë¶aNù ËXx JBk&amp;´Dm
+JfDDÃ@`òå¸å¹xå¤S$ Äf.È¹`$DB´Dm&quot; BD`ôxå¤SFÂÈ¹ä¼ä¹ BNuJBjRBa¤ââÓÑNu&quot;/ N¹ Ëjaâa ÿ\/A .Nu&quot;/ N¹ ËjaÊ`JBk ÿpNu&quot;/ N¹ ËjaìN¹ ËÔ/A .NuNù ÙÚ /  o &quot;/ Hç0 &lt;     e   $cr
+  ÿÿb°e.ÁH@  0    H@`êv tãã¶eR QÊÿò 0`Æ  0   9c^ ÀfòLß  S¯ Nu&quot;ÁA  ÿnÿÿ mÁiHÀNu/BJlDFJlDFaJgD$Nu&quot;ÁA   d0Áir 2 B@H@ÁANu/$&quot; B@H@ÂH@HA2 HAÂ0BAHA$NuHç0 &amp;&quot; H@B@BAHAtÐÓ²eR QÊÿòLß Nu&quot;ÁA   d
+ÁiB@H@Nua Nu&quot;ÁA  ÿnÿÿ m
+ÁiH@HÀNu/BJlDJlDRa ÿR JgD$Nu&quot;Hç  $ ÀÁBBHBgÄÁHBBBÐ$BAHAgÄÁHBBBÐ$NuNù ÙÚHç&gt; $/ ,/   o Jmx `xÿÿÿp°n  È*    ÿÿ    p5°l
+x  ¨ `@p!°n$ r!vá«(ÈJ¨ fS Àfp `p` Svá«(( ÈS À¨ p5°nBB¨ `4p °n r &quot;à©!A B` ( ì¨!@ p &quot;á©¨  ì¨ JgJf (    gR¨ fR ¨ fp&quot;#À e  ÿÿÿ   d &lt;   `p &quot;g&quot;&lt;   `r Lß |NuNVÿøHç0&lt;Gîÿø(| e *| ó&amp;Eî  . $   
+gp!(`n gp&quot;(&amp;¼ð  &#x27;|     `\ g(X J$(ÿüP J&amp;¨ÿø&#x27;hÿü &amp;//HnÿøN¹ Ï@`. 
+gp&quot;(&amp;¼ð  &#x27;|     ` f 	f&amp;&#x27;m  &quot;+  Lî&lt;ÿàN^NuNVÿøHç80$n GîÿøCîÿø IX-n ÿø-n ÿüB ð  ð  f(  ÿÿg/.ÿü/.ÿø/&lt; Ö@ N¹ ÐpOï `  Ø ÿÿÿg  Â ÿÿÿð  fJf/&lt; Ö  N¹ ÐpX`  ¤ ð  râ¨  þ$ ð  fp  ÿÿgd    ( ±R  ÿÿg&amp;pá«t`RÖJnø å¨&amp;`&amp;t`RÖJnø å¨  rÐtp &quot;à© å¨ ÿÿ ?à  &quot;.ÿü .ÿøLîÿäN^Nu / &quot;/ /_ N¹ Ë
+ _Nu / &quot;/ /_ N¹ Éb//@ /A Nu / &quot;/ /_ N¹ Æ//@ /A Nu / &quot;/ /_ N¹ Å//@ /A Nu / &quot;/ N¹ Ç: _PNÐ N¹ Ç W./ NÐ o  R @¯ NuNV  Hç  Eî Hy Òö/
+/. Hn N¹ Úò$  n B LîÿøN^Nu o / °g
+Jføp `   Nu o &quot;o 02	³    f&gt;0   g
+°f@J g&lt;/4&lt;ÿ  °fJ gÀBg
+H@J gÀBfèp $`  $YY°f
+J föp `  !HHÀNuNVÿÔHç?&lt;.. &amp;n n ÿó-n ÿÔ-n ÿØ .ÿÔð  ð  fZ .ÿÔ ÿÿfJ®ÿØg | ó®&quot;KØfüp-@ÿô`(B®ÿô .ÿÔ  gü -R®ÿô | ó¢&quot;KØfüpÑ®ÿôS®ÿô .ÿô` p-@ÿü.ÿóH@ g
+B®ÿü. ÿóB®ÿôB.ÿòB.ÿñB.ÿðJl~. gÿóg. Gÿóf| ÿñJfR`R. fÿóf| ÿò-Gÿìp°lp-@ÿì/. /. B§B§N¹ Òblü -R®ÿô
+.  -n ÿà-n ÿä .ÿàã®ÿäfB®ÿè| ÿð` HnÿÜ/.ÿä/.ÿàN¹ Ñ$Oï  .ÿÜ&quot; åÐçÐår
+â -@ÿÜB-nÿÜÿèjD®ÿÜRt $| óZ`N .ÿÜ   g6Jg/.ÿä/.ÿà/* /N¹ Ò`/.ÿä/.ÿà/* /N¹ Òx-_ÿà-_ÿä .ÿÜâ-@ÿÜPRJ®ÿÜf¬/.ÿä/.ÿàB§/&lt;?ð  N¹ ÒblS®ÿè/.ÿä/.ÿàB§/&lt;@$  N¹ Ò`2/.ÿä/.ÿàB§/&lt;@$  N¹ Òbm&quot;R®ÿè/.ÿä/.ÿàB§/&lt;@$  N¹ Òx-_ÿà-_ÿäJ.ÿñgpü°®ÿèn¾®ÿèo| ÿò$K-JÿøJ.ÿðgü 0` &lt;tJ.ÿòf-nÿà -nÿä `$.ÿèjt(`&quot;/. /. B§/&lt;AÍÍeN¹ Òx-_ -_ p	p	°oØ| /. /. N¹ ÒÒ* Jgv `ü 0R0åH | ó2 0  °nèJg,/
+/N¹ ÙÚPÕÀ/. /.  N¹ ÒèN¹ Ò´-_ -_ g0x	p°o/. /. B§/&lt;AÍÍeN¹ Ò-_ -_ Rp°n ÿnJ.ÿògTp°®ÿèl(nÿøpÙÀ`ü 0¹ÊeøJ®ÿèlt`ü 0Sjø .ÿèÐ®ÿìr²np®ÿè-@ÿìnp@ÿðHHÀ-@ÿì*Jü .J.ÿðg$`ü 0Sfø` J.ÿòg2J®ÿèl,/.ÿä/.ÿàB§/&lt;@$  N¹ Òx-_ -_ $.ÿè`ü 0Rføt  . ã® fx	`ü 0Sjø`  /. /. B§/&lt;AÍÍeN¹ Ò-_ -_ /. /. N¹ ÒÒ* v `ü 0R0åH | ó2 0  °nè/
+/N¹ ÙÚPÕÀp	°l,Jf/. /.  N¹ ÒèN¹ Ò´-_ -_ Rp°n ÿ\J.ÿñgJ.ÿòg .ÿè®ÿì(MÙîÿì`¼ 0R¹ÊeöBJ.ÿñg¾®ÿìl..ÿì(nÿøÙÇ¹ÍeRµÌd(J`Iõx `ü 0µÌcø$MÕîÿì*J 5mJ&quot; .fSR  9o8¼ 0µËfæRR&amp;M`«ÿÿS·Êfö¼ 1-JÿøJ.ÿòfRü .¼ 0R®ÿèS¼ 0B$LJ.ÿñgJ®ÿüg&quot; 0gúRBU.ÿó* .ÿÿfJ®ÿügB&quot;J.ÿòfbîÿóJ®ÿèmü +`ü -D®ÿè .ÿè$ rc²l rdN¹ Î  0À rdN¹ ÎÒ$  r
+N¹ Î  0À r
+N¹ ÎÒ  0ÀB$
+®ÿø .ÿôÐLî&lt;üÿ¬N^Nu/ o  / jDü -&lt;    ÿÿbr
+°e2ÁH@  0    H@`êr tãã 
+e 
+R QÊÿî 0`À  0Àßfü S¯ $NuNVÿÜHç&gt; (. *. p°np$°lz
+EîÿÿB| p°f $è`Dp°f $æ`2p
+°f r
+N¹ ÎR$ ç ` &quot;N¹ ÎR$ ÀÅ   0  9o^R¸e(` J&quot;n Øfü Lî|ÿÄN^NuNVþ¸Hç?&lt;$n (n *n ~ ` tR. %ÿûg/
+.ÿûHHÀ/ NPR` TB.þ¾B.þ½B.þ¼B.þ»| HHÀr-°Agr0°Agr+°Ag$r °Ag*r#°Ag2`8R.þ¾| R`ÐJ.þ¾f|0R`ÄR.þ½B.þ¼R`¸J.þ½fR.þ¼R`ªR.þ»R`¢ *fX®  n *(ÿüJlDR.þ¾R`*z ` åÐÐHHÁÐ   0* R 0m 9oÚxÿ .fBR *fX®  n ((ÿüR`*x ` åÐÐHHÁÐ   0( R 0m 9oÚBB.þ¿ lfR.þ¿` hfR` LfRAîþÀ&amp;H-Hÿü@ÿûHHÀrx°b pAù Üªr°SÉÿüf ^Ò0;Nû  æ Þ .ð â n n T æEGXcdefginopsux X®  n &amp;hÿü f&amp;| ï K&amp;JfüF` X®  n  (ÿü@þÀB.þÁv` üR/J.þ¿fJgX®  n  (ÿüHÀ/ `X®  n /(ÿüN¹ ÙÚP&amp;  -gJ.þ½fJ.þ¼gJ.þ½gp+`p  RJm ¸l(ºl*|0` t
+`t`tB.þ½B.þ¼J.þ¿fJgX®  n  (ÿü  ÿÿ`X®  n  (ÿü&amp; Jg2J.þ»g,/
+Hx 0NPp°f/
+. xÿûf/&lt;   x`/&lt;   XNP//.ÿü/N¹ ÚFOï Ð®ÿü&amp; . xÿûf ÿR` Am  RJfðGîþÀ` ÿ8/.ÿûHHÀJ.þ»gr`r / R/P®  n /(ÿü/(ÿøN¹ ÓÀOï &amp;  -gJ.þ½fJ.þ¼gJ.þ½gp+`p  Rxÿ`xHx /X®  n /(ÿüN¹ ÚFOï &amp; ` þ¶J.þ¿gX®  n  hÿü `  ÊJgX®  n  hÿü0`  ´X®  n  hÿü `  ¢/
+.ÿûHHÀ/ NPR`  ¸lJm&amp;$oÞJ.þ¾fB 0f&amp; -gJ.þ½fJ.þ¼g/
+HHÀ/ NPRRSR`/
+HHÀ/ NPSnîÞR`/
+HHÀ/ NPRSfìR`/
+HHÀ/ NPSnîRÿûf û Lî&lt;üþN^NuNo Timer Available for GIP timeout. X 
+ X 
+ 
+ &lt; 
+ &lt; 
+ &lt; %1d          ÿ%1d %4u %4X %-8u ÿ%-8X ÿDATBL DBTBL PRTBL ADTBL MPBEG MPEND DGBEG DGEND DABEG DAEND DBBEG DBEND PRBEG PREND ADBEG ADEND FGBEG FGEND CODE_FS DIRRT ú P/R:            ```` ú Destination A:  ```` ú Destination B:  ```` ú Route:          ```` Download card detect NOT ACTIVE, No Timer Available. ÿDownload card detect NOT ACTIVE, No Card Drive Present ÿTIMEOUT %1u ERROR GTIS ÿGTID ÿ%1s%1u ÿWARNING: Too many event message codes for GTI signs %4u %4X %-8u ÿ%-8X ÿú P/R:            ```` ú Destination A:  ```` ú Destination B:  ```` ú Route:          ```` A2 MESSAGE? A5 MESSAGE? A6 MESSAGE? A3 MESSAGE? A1 MESSAGE? %1d          ÿ%1d [H[2J   [H [B L [K DAY0 ÿSUNDAY ÿDAY1 ÿMONDAY ÿDAY2 ÿTUESDAY DAY3 ÿWEDNESDAY DAY4 ÿTHURSDAY ÿDAY5 ÿFRIDAY ÿDAY6 ÿSATURDAY ÿDAY0A SUN DAY1A MON DAY2A TUE DAY3A WED DAY4A THU DAY5A FRI DAY6A SAT MONTH0 ÿJANUARY MONTH1 ÿFEBRUARY ÿMONTH2 ÿMARCH MONTH3 ÿAPRIL MONTH4 ÿMAY MONTH5 ÿJUNE ÿMONTH6 ÿJULY ÿMONTH7 ÿAUGUST ÿMONTH8 ÿSEPTEMBER MONTH9 ÿOCTOBER MONTH10 NOVEMBER ÿMONTH11 DECEMBER ÿMONTH0A JAN MONTH1A FEB MONTH2A MAR MONTH3A APR MONTH4A MAY MONTH5A JUN MONTH6A JUL MONTH7A AUG MONTH8A SEP MONTH9A OCT MONTH10A ÿNOV MONTH11A ÿDEC AM ÿAM ÿAM_L ÿam ÿPM ÿPM ÿPM_L ÿpm ÿ
+** RTXCbug -  ÿ
+RTXCbug&gt;  ÿ
+ T - Tasks
+ ÿM - Mailboxes
+ ÿP - Partitions
+ Q - Queues
+ R - Resources
+ ÿS - Semaphores
+ C - Clock / Timers
+ K - Stack Limits
+ Z - Zero Partition/Queue/Resource Statistics
+ $ - Enter Task Manager Mode
+ ÿ# - Task Registers
+ G - Go to Multitasking Mode
+ ÿH - Help
+ X - Exit RTXCbug
+ 
+Returning from RTXCBug
+ ÿ
+Bad command
+ 
+** Task Snapshot **
+   #   Name  Priority  State
+ ÿ-- More -- ÿ(I3,X1,S8,X2,UI3,X5,N) ÿSUSPENDED  ÿINACTIVE  Semaphore  ÿ(X1,S8,N) (H&#x27;&lt;QE&gt; &#x27;,S8,N) (H&#x27;&lt;QF&gt; &#x27;,S8,N) (H&#x27;&lt;QNE&gt; &#x27;,S8,N) ÿ(H&#x27;&lt;QNF&gt; &#x27;,S8,N) ÿ(H&#x27;&lt;MBXNE&gt; &#x27;,S8,N) ÿQueueEmpty ÿQueueFull  ÿ(X1,S8,N) Mailbox     (S8,N) ÿDELAY               Resource    (S8,N) ÿPartition   (S8,N) ÿ-READY  READY (X1,H&#x27;(&#x27;,I4,H&#x27;/&#x27;,I4,H&#x27; ticks)&#x27;,N) 
+ 
+** Queue Snapshot ** 
+  #   Name  Current/Depth Worst Count Waiters
+ -- More -- ÿ(I3,X1,S8,X2,I5,H&#x27;/&#x27;,2(I5,X1),UI5,N) ÿ(X1,S8,N) (X1,S8,H&#x27;&lt;E&gt;&#x27;,N) ÿ(X1,S8,H&#x27;&lt;F&gt;&#x27;,N) ÿ(X1,S8,H&#x27;&lt;NE&gt;&#x27;,N) (X1,S8,H&#x27;&lt;NF&gt;&#x27;,N) 
+ 
+** Semaphore Snapshot ** 
+  #   Name  State  Waiter
+ -- More -- ÿ(I3,X1,S8,X1,N) DONE
+ PEND
+ (H&#x27;WAIT &#x27;,S8,N) (H&#x27; &lt;QE&gt; &#x27;,S8,N) ÿ(H&#x27; &lt;QF&gt; &#x27;,S8,N) ÿ(H&#x27; &lt;QNE&gt; &#x27;,S8,N) (H&#x27; &lt;QNF&gt; &#x27;,S8,N) (H&#x27; &lt;MBXNE&gt; &#x27;,S8,N) 
+ 
+** Resource Snapshot ** ÿ
+  #   Name   Count Conflicts   Owner   Waiters
+ ÿ-- More -- ÿ(I3,X1,S8,X1,UI5,X3,UI5,N) ÿ **  ÿ     ÿ(S8,N) ÿ(X1,S8,N) 
+ 
+** Partition Snapshot ** 
+  #   Name   Avail/Total Worst Count  Bytes Waiters
+ -- More -- ÿ(I3,X1,S8,X1,I5,H&#x27;/&#x27;,3(UI5,X1),UI6,N) (X1,S8,N) 
+ 
+** Mailbox Snapshot ** 
+  #   Name   Current Count Waiters
+ ÿ-- More -- ÿ(I3,X1,S8,2(X2,UI5),N) ÿ(X1,S8,N) 
+ 
+** Clock Snapshot **
+
+ (H&#x27;Clock rate is&#x27;,I5,H&#x27; Hz, Tick interval is&#x27;,I4,H&#x27; ms, &#x27;,N) ÿ(H&#x27;Maximum of&#x27;,I3,H&#x27; timers
+Tick timer is&#x27;,UL9,N) (H&#x27;, ET is &#x27;,UL9,H&#x27; ticks, RTC time is &#x27;,UL9,//N)    Time        Cyclic   Task   Timer      Object
+  Remaining      Value   Name   Type        Name
+ ÿ-- More -- ÿ(2(L10,X1),S8,X1,N) (H&#x27;Timer      &#x27;,S8/N) (H&#x27;Delay      &#x27;,S8/N) (H&#x27;Semaphore  &#x27;,S8/N) (H&#x27;Mailbox    &#x27;,S8/N) (H&#x27;Partition  &#x27;,S8/N) Queue Empty Full  (X1,S8/N) (H&#x27;Resource   &#x27;,S8/N) Unknown timer type
+ 
+ Task Register set is undefined
+ ** Task Register Snapshot **
+       0        1        2        3        4        5       6        7
+ ÿ(H&#x27;A &#x27;,R16,Z-,8(UL8,X1),/N) (H&#x27;D &#x27;,R16,Z-,8(UL8,X1),/N) (R16,Z-,H&#x27;PC &#x27;,UL8,H&#x27; SR &#x27;,Ui4/N) Undefined Task
+ 
+Task (# or name)&gt;  
+ Priority&gt;  ÿ
+ Time slice (in ticks)&gt;  
+ 
+ 
+$RTXCbug&gt;  
+ S - Suspend
+ ÿR - Resume
+ T - Terminate
+ ÿE - Execute
+ ÿC - Change task priority
+ B - Block (-1=All)
+ U - Unblock (-1=ALL)
+ / - Time slice
+ H - Help
+ X - Exit Task Manager Mode
+ 
+Re-entering RTXCbug mode
+ ÿ
+Bad command
+ 
+** Stack Snapshot **
+ ÿ  #   Task    Size  Used  Spare
+ ÿ-- More -- ÿ(I3,X1,S8,3(UI6),/N) ÿ-- More -- ÿ(H&#x27;Worst case interrupt nesting =&#x27;,B2,/N) (H&#x27;Worst case signal list size =&#x27;,I3,/N) ÿ(L10,H&#x27; ms&#x27;,N) ÿ(H&#x27;Task&#x27;,Z-,I4,N) RTXC 3.1e 03/10/94 ÿ(null) ÿ                                           q &quot;^       @ &amp;^        *^       P .^     
+ F 6ö      
+ ú :ö       p &gt;ö  Ü      DÒ     2         RTXCBUG  D0RBDRV  D0TBDRV  TOOLS    RW_FLASH STARTUP  GTIDRV   MIXER    ÿ               CBUGSEMA D0RASEMA D0TASEMA D0RBSEMA D0TBSEMA BUF1SEMA BUF2SEMA GIPBSEMA GIPRSEMA GIPTSEMA GIPMSEMA GIPISEMA WATMSEMA TOOLSEMA SU_MSEMA GTINSEMA GTIMSEMA GTIDSEMA MIXMSEMA MIX_SEMA ÿ             ÿ                HV      2 H       L               D0RBQ    D0TBQ    MAXPQ                    L¨   &amp;   (         PATMAP               TOOLMB   FLASHMB  ÿ      2             (((((                  H                                                                                                                                 ÿÿÿÿÿÿÿÿÿÿÿõá   B@    &#x27;  è   d   
+       @$      @Y      @Ã     A×    CAÃy7à F¸µµnM8Oé?ùõZwHù02uOÝs¿=&lt;Infinity&gt; ÿ&lt;NaN&gt; XRGL óô ô    ÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿEODTÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿpMPBEGv1
+pMPENDv4
+pDGBEGv1
+pDGENDv3
+pDABEGv1
+pDAENDv1
+pDBBEGv2
+pDBENDv2
+pPRBEGv3
+pPRENDv3
+pFGBEGv4
+pFGENDv4
+pCODE_FSv4
+pDATBLvC
+pDBTBLvC
+pPRTBLvB
+pDIRRTv5
+</td></tr>
+<tr><td>4</td><td>(Eh0951-0.lod)</td><td>     Hç¤                                                     eh0951-0.lod  02-15-96 JUMP TO FIRMWARE - FSPB U16 ADDR $C0200
+                                                              
+                                                              
+                                                              
+                                                              
+                                                              
+                                                              
+Nù  NqNqNqNqNqNqNqNqNqNqNqNqNq</td></tr>
+<tr><td>5</td><td>(Eh0112-0.lod)</td><td> &lt;                             
+     0   1   1
+ÉÍÍÍÍ P/N 412011-002 ÍÍÍÍ»
+º     Copyright 1990     º
+º Gulton Industries, Inc.º
+ÈÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍ¼                    ÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ` :` ^` 
+h` 
+d` 
+`` 
+\` 	^` 
+T` 
+P` 
+L` 
+H` 
+D` 
+@` 
+&lt;` 
+8` 
+4` 
+0` 
+,` 
+(` 
+$` 
+ ` 
+` H` 
+` 
+` 
+` ¦` 
+` Â` Ê` Ò` ` ä` Ò` 	è` 	ä` 	à` 	Üÿÿÿÿ |   N`Fü Aù  °#È  ¨#È  ¬Aù  °#È    ü n ü  ü x ü  ü 	 ü ú#È  ¤¹    æ9    ægS¹  èfa H y   ±ù  ¤gÜ&quot;X±ü  °l#È   `
+#ü  °   N`¼Fü&#x27; (y  ¤(Ë¹ü  °l#Ì  ¤`
+#ü  °  ¤NsFü&#x27; (y  ¬(Ë¹ü  °l#Ì  ¬`
+#ü  °  ¬Nsü    ìü    ¹    &#x27;ü   ðü 
+  wNu#ü  R  3ü    3ü   a  Nu&amp;y  øa æ3ü    9   vgü    ìp (k , 	f6t 49  ôa $
+   gt 49  ôa #°y    n p`
+pü    ì#À  t 49  ôa $&#x27;y   |   |  «  
+y   f«  
+p &quot;k +  
+g
++  
+f`+  
+g+  
+fp`Ð) Ð) Ðy  3À  aNu3ü    ü&amp;y  øp + °y  n Ê+ þ fr&quot;k +  
+g+  
+f p&#x27;y  þ `@+  
+g&#x27;k  `0+  
+g«  
+&#x27;y  þ )   f 0` ë  
+&#x27;k  `+  
+g
+)   f &quot;k é   0) 
+g  0) g  ¨) gxa   g ÿZCù  v29  Eñ &amp;y  ø« #ë   
+Aù  tEù  v,k %hÿþÿü&#x27;H 49  ôü ÂHB  gÐ`ü    a &lt;&#x27;y  
+ `.ü    a ` 0) f) gü    a º`Nq`    g þ¸Cù  r#É  âGù NJ| 9  SFoNKSFnú&amp;y  ø+  Gù ¼NKNu|   Aù  v,k k ÿün ÿý1n 
+ÿþ9  r t 9  Äü  RA²Bmö`Gù 
+tNJGù 
+NKNuEù   49  ôÅü  02 3À  ôÁü  Cò  3é   ö#É  ø)   
+fGù 
+`Gù 
+NJNuGù 
+¤NJGù 
+NKNu0&lt;5S@füGù 
+ÂNJNuNDNua rAù  zCù  r2ù  öÁù  wØØØØpü ÿR@  oôRA oÔCù  r#É  âGù NJrNKRA oöGù 
+tNKGù 
+NKNu29  öCù &lt; i $y  ø0g
+°AgÐü `òª   
+3ü    ü#È  âGù NJ²y  ðf
+Gù &amp;NKNuGù 
+tNKGù 
+NKNuAù &lt;$h &amp;h Iù   &quot;Px |ÿ~ÿ&lt;|  r 01 g  þt :2  g  ô°Ef2 @ gB `æKò  )@v z 30  ÿgÊü ²Ef3  0gC `Þ@ f  ®`Kó0 )@z Å  Å Å Å Å Å @
+¼  @¼ @@ ÿo@ÿo@ÿo6`3À  ðò   w´ @
+9@Fÿÿg9``3Î  ò3Î  ô&lt;`69   f,ô @
+9@Gÿÿg9p`3Î  3Î  &gt;`ô @
+D  RN¼ü n
+2Âü ` þâFÿÿg9¹  ò`Gù ´NJIù   Gÿÿg29¹  p09  3À  Áü  Cô  #É  &quot;ù    &#x27;Gù 6NJNu9   g&lt;9   g2Aù  òEù  ¼ tNGAù à NqAù  òEù  ¼ tNGNuGù  J°9  wf  Ä fù   v`   ftAù  zCù  $¹   v`h f tAù  ~Cù  (¹    v¹   v`B f tAù  Cù  ,ù    v¹   v` f@tAù  Cù  °¹   v[ [ [ a  Aù  vCù   tarGù 
+Æ`Gù 
+NJAù   09  3À  Áü  Cð  #É  &quot;p 0 
+ gÅ  Å Å Å Å Å  
+¼  @  @àoÊü    ìNu2)ÿðEñ 2SAmN0 °2 fSAlò`&gt;NG2SAm60 °2 fSAlò`&amp;&amp;HAù  xEéÿð6C C g08tNG4 K`¤NuHçàø0&lt;  Cù   a üLßNsHçÿþ0&lt; Cù   a äLßÿNsv (*,.&amp;CIù   Kù  D$T4, 6l ´Kn(2  RB :fð´KnaL ÿo  n
+XDã\¸KoÆ `.SGka*`ø    fz v - Çü  Gù   ­ 0­ 0NuaéaØP REÜNu2  RB /o 9o @o Fo
+Æ &lt;  `  NuNqNqNqNsNqNqNqNu0&lt;  Aù   y    f,(y  ¨¹ù  ¬g&amp;\¹ü  °l#Ì  ¨`
+#ü  °  ¨NJNuAù   0(ÿðð    vAù  $0(ÿð#ð    zAù  (0(ÿð#ð    ~Aù  ,0(ÿð#ð    Aù  °0(ÿð#ð    Eù  za(#Á  9    vfEù  ~`Eù  a#Á  Nup 9  wr t v a þâ¶@lÃÀÒ mî`r Nu#ü 
+  3ü 
+  a 
+Nu:00000001FF
+ x `xÿv`&amp;vxÿ` x¡`x¢`x£`x¤`x¥`
+x¦`x§`x¨vAù   Eù  n ü  ®0ü  0ü @ Ê0ü  0ü 49  ô&quot;y  øÃra  êa Nu&quot;y  øé   
+Gù 
+¾NJNu&quot;y  ø)  f$)   g)  f)  lR) Gù ´`é   
+Gù 
+¾NJNu&quot;y  ø|   )  
+fGù ´`Gù 
+®NJNu&quot;y  ø|   Gù ´NJNu0&lt;  2&lt; 49  üv Aù   &quot;y  âEù  ~#Ê  3ü    3ü -  a#É  âÔA3Â  üa ¬Nuü :z &lt;a,&lt;à^a&amp;a&quot;a8aSDfø
+EÿÿREa
+ü 
+ü 
+NuÚFè  0 9o Ç  0 9o ÇNuy   öga`¹    æGù ´NJNuy   öfa ÷¢ y  øCù r  g g. n  l6&lt; `0(  ¨n ¡m `&lt; `(   g&lt; `&lt; Âü xÒÁr 9    æfJ f  &gt; f  6  f  .9  õ°9  Ff  (  g&amp; g&lt; n  lJ&lt; `D&lt; ¹    æ`6(  n  m ` &lt; `(  n m z`&lt; Âü ÒÁ&amp;QNJNu 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+ 
+ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+ 
+ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ b þ ; ; 
+¶  
+¾ ;  
+¾ 
+¶ ; ;Ü ;Ü 
+¾ ;Æ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+   &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; 
+ &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; 
+ &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; 
+ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+ 
+ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾  ;Ü 
+ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ Ö 
+¾ 
+¾ 
+¾ 
+¾ ; 
+ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ Ö 
+¾ 
+¾ 
+¾ 
+¾ ; 
+ 	Ú ; 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¶ 
+ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+ 
+¾ 
+¾ 
+¾ 
+º 
+ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ ´ 
+¾ 
+¾ 
+¾ ´ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+ 
+¾ 
+Â 
+ 	Ú ; 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¶ 
+ &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; 
+ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾  
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ ;Æ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ 
+¾ ´Aù   0 
+Â9  l gJ$Q4) ü   ð°   2 
+  gRB´i g3B `  ¨3|   a :Gù ¨NJGù tNJ`   g9  l ß 
+¼   `  l  g0$i 4) ´i g²   RB3B `H3|   a Gù NJ`4 g.$i 4) ²   RB2    g´i g3B `
+3|   a  Nu0&lt;  &lt; fNuAù   0&lt;  ¼ À ¼ 0 ü    lNuAù   ¼   ¼   ¼ 0 ¼ 0 ¼  ¼  ¼   ¼   ¼  ¼  ¼ ° (  g¼ Ì `¼ »  ¼ @ ¼   Nu9  l ý 
+¼   ¼  Á  l¹    æNu9  l þ 
+0  gø¼ 0 ¼ P   Á  l 
+¼  Nu9  l ï 
+0  gø¼ 0 ¼  Á  lNuNq0&lt;  Aù   9  l ý 
+¼   ¼ P   Á  l 
+ù    æv &amp;y  ø(k , Æüü#Ã  è¼  Nu&amp;&lt;   Sjü0&lt;  Aù   9  l ß 
+¼   ¼     Á  l 
+¼  NuAù à p ¼ @| ÿ | ÿ  |   | T &quot;|   &amp;|   (| ð *| °  è    ¨  | P 
+|  |  Ð ü    NuHçàÀAù à  ü   LßNs49  2Âü  2
+À À À À À 
+¼ ´y  g42`Ê3Â  Åü  Cò  #É  &quot;NuHç Gù à «    Gú NqNJLß NsAù à Eù   9   g
+ü   `9    g(  gÐ ü    a ÿP49  Åü  02 3À  Áü  Cò  #É  &quot;)  
+g|  ) S o@ 49  ´y  m¼`L3é    ü   ¼ü   Ùü   à(i ,   Vm  [n@ &quot;|   &amp;|   (| ð *`¨  | T &quot;|   &amp;| b (|   *| °  è    NuHç øGù *â`&quot;Hç øGù /Î`Hç øGù 2L`
+Hç øGù -XAù à ¨    ¨  ¨  NJLß NsHçøøAù à 9  Ø9  Ùg(  g  ²  g$  g(  g,  g@  gD`lü   Ù`bü   Ù`Xü   Ù`Bü   Ù69  9  Ø `4ü   Ù`ü    Ùü   ¼| T &quot;¨  `| õ *  3`|  *|   (|   &amp;C | °  è    `¨    Gù 4ÊNJLßNsHçøøAù à 9  ß9  àg  g  d  g  g`0ü   à`&amp;ü   à`ü    àü   ¼| T &quot;¨  |  *|  (|   &amp;C | °  è    `¨    Gù 7hNJLßNsEù  v&amp;y  øk ÿü,k n ÿý5n 
+ÿþ&amp;y  øCù  #É  ü    *k ¹    Fr 2- ^Aü A mA or3Á  :Âí 
+p ÀSAnú0. a N k Eù  vt 49  ôü a Ü ga &#x27;H @ Nuz v x p j  ðl  Ö¶m lì¸y  &gt;läºm 
+lÞ  `fR9  9   nÈ&quot;y  #É  °y  Dn²y  BkªÀü r 44  24 Cô  Bù  &lt;09  &lt;t S@oá`öE  lÔù  :`C  gmçº`èº09  :S@oà`öRESAn¼09  @S@k
+REÔù  :`ò9   8f ÿ.09  a &lt;` ÿ g Ì  ñg 
+  óg&lt;  ôg  v  õg  ¨  ög  ª  ÷g  ²  øg  ¸  ùg  ¸  úg  ¼` º9    Fga áX@ g: Eù  vÀù  :ÔÀáX@ g6 x C` þ9    Fga  Ðp   ÿg: Eù  vÀù  :ÔÀ  ÿg6 x C` þXáX` þNáXa Lp ` þLáXa L` þ0` þ(Ø  s` þØ  tØ  u` þ9    FgaJ.   f  Ú0- 
+Eo4ù    F3Å  H3À  L#Ê  NEù  rz Cù  rÀù  :ÅS@nú` ý¶¹    F$y  NE  gH| &lt;9  LºFl&quot;2Âù  :ERFü ÚFÚy  HÌù  :ÔÆ`
+:2Âù  :Cù  rSAnøNu:9  HNu9    Fg
+E  ga ÿv 6- my  &gt;kü `v x C` ýa  9    Fga ÿX|&#x27;H @ Eù  rNu&quot;zbNqü   8`&quot;zNNqü    83À  Àü (q  r 1 3Á  &gt;^Aü A mA or3Á  &lt;r 1 3Á  @1 3Á  B1 3Á  DNujü  ül8  þl2  òm  óoT`àX`Ü  ífÖp @ nÀü ÐÀ`Ä   `ÀNuvj&quot;  íg  üo  :`  6C oU`  (   m    n  °f  
+HBf
+HBSfÚ| NuHBSgÆü ÐÃ|NuEù  v`*Eù  4&amp;y  &quot;Cù  ¹    J¹    G`Eù  v&amp;y  øCù  ôk ÿü#Ê  Iù  #Ì  ü    ,k n ÿý5n 
+ÿþ*k ¹    Fr - p - 	ÂÀ3Á  &lt;  ÀSnú k $y  t 4ü a þô ga þ¦&#x27;H @ Nuz v p j  ðlRº- lî¶- 	lè  `fR9  9   nÒ(y  #Ì  @ ßn¾@  m¸  lR`  mÀR`¢g |  ñg  Æ  óg8  ôg&gt;  õg@  ög  r  ÷g  r  øg  r  ùg  r  úg  z` ¨` ÿN` ÿF9    Fga  Äp   ÿg:   ÿg6 - $y  ÔÅÀÃÔÀ` ÿ` ÿ` þþ` þö(y  Xÿý` þæ(y  XÿþXÿÿ` þÔ9    FgaR+  
+gù    GÅ  Jù    F3Å  Hp - Elp 3À  L#Ê  NEù  rz .   f  ¼` þv¹    F$y  NE  g4| &lt;9  LºFl2ERFü ÔÆÚFÚy  H`:2Iù  rÜSAnúNu:9  HNu9    Fg
+E  g(a ÿv - 	gSCü p - $y  ÔÅÀÃÔÀ` ýîv - 	gSCü p - (y  Øù  HÀÃØÀ#Ì  N` ýÀa  n  õg ý´9    Fga ÿ2|&#x27;H @ 4. $zNqÄü 2   f2 r  0Eð   Vf&quot; Ff Of Nf Tf
+&amp;y  a rNujü  ülN  òm  õg,  óoT`àX`Ü  ífÖp @ nÀü ÐÀ`Ä   `Àp   ÿg²°Cg®W&lt; õNup xAù  4Eù  Rü v
+ v0  Á³R@  mðü 
+ 
+ÄNu 9  ë  
+    g2Cú$Nq i a  À   g#È  þü   ì9    g«  
+Nu 9  ë  
+    g*CúÜNq i a  x   g#È  9    g«  
+Nu 9  ë  
+    g*CúNq i a8   g#È  9    g «  
+`CúrNq i #È  ü    ìNurx &quot;H ûgV ògZ ýg   íg\ þg4  m nvRjü ûoP üg^ ýg` þfZ²gnn\R`¨²lTR` r á`ááá`v  n$Æü ÐÃ`¦ òm  óoT`X`` ÿtRRDD dmAú¤Nq&quot;h p  INu Iü ü    a ùæ  üo  gÝy  ü   a ù  þfØp INu:9  E  g,2 KpIú ìNq´g
+S@fø$H6`$ Jf PRSAfØNupIú ÂNq´gS@føRSAfè:&gt;A`&quot; Lf `
+ Jf P&gt;AR&amp;HSA:2 JpIú Nq´g&amp;S@føSAfêpIú ~Nq2 J´gSAføS@fî` ÿTASA,HG  g J 0m
+ Zn PRSGfèA  g ÿ&amp; N 0m
+ Zn RSAfè` ÿ !%&#x27;+,-./1:;IJLT_MNVWXYZRKBDPGSAQOUCHEF3245697809    ¼g` n9  ¸9  ºR9  ¦y    ¤y À  ¤n9  ¦gÞ` Ô3ü    ¤ y  °&quot;y  ´Sy  ¢y    ¢m8 !9   &amp;frÿ`±gÚ#È  °#É  ´À  ¸Á  ºü    ¦`3ü   ¢ y  ¨&quot;y  ¬ØRy  À09  Â°y  Ào  Zy   y    nhp r 9   &amp;g² gÂ#È  ¨#É  ¬$y  0°y  6ny  4lp Àü 42  Aò ²y  6ny  4lr Âü 42 Cò ` ÿ&amp;3ü     y   y   n` ÿ|3ü     3ü    3ü    À`  Xa 
+3ü    ¤3ü   ¢3ü     3ü    À3ü    09  2 Ãü 3Á  Aù  4Eù  °Áü Cò  ` ÿ
+3ü    ü    &amp;Aù à | T &quot;|   &amp;|   (| ð *| °  è    ¨  Nu g0&lt;@ `0&lt;  Ðy  Ðy  Ðy   Ðy  ¢Ðy  ¤ü    ¼Aù à  |   &amp;|   (| ú *| °  è  è    Nu9    ¼g` n9  ¸9  ºR9  ¦y    ¤y    ¤m9  ¦gÞ` Ô3ü À  ¤ y  °&quot;y  ´Ry  ¢y   ¢n8 !9   &amp;frÿ`±gÚ#È  °#É  ´À  ¸Á  ºü    ¦`3ü    ¢ y  ¨&quot;y  ¬ØRy  À09  Â°y  Ào  [y   y     mhp r 9   &amp;g² gÂ#È  ¨#É  ¬$y  0°y  6ny  4lp Àü 42  Aò ²y  6ny  4lr Âü 42 Cò ` ÿ&amp;3ü    y   y    m` ÿ|3ü    3ü   3ü    À`  Xa 
+¤3ü À  ¤3ü    ¢3ü    3ü    À3ü   09  2 Ãü 3Á  Aù  4Eù  °Áü Cò  ` ÿ
+3ü    ü    &amp;Aù à | T &quot;|   &amp;|   (| ð *| °  è    ¨  Nu g0&lt;@ `0&lt;  Ðy  Ðy  Ðy   Ðy  ¢Ðy  ¤ü    ¼Aù à  |   &amp;|   (| ú *| °  è  è    Nu9    ¼g` v09  ¸29  ºR9  ¦y   ¤y p  ¤n9  ¦gÞ` Ü3ü    ¤ y  °&quot;y  ´Ry  ¢y   ¢n8029   &amp;frÿ`±AgÚ#È  °#É  ´3À  ¸3Á  ºü    ¦`3ü    ¢ y  ¨&quot;y  ¬ØRy  À09  Â°y  Ào  ¨y    y   nhp r 9   &amp;g² gÀ#È  ¨#É  ¬$y  0°y  6ny  4lp Àü 42  Aò  ²y  6ny  4lr Âü 42 Cò  ` ÿ$3ü     3ü    Ày   y   nAù  4` ÿn3ü     3ü    `  Xa &amp;3ü    ¤3ü    ¢3ü     3ü    À3ü    09  2 Ãü 3Á  Aù  4Eù  °Áü Cò  ` ÿ3ü   ü    &amp;Aù à | T &quot;|   &amp;|   (| ð *| °  è    ¨  Nu g0&lt;@ `0&lt;  Ðy  Ðy  Ðy   Ðy  ¢Ðy  ¤ü    ¼Aù à  |   &amp;|   (| ú *| °  è  è    Nu9    ¼g` v09  ¸29  ºR9  ¦y   ¤y    ¤m9  ¦gÞ` Ü3ü h  ¤ y  °&quot;y  ´Sy  ¢y    ¢m8029   &amp;frÿ`±AgÚ#È  °#É  ´3À  ¸3Á  ºü    ¦`3ü   ¢ y  ¨&quot;y  ¬ØRy  À09  Â°y  Ào  ¨y    y     mhp r 9   &amp;g² gÀ#È  ¨#É  ¬$y  0°y  6ny  4lp Àü 42  Aò  ²y  6ny  4lr Âü 42 Cò  ` ÿ$3ü   3ü    Ày   y   nAù  4` ÿn3ü   3ü    `  Xa ¨3ü h  ¤3ü   ¢3ü   3ü    À3ü    09  2 Ãü 3Á  Aù  4Eù  °Áü Cò  ` ÿ3ü   ü    &amp;Aù à | T &quot;|   &amp;|   (| ð *| °  è    ¨  Nu g0&lt;@ `0&lt;  Ðy  Ðy  Ðy   Ðy  ¢Ðy  ¤ü    ¼Aù à  |   &amp;|   (| ú *| °  è  è    Nu9    ¼f R9  Ø  3Aù à C ü    ¼|   &amp;|   (| õ *| °  è    r v ü    Ù9   Úf
+Ã Ã  `Ã Ã 9  Ä9  Å49  Æ&quot;y  ÈR o&gt;r 49  ÆRB´y  Ìmt R   fp `  opÀ  Ä3Â  Æa ¨#É  ÈÁ  Å1 fÃ r 9  Î9  Ï49  Ð&quot;y  ÒR   fp `B  o&lt;pR o,r 49  ÐRB´y  Öm
+t ü   Ù3Â  Ða 6#É  ÒÁ  ÏÀ  Î1 fÃ Ã  ØNua Pv z Kù  2m nºy  gü   Ú`Aù à | T &quot;`  ¨ü    Ú y  &quot;p (h , 3À  Ì3À  Ör Á  Åt 3Â  Æa   #É  ÈpÀ  Ä1 fÃ pÀ  Îr Á  Ït 3Â  Ða  l#É  Ò1 fÃ Ã  ØËü E@ 3Å  E Aù à  è  ü   Ùü    ¼|   &amp;|   (|  *| °  è    NuKù  4x 5  ¸y  6ny  4lx Èü $y  0&lt;2@ Cò` Nu9    ¼f  Ò9  ßÃ    Aù à C ü    ¼|   &amp;|  (|  *| °  è    r ü    à  9  Û9  Ü9  Ý9  ÞS k  g`,p`(RAA m
+r ü   àa JÁ  ÜÂ  ÝÄ  ÞÀ  Ûf `Ã  ff `Ã Ã  ßNu&amp;y  &quot;+   
+g«   
+ù   a ¹   v z Aù à Kù  2m2 n,ºy  g4 9    Gg9    JgÃ `Ã `ü   à| T &quot;``Ã r Á  Üa  zÂ  ÝÄ  ÞpÀ  ÛgÃ  fgÃ Ã  ßC Ëü E@  è  ü   àü    ¼|   &amp;|  (|  *| °  è    NuKù  45  `m  `ô 0ftO²9  Jmx `Nu&amp;y  &quot;p (k , 3À  Â(k 0, &quot;z|NqÀü #ñ    0r 1 3Á  41 3Á  6+  
+g  ´9   f R«  
+a Òè3ü    9   vgü    ìp (k , 	f6t 49  a î   gt 49  a í²y    n p`
+pü    ì#À  t 49  a î&#x27;y   &#x27;y   |   ü   &amp;y   f«  
+9    f   + þ f  r&quot;k +  
+g+  
+f  ¨&#x27;y  þ `&gt;+  
+g&#x27;k  `.+  
+g«  
+&#x27;y  þ )   fX` ë  
+&#x27;k  `
++  
+g  
+)   f6a èÒ&amp;y  &quot;  g ÿv9  1@ +  `Zü   Jù    G`ü    J¹    G|   Aù  4,k 1n 
+ÿþ. @ÿý@ +  r ¼   RAA mòNu y  ø|   Gù 
+®NJNu y  ø(   l
+R Gù 
+®`p è   
+Gù 
+¾@ NJNu y  ø|   Gù 
+ªNJNu y  ø(   l
+R Gù 
+ª`p è   
+Gù 
+¾@ NJNu</td></tr>
+<tr><td>6</td><td>(Eh0582-0.lod)</td><td> JÞ            R 	
+
+ !&quot;#$%&amp;&#x27;()*+,-./0123456789:;&lt;=&gt;?@ABCDEFGHIJKLMNOPQ    0       1       1     ÿ      0                                                
+ÉÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍ»
+º                                      º
+º            P/N 412058-002            º
+º             Copyright 1998           º
+º               Luminator              º
+º                                      º
+ÈÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍ¼
+
+
+                                ` X` |` ø` ô` ð` ì` ` ä` à` Ü` Ø` Ô` Ð` Ì` È` Ä` À` ¼` ¸` ´` °` ¬` $t` ¤`  ` ` $Ò` ` %î` %ö` %þ` &amp;0` &#x27;` %þ` x` t` p` lÿÿÿÿ |   N`Fü Aù  ¸#È  ¨#È  ¬Aù  ¸#È  °#È  ´Aù  ¸#È    ü $: ü ª ü 
+&lt;#È  ¤¹    xü    Z9    xgS¹  zfa Î9    ZgS¹  \fa Ø y   ±ù  ¤gÆ&quot;X±ü  ¸l#È   `
+#ü  ¸   N`¦Fü&#x27; (y  ¤(Ë¹ü  ¸l#Ì  ¤`
+#ü  ¸  ¤NsFü&#x27; (y  ¬(Ë¹ü  ¸l#Ì  ¬`
+#ü  ¸  ¬Nsü    ~ü    -ü    ÿü   3ü   øü 
+  Ùü   ü   ü   ü    ZNupÀ  #À   aZ o&lt; Å  pÀ  ü    ü    #À   a*a  æ9   oü   9   oü   Nuz t 49  ö&amp;y  úa 2Z   g  ¢ y  ü    	ü    
+t 49  öü a *( ga )à  þfÐ`hm
+  `föR`ò  ügº  þlN  òmà  óo&gt;  úg(  õf.9   f9   	ga&quot;À  
+`¬À  	` T`X`Nu9    
+f
+Û9  z `Û9  z Nu&amp;y  a 
+¹   ¹    |   3ü    &amp;9   Øgü    ~p (k , 	fjt 49  9   ØfJ9   Øfa 0ì   g:`p#À   a 1   g&amp;ù   t 49  a 0vy    &amp;n$p`p`
+pü    ~#À   t 49  a 0Ð&#x27;y   &#x27;y   |   |  «  
+y   &amp;f«  
+p &quot;k +  
+g
++  
+f`+  
+g+  
+fp`Ð) Ð) Ðy  &amp;3À  (aNu3ü    
+&amp;y  p + °y  (n ê+ þ f  &quot;k +  
+g+  
+f &#x27;y   `N+  
+g&#x27;k  |   `89    ~g«  
+&#x27;y   )   f F`&amp;ë  
+&#x27;k  |   `+  
+g
+)   f &quot;k é   %0) 
+g   0) g  ²) g  a )  g ÿHCù  29  Eñ &amp;y  « #ë   Aù  Eù  #Ê  ,k %hÿþÿü&#x27;H t 49  ü ÂHB  gÐ`ü    $a &quot;&#x27;y   `4ü    $a &quot;X`&amp;0) f) gü    $a (´`ü    %`    g þCù  #É  tGù &amp;NJ| 9  %SFoNKSFnú&amp;y  +  Gù zNKNu|   Aù  ,k k ÿün ÿý1n 
+ÿþ9  $r t 9  %Äü  RA²Bmö`t 9  %Äù  (3Â  *Gù òNJGù &quot;NKNuEù   49  Åü  02 3À  Áü  Cò  3é   #É  )   
+fGù &quot;`Gù &amp;NJNuGù ,NJGù &quot;NKNu0&lt;5S@füGù JNJNuNDNuEù  bAù  #È  tvCù  9  ÙaFvCù  a&lt;vCù  &quot;a2Gù &amp;NJRy  *rNKRy  *R oðGù òNKGù &quot;NKNur 0ù  ÃÀt ò  RAA mòü ÿRAA môNu&amp;y  a 
+¢¹   |   p
+9   Ð9  #À   3ü    &amp;t 49  a ,è   g
+y    &amp;f9 	  o¼` :&#x27;y   |   |  «  
+3ü    
+Eù  bAù  #È  t9   f
+Cù  `  ² f
+Cù  `  ¢ f
+Cù  &quot;`   f
+Cù  2`   fCù  :`F f` f` 	f  9  Ùr 0ù  ÃÀü ÿRAA môGù &amp;NJRy  *`DGù &amp;pa þNJRy  *pa þNKRy  *R   oì`9  Ùa þtGù &amp;NJRy  *p &amp;y  +  
+f(Ðy  &amp;3À  (Gù VNK`t Gù òNJGù &quot;NKNu&amp;y  p + °y  (n 0+ þ g &amp;&quot;k é   %0) 
+g  0) g  ®) g~a %0  gÊCù  29  Eñ &amp;y  « #ë   Aù  Eù  #Ê  ,k %hÿþÿü&#x27;H t 49  ü ÂHB  gÐ`ü    $a F&#x27;y   `4ü    $a `&amp;0) f) gü    $a $d`ü    %`  R  g ÿCù  #É  tGù &amp;NJRy  *| 9  %SFoNKRy  *SFnô&amp;y  +  Gù VNKNuGù 	ªNJNu3ü    *29  Cù JÞ i $y  0g
+°AgÐü `òª   
+3ü    
+#È  tGù &amp;NJRy  *@ mg@g@ÿoGù òNKGù &quot;NKNuGù 	NKNuü   ù    Gù 	ªNKNuAù JÞ$h &amp;h Iù   &quot;Px |ÿ~ÿ&lt;|  r 01 g &quot;t :2  g °Ef2 @ gB `æKò  )@v z 30  ÿgÊü ²Ef3  0gC `Þ@ f  Ò`Kó0 )@z Å  Å Å Å Å Å @
+¼  @¼ @@ ÿoJ@ÿo&amp;@ÿod@0f8ü   ´ @
+9@3Î  `p3Î  ö3À  øAô@ #È  úò   Ù´ @
+9@Fÿÿg9``3Î   3Î  &lt;`,ô @
+9@Gÿÿg9p`3Î  ,3Î  0&gt;`ô @
+D  RN¼ü n
+2Âü ` þ¾Aù   Gù $îNJy  ømGù üNJFÿÿg1¹   `ù    ÿGù ¦NJGÿÿg21¹  ,p09  03À  .Áü  Cð  #É  4ù   ÿGù &amp;bNJNua  À   g*  g9   gGù &gt;`Gù NNJNuGù &amp;`Gù NNJaNuAù   9    ÿg&quot;09   Áü  0 
+  &gt; 
+00 °y   fä9   ÿg&lt;09  ,Áü  0 
+  ? 
+00 °y  ,fä09  .3À  0Áü  Cð  #É  4ü    ~NuGù  R9  Ø f4   y   øg
+y  øfp`pa Cù  2` D f  Â¹     fü    Cù  Ú`t  fCù  â`f  fCù  ê`X  fCù  ò`J  f Cù  úa@9   f2 Å  p(Gù  Úa |Cù  :v a  âRCC (mô`  ¸apNuR9  °9  gù   p ³    R@@ mòNu°9  Ùf   fÅ  `  n 
+f  `  \ fCù   `: fCù       ` f&gt;Cù  &quot;Å     v a  (RCC môv Å  ØGù  ØCù  ap NupNutr 10 Iù  bAó0 Eô °g,NG°g$Aù  R gÀ  Eñ0 NGEÐAù  NG`¸NuNqGù  L f*  f$ f f ÿf9   þfNDNuNENuGù  R 
+g m   n
+a ý¨a ý&quot;`zt Eù  b f49  2   g
+v  f`  f
+vCù  `@vCù  &quot;`6 f
+vCù  `&amp; f
+vCù  2` f
+Cù   `@` f`NuAù  (r 0ÁÃù  Ùt ò  RAA mòü  RAA môCù  (0&lt;  rt v Aù   Eù  ö#Ê  3ü    3ü -  a Za NuNVÿ2&lt;  C÷ 2&lt; ÈE÷ I×r(K÷ Å  Ør 3  am
+ zn   RA²@mâr x z 1 ¼  P(A  gv ´50 g8RC¶EmôP R5P(PP@ RD6RC¶@l10 ´5P fð@ RDR5P(`äRERA²@mªSEr 650 8RC¶En´50 mô`ì¸Ag&amp;µ @  5@(µ(@((5@PµP@PPRA²EmºAù JÞ h $a  ªF  m  r 4¸5  g0mæ64¸5  g$nÚt 4AB mÎü ÔA¸5  g
+n6`â2`Þx ~ 5 P5 (4@ t RB´Fn(2  RA²@l  g1   gì¶1 gÜSGo ÿ~RD`Ìr ¼   RA²@oôù   ØNqNq9  ØN^Nu|ÿ ûfT`ô òfX`ê þgä ýg   íft  ndÄü ÐÂ`  mV nPRk&quot;RF¼@l6ah é` kaX Õ2` `Ú ûo. üg&gt; ýg6 þg2` üg( þg&quot;4 a 20` ÿ\ òm  óoT`X`|ÿNqNu /o 9o @o Fo
+Æ &lt;  `  NuHçàø0&lt;  Cù   a 
+\LßNsHçÿþ0&lt; Cù   a 
+DLßÿNsIù   Kù  L$T4, 6l a  ¹   þ    g
+ù    þ`&amp;¹    þz v - Çü  Gù   ­ 0­ 0NuIù   Kù  L$l 4, 6l a$ù   þ    g
+ù   þ`¹   þNuv (*,.´Kn(2  RB :fð´Kna&amp; ÿo  n
+Xã\¸KoÆ `SGka`øNuaéaØP REÜNu2  RB /o 9o @o Fo
+Æ &lt;  `  NuNqNqNqNsNqNqNqNu0&lt;  Aù   y    f,(y  ¨¹ù  ¬g&amp;\¹ü  ¸l#Ì  ¨`
+#ü  ¸  ¨NJNup t ~Eù  b9  Ù  
+g
+  ga ñ Cù  a6#Ä  Cù  2  Ã  Ø  fCù  `Cù  &quot;a#Ä   Nur v x z | 1 a ÿ f¶@lÈÀÊÀØHDÚD8&lt;  HDRA²mÖHD8HD`x Nur 49  *vEù  #Ê  3ü    3ü 
+  a Za 
+¾Nux `xÿv`&amp;vxÿ` x¡`x¢`x£`x¤`x¥`
+x¦`x§`x¨vAù   Eù  v ü  ¶0ü  0ü @ Ê0ü  0ü 49  &quot;y  Ãra  êa 
+NNu&quot;y  é   
+Gù FNJNu&quot;y  )  f$)   g)  f)  lR) Gù ¦`é   
+Gù FNJNu&quot;y  |   )  
+fGù ¦`Gù 6NJNu&quot;y  |   Gù ¦NJNu0&lt;  2&lt; 49  
+v Aù   &quot;y  tEù  #Ê  3ü    3ü -  a#É  tÔA3Â  
+a lNuü :z &lt;a2&lt;à^a,a(a$A  g
+8aSDfø
+EÿÿREa
+ü 
+ü 
+NuÚFè  0 9o Ç  0 9o ÇNuy   ga`¹    xGù ¦NJNuNuy   fa ï y  Cù  r  g g. n  l6&lt; `0(  ¨n ¡m `&lt; `(   g&lt; `&lt; Âü xÒÁr 9    xf&gt;9    þf  .9  °9  Nf  (  g&amp; g&lt; n  lJ&lt; `D&lt; ¹    x`6(  n  m ` &lt; `(  n m z`&lt; Âü ÒÁ&amp;QNJNu9   þfa öÄNu F F F F F F F F F F F F F F F F F F F F F F F F F F F F &amp;  F F F F F F F F F F F F F F F F F F F F F F F F F F F F &amp;  F F F F F F F ê ð JR Jh &gt;  F JR 	 F &gt; Jh J® J® F J F F F F F &quot; ¨ 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	  	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	  	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	  F F F F F F F F F F F F F F F F F F F F F F F F F F F F &amp;  F F F F F F F F F F F F F F F F F F F F F F F F F F F ¤ J®  F F F F F F F F F F F F F F F F F F F F F F F B F F F F Jh  F F F F F F F F F F F F F F F F F F F F F F F B F F F F Jh   JR F F F F F F F F F F F F F F F F F F F F F F F F F F &gt;  F F F F F F F F F F F F F F F F F F F F F F F F &quot; F F F B  F F F F F F F F F F F F F F F F F F F F F F F F F ¦ F F F ¦ F F F F F F F F F F F F F F F F F F F F F F F F F F &quot; F J   JR F F F F F F F F F F F F F F F F F F F F F F F F F F &gt;  	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	  F F F F F F F F F F F F F F F 	 F F F F F F J F F F F F F ¦Aù   0 
+Â9  t gF$Q4) ü   °   2 
+  gRB´i g3B Nu3|   a ¸Gù ÜNJGù NJNu gR0   f0 Nu9  $i 4) °   2 
+  gRB´i g3B Nu3|   Gù 8NJGù NJNu  g0$i 4) ´i g²   RB3B Nu3|   a vGù NJNu g($i 4) ´i l²   RB3B Nu3|   a Nu fNuNuAù   0&lt;  ¼   ¼   ¼ 0 ¼ 0 ¼  ¼  ¼   ¼   ¼  ¼  ¼   ¼  ¼ Z ¼   ¼ ° 0  g¼ Ì `¼ » 0  g¼  `¼ » Nq¼ @ ¼ À ¼ 0 ¼   
+ü    tNuAù   0&lt;  Cù   #|  Ä 3|   3| 0 a  Nu9  t ý 
+¼   ¼  Á  t¹    xNu9  t ß 
+¼   ¼   Á  t¹    xNu9  t þ 
+0  gø¼ 0 ¼ P   Á  t 
+¼  Nu9  t   Á  t 
+¼  Nu9  t ïÁ  t 
+¼  NuNq0&lt;  Aù   9  t ý 
+¼   ¼ P   Á  t 
+ù    xv &amp;y  (k , Æüü#Ã  z¼  NuNq0&lt;  Aù   9  t  Á  t 
+¼  NuAù à p ¼ @| ÿ | ÿ  |   | T &quot;|   &amp;|   (| ð *| °  è    ¨  | P 
+|  |  Ð ü    -NuHçàÀAù à  ü   -LßNs49  ,2Âü  2
+À À À À À 
+¼ ´y  .g42`Ê3Â  0Åü  Cò  #É  4NuHç Gù à «    Gú NqNJLß NsAù à Eù   9   -g
+ü   -`9    -g(  gÐ ü    -a ÿP49  0Åü  02 3À  0Áü  Cò  #É  4)  
+g|  ) S o@ 49  0´y  .m¼`L3é   2ü   Nü   kü   r(i ,   Vm  [n@ &quot;|   &amp;|   (| ð *`¨  | T &quot;|   &amp;| b (|   *| °  è    NuHç øGù 9Z`&quot;Hç øGù &gt;F`Hç øGù @Ä`
+Hç øGù ;ÐAù à ¨    ¨  ¨  NJLß NsHçøøAù à 9  j9  kg(  g  ²  g$  g(  g,  g@  gD`lü   k`bü   k`Xü   k`Bü   k69  .9  j `4ü   k`ü    kü   N| T &quot;¨  `| õ *  3`|  *|   (|   &amp;C | °  è    `¨    Gù CBNJLßNsHçøøAù à 9  q9  rg  g  d  g  g`0ü   r`&amp;ü   r`ü    rü   N| T &quot;¨  |  *|  (|   &amp;C | °  è    `¨    Gù EàNJLßNsEù  &amp;y  k ÿü#Ê  ,k n ÿý5n 
+ÿþ&amp;y  *k ¹    Xr 2- ^Aü A mA or3Á  LÂí 
+p ÀSAnú0. a  k $y  t 49  ü a   ga Ø&#x27;H @ NuCù  |   a ®z v x p j  ðl  ÈCù  |   ¶m là¸y  PlØºm 
+lÒ  `fa °y  VnÀy  Tk¸Àü r 44  24 Cô  Bù  N09  Nt S@oá`öE  lÔù  L`C  gmçº`èº09  LS@oà`öRESAn¼09  RS@k
+REÔù  L`ò9   Jf ÿ&lt;09  &quot;a ` ÿ.g   ñg R  óg&lt;  ôg  v  õg  Ú  ög  Ü  ÷g  ä  øg  ê  ùg  ê  úg  ò` 9    Xga XáX@ g: $y  Àù  LÔÀáX@ g6 x C` þ 9    Xga Cù  p   ÿg   fé   : $y  Àù  LÔÀ`é    ÿg  mé  6 x C`é  a Þ` þ4áX` þ*áXa bp ` þ(áXa b` þ` þ&quot;y  Xÿý` ýô&quot;y  XÿþXÿÿCù  |   a |` ýÒ9    XgaJ.   f  Ú0- 
+Eo4ù    X3Å  Z3À  ^#Ê  `Eù  Øz Cù  ØÀù  LÅS@nú` ý|¹    X$y  `E  gH| &lt;9  ^ºFl&quot;2Âù  LERFü ÚFÚy  ZÌù  LÔÆ`
+:2Âù  LCù  ØSAnøNu:9  ZNu9    Xg
+E  ga ÿv 6- my  Pkü `v x C` üäa  9    Xga ÿX|&#x27;H @ Eù  Nu&quot;zÌNqü   J`&quot;z¸Nqü    J3À  &quot;Àü (q  r 1 3Á  P^Aü A mA or3Á  Nr 1 3Á  R1 3Á  T1 3Á  VNujü  ül2  òm  óoT`æX`â  ífÜp @ nÀü ÐÀ`Ê   `ÆNuvj&quot;  íg  üo  :`  6C oU`  (   m    n  °f  
+HBf
+HBSfÚ| NuHBSgÆü ÐÃ|Nu2+ AmAÿn
+9    f6Hç p ) n ) °) n Q0  Aù  b0  R) `S) p Lß Nu2+ AmAÿn9    f Hç 8|   |   p 9   f9  Iù  2`TIù  :9     g.)   g)  g)  g`  ¦+  gØÀ9  `9  À  ü    @ &quot;r &amp;y  +ÿÿ gft Eù  b) °) l4  2   fR R`èS @ ) S °) o4  2   fS R`è@ +  ÿÿg+ ÿÿgRü B Lß NuEù  `*Eù  &lt;&amp;y  4Cù  0¹    \¹    Y`Eù  &amp;y  Cù  k ÿü#Ê  ,k n ÿý5n 
+ÿþ*k ¹    Xr - p - 	ÂÀ3Á  &lt;  ÀSnú k $y  t 4ü a ý ga ýP&#x27;H @ NuCù  |   a þ&amp;z v p j  ðlDCù  |   º- lâ¶- 	lÜ  `fa ý¢@ ßnÌ@  mÆ  lR`  mÀR`°g ¾  ñg   óg8  ôg&gt;  õg@  ög  ¤  ÷g  ¤  øg  ¤  ùg  ¤  úg  ¬` ê` ÿ\` ÿT9    Xga Cù  p   ÿg   fé   : `é    ÿg  mé  6 `é  - $y  ÔÅÀÃÔÀa ý` þê` þî` þÚ` þÒ(y  Xÿý` þÂ(y  XÿþXÿÿCù  |   a üÄ` þ 9    XgaR+  
+gù    YÅ  \ù    X3Å  Zp - Elp 3À  ^#Ê  `Eù  Øz .   f  ¼` þB¹    X$y  `E  g4| &lt;9  ^ºFl2ERFü ÔÆÚFÚy  Z`:2Iù  ØÜSAnúNu:9  ZNu9    Xg
+E  g(a ÿv - 	gSCü p - $y  ÔÅÀÃÔÀ` ýºv - 	gSCü p - (y  Øù  ZÀÃØÀ#Ì  `` ýa  n  õg ý9    Xga ÿ2|&#x27;H @ 4. $zæNqÄü 2   f2 r  0Eð   Vf&quot; Ff Of Nf Tf
+&amp;y  a èNujü  ülN  òm  õg,  óoT`àX`Ü  ífÖp @ nÀü ÐÀ`Ä   `Àp   ÿg²°Cg®W&lt; õNuEù  &amp;y  k ÿü,k n ÿý5n 
+ÿþ*k rPp0ÀSAnú k Eù  t 49  ü a ùæ ga ù&#x27;H @ Nuz (&lt;0000ü    ²v p j  ðl  ` nì  ,g:  0mà  9o  Dg  dfÎRCC nü   ²`¼RCC ná `®S9   ²fá&lt; Dà$ÄR`g     ñg    óg&lt;  ôg  B  õg  B  ög  B  ÷g  B  øg  B  ùg  B  úg  F`  Z` ÿ&lt;` ÿ4` ÿ,` ÿ$` ÿ` ÿØ  ` ÿØ  Ø  ` þø` þô` þð9   ²fá&lt; Dà$ÄR|&#x27;H @ Eù  Nu 9  ë  
+    g2Cú~Nq i a  À   g#È  ü   ~9    ,g«  
+Nu 9   ë  
+    g*Cú6Nq i a  x   g#È  9    ,g«  
+Nu 9   ë  
+    g*CúöNq i a8   g#È  9    ,g «  
+`CúÌNq i #È  ü    ~Nurx &quot;H ûgV ògZ ýg   íg\ þg4  m nvRjü ûoP üg^ ýg` þfZ²gnn\R`¨²lTR` r á`ááá`v  n$Æü ÐÃ`¦ òm  óoT`X`` ÿtRRDD dmAúþNq&quot;h p  INu Iü ü    ,a öÐ  üo  gÝy  &amp;ü   ,a öt  þfØp INu:9  E  g,2 KpIú ìNq´g
+S@fø$H6`$ Jf PRSAfØNupIú ÂNq´gS@føRSAfè:&gt;A`&quot; Lf `
+ Jf P&gt;AR&amp;HSA:2 JpIú Nq´g&amp;S@føSAfêpIú ~Nq2 J´gSAføS@fî` ÿTASA,HG  g J 0m
+ Zn PRSGfèA  g ÿ&amp; N 0m
+ Zn RSAfè` ÿ !%&#x27;+,-./1:;IJLT_MNVWXYZRKBDPGSAQOUCHEF3245697809    Ng` n9  J9  LR9  8y    6y À  6n9  8gÞ` Ô3ü    6 y  B&quot;y  FSy  4y    4m8 !9   8frÿ`±gÚ#È  B#É  FÀ  JÁ  Lü    8`3ü   4 y  :&quot;y  &gt;ØRy  R09  T°y  Ro  Zy  2y   2nhp r 9   8g² gÂ#È  :#É  &gt;$y  B°y  Hny  Flp Àü 42  Aò ²y  Hny  Flr Âü 42 Cò ` ÿ&amp;3ü    2y   0y   0n` ÿ|3ü    23ü    03ü    R`  Xa 
+3ü    63ü   43ü    23ü    R3ü    009  02 Ãü 3Á  .Aù  &lt;Eù  ¸Áü Cò  ` ÿ
+3ü    .ü    8Aù à | T &quot;|   &amp;|   (| ð *| °  è    ¨  Nu g0&lt;@ `0&lt;  Ðy  .Ðy  0Ðy  2Ðy  4Ðy  6ü    NAù à  |   &amp;|   (| ú *| °  è  è    Nu9    Ng` n9  J9  LR9  8y    6y    6m9  8gÞ` Ô3ü À  6 y  B&quot;y  FRy  4y   4n8 !9   8frÿ`±gÚ#È  B#É  FÀ  JÁ  Lü    8`3ü    4 y  :&quot;y  &gt;ØRy  R09  T°y  Ro  [y  2y    2mhp r 9   8g² gÂ#È  :#É  &gt;$y  B°y  Hny  Flp Àü 42  Aò ²y  Hny  Flr Âü 42 Cò ` ÿ&amp;3ü   2y   0y    0m` ÿ|3ü   23ü   03ü    R`  Xa 
+¤3ü À  63ü    43ü   23ü    R3ü   009  02 Ãü 3Á  .Aù  &lt;Eù  ¸Áü Cò  ` ÿ
+3ü    .ü    8Aù à | T &quot;|   &amp;|   (| ð *| °  è    ¨  Nu g0&lt;@ `0&lt;  Ðy  .Ðy  0Ðy  2Ðy  4Ðy  6ü    NAù à  |   &amp;|   (| ú *| °  è  è    Nu9    Ng` v09  J29  LR9  8y   6y p  6n9  8gÞ` Ü3ü    6 y  B&quot;y  FRy  4y   4n8029   8frÿ`±AgÚ#È  B#É  F3À  J3Á  Lü    8`3ü    4 y  :&quot;y  &gt;ØRy  R09  T°y  Ro  ¨y   2y  2nhp r 9   8g² gÀ#È  :#É  &gt;$y  B°y  Hny  Flp Àü 42  Aò  ²y  Hny  Flr Âü 42 Cò  ` ÿ$3ü    23ü    Ry   0y   0nAù  &lt;` ÿn3ü    23ü    0`  Xa &amp;3ü    63ü    43ü    23ü    R3ü    009  02 Ãü 3Á  .Aù  &lt;Eù  ¸Áü Cò  ` ÿ3ü   .ü    8Aù à | T &quot;|   &amp;|   (| ð *| °  è    ¨  Nu g0&lt;@ `0&lt;  Ðy  .Ðy  0Ðy  2Ðy  4Ðy  6ü    NAù à  |   &amp;|   (| ú *| °  è  è    Nu9    Ng` v09  J29  LR9  8y   6y    6m9  8gÞ` Ü3ü h  6 y  B&quot;y  FSy  4y    4m8029   8frÿ`±AgÚ#È  B#É  F3À  J3Á  Lü    8`3ü   4 y  :&quot;y  &gt;ØRy  R09  T°y  Ro  ¨y   2y    2mhp r 9   8g² gÀ#È  :#É  &gt;$y  B°y  Hny  Flp Àü 42  Aò  ²y  Hny  Flr Âü 42 Cò  ` ÿ$3ü  23ü    Ry   0y   0nAù  &lt;` ÿn3ü  23ü    0`  Xa ¨3ü h  63ü   43ü  23ü    R3ü    009  02 Ãü 3Á  .Aù  &lt;Eù  ¸Áü Cò  ` ÿ3ü   .ü    8Aù à | T &quot;|   &amp;|   (| ð *| °  è    ¨  Nu g0&lt;@ `0&lt;  Ðy  .Ðy  0Ðy  2Ðy  4Ðy  6ü    NAù à  |   &amp;|   (| ú *| °  è  è    Nu9    Nf R9  j  3Aù à C ü    N|   &amp;|   (| õ *| °  è    r v ü    k9   lf
+Ã Ã  `Ã Ã 9  V9  W49  X&quot;y  ZR o&gt;r 49  XRB´y  ^mt R   fp `  opÀ  V3Â  Xa ¨#É  ZÁ  W1 fÃ r 9  `9  a49  b&quot;y  dR   fp `B  o&lt;pR o,r 49  bRB´y  hm
+t ü   k3Â  ba 6#É  dÁ  aÀ  `1 fÃ Ã  jNua Pv z Kù  :m nºy  0gü   l`Aù à | T &quot;`  ¨ü    l y  4p (h , 3À  ^3À  hr Á  Wt 3Â  Xa   #É  ZpÀ  V1 fÃ pÀ  `r Á  at 3Â  ba  l#É  d1 fÃ Ã  jËü E@ 3Å  .E Aù à  è  ü   kü    N|   &amp;|   (|  *| °  è    NuKù  &lt;x 5  ¸y  Hny  Flx Èü $y  B&lt;2@ Cò` Nu9    Nf  Ò9  qÃ    Aù à C ü    N|   &amp;|  (|  *| °  è    r ü    r  9  m9  n9  o9  pS k  g`,p`(RAA m
+r ü   ra JÁ  nÂ  oÄ  pÀ  mf `Ã  ff `Ã Ã  qNu&amp;y  4+   
+g«   
+ù   -a ¹   -v z Aù à Kù  :m2 n,ºy  0g4 9    Yg9    \gÃ `Ã `ü   r| T &quot;``Ã r Á  na  zÂ  oÄ  ppÀ  mgÃ  fgÃ Ã  qC Ëü E@  è  ü   rü    N|   &amp;|  (|  *| °  è    NuKù  &lt;5  `m  `ô 0ftO²9  \mx `Nu&amp;y  4p (k , 3À  T(k 0, &quot;zÖNqÀü #ñ    Br 1 3Á  F1 3Á  H+  
+g  ü9   -f ²«  
+a Ï ¹   |   3ü    &amp;9   Øgü    ~p (k , 	fjt 49  09   ØfJ9   Øfa íê   g:`p#À   a î   g&amp;ù   t 49  0a íty    &amp;n$p`p`
+pü    ~#À   t 49  0a íÎ&#x27;y   &#x27;y   |   |  ü   8y   &amp;f«  
+9    -f  ¸+ þ f  &quot;k +  
+g+  
+f  À&#x27;y   `V+  
+g&#x27;k  |  |   `:+  
+g«  
+&#x27;y   )   fd`,ë  
+&#x27;k  |  |   `
++  
+g  
+)   f6a æÌ&amp;y  4  g ÿ^9  9@ +  `Tü   \ù    Y`ü    \¹    Y|   Aù  &lt;,k 1n 
+ÿþ. @ÿý@ r ¼   RAA mòNu y  |   Gù 6NJNu y  (   l
+R Gù 6`p è   
+Gù F@ NJNu y  |   Gù 2NJNu y  (   l
+R Gù 2`p è   
+Gù F@ NJNu</td></tr>
+<tr><td>7</td><td>(Eh1015-0.lod)</td><td> !ä   Hç§  !ã                                                EH1015-0.LOD  03-18-98 ISCU NEXTSTOP SYSTEM WITH J1708 INTFC. 
+                                                              
+                                                              
+                                                              
+                                                              
+                                                              
+                                                              
+Hç &lt;(| (*| ²¡.|   #ü    zt y ztB( 
+ y zt|  N¹ !øB9 ·lp&lt;#À ¶p&lt;#À ±¬N¹  Hp$@&amp;|  ).$ü  )F$Ë$Ë$Ë$Ë$Ë$Ë$Ë$Ë$p&lt;$@$p`$@$Ë$Ë$Ë$Ë$Ë$Ë$Ë$B9 ² ¼ (¼ 0  TNqNqNqNqNqNqJB9  ² gNù  þB9 ² ¼ (¼    TNqNqNqNqNqNqJB9  ² fB9 µÖ`ü   µÖN¹  Ä y z|(   9À ¾P|øÿt $| !Ü¤`/N¹ !XXRJfî`þLß&lt;NuNVÿü/
+$| zt$¼   #Ò z rÐ#À zHy !j¦Hx @N¹ !8P R| @  R| ±  R| -  RB(  Rh ÿÿ | ü  vÇ Ry vÇ 
+|øÿ$_N^NuHç 0&amp;| z|&amp;¼   #Ó z rÐ#À zB9 ² ü  ²¡$Sp	ÕÀNqNqNqNqNqNqJB9 ²¡J9 ² f  JHy !jÆHx AN¹ !8P S| A  S| ð  S| á  SB(  | B9 vÉ Sy vÉ 
+|øÿLßNu o | &quot; | 8 | @ |  ¯ o  o  Nu/
+$| |* 1 $f  Ôp&lt;R°n  ÊBp&lt;Rª °ª n  ¶Bª pRª °ª n  ¤Bª Rª pRª °ª nBª  * r°b`Ð0;Nû   (              p Rª `*pRª `&quot;pRª °ª n&quot; 
+rÐ/ N¹  X   °ª np%@ p°ª fpRª °ª nBª Bª Rª pY`pN$_Nu/ o $  l rN¹ !« Jf( rdN¹ !« Jf &quot;&lt;  N¹ !« Jfp`p`p $NuNVÿàHç8&lt;&amp;| !8(| z´*| p-@ÿàp-@ÿäp-@ÿèp-@ÿìp	-@ÿðp
+-@ÿôp-@ÿøB®ÿüN¹ !`#À zxg&amp;Hx 
+B§Hx &lt;/9 zxN¹ !/9 zxN¹ !fOï #ü   y|/9 y|N¹  (öXJ f$N¹ !`$@ 
+gHx Hx &lt;Hx &lt;/
+N¹ !Oï $| y¼5| 
+ %| !Ä  %| º4 Hx Hx /
+Hx N¹ !
+Hy º4N¹  (x&amp;    þd$p 9 ²%°bp 9 ²&#x27;°dp 9 ²°fB9 t`Ã tü » µD$| ¼5|  | A p%@ Hx Hx /
+Hx N¹ !
+Oï $$j  
+g  ` 0e 9c üfì þfæ ýfà 1f  2f
+ü f µD`P 9fJü Ì µD`@ 2f¼ 4g4ü  µD`* 4f 8fü  µD` 9f 6fü » µD9 µD/ Hx &#x27;Hx /9 za üOï  |  9   vÇ y zty vÇ 
+|øÿ |  y zt(  HÀ   .np.#À t¨ (  y z|  B¹ vÀ|øÿ#ü ½6 z #ü ½ z°Hx N¹ !pHx N¹ !Hx N¹ !Hx 
+N¹ !pOï B9 y#ü ½ z°ü E vîü E w4ü E w6HnÿàN¹ !JX&amp; p°fHy vîHy  Hy ¾üN¹  Oï `Îp°fHy w4Hy Hy ¿N¹  Oï `ªp°fHy w6Hy Hy ¿,N¹  Oï `p	°fHJ¹ zxg,/9 zxN¹ !fX`Hy !Ä
+Hx NHy !ÄHx NOï 9  ´ÌgÚN¹  Z` ÿ:p°f Êp 9 z´r:°gDr@°g  r#°g  Ør!°g &amp;rd°g Pre°g rb°g °ru°g àrg°g ` JJ¹ zxg4B§Hx &lt;/9 zxN¹ !êOï `Hy !ÄHx NHy !ÄHx NOï 9  ´ÌgÚB` þ9  ´Ìf /Hx NP Yg6Hy !ÄHx NP`&amp; Yg/Hx NHy !ÄHx NOï ü Y z­B` þ&gt;9  ´Ìf /Hx NP Yg6Hy !ÄHx NP`&amp; Yg/Hx NHy !ÄHx NOï ü N z­B` ýèJ9 ´Ìf$ Yg/Hx NHy !ÄHx NOï t` ý¼B` ý¶J9 ´Ìf* f$ Yg/Hx NHy !ÄHx NOï t` ýB` ý~J9 ´Ìf* f$ Yg/Hx NHy !ÄHx NOï t` ýLB` ýFJ9 ´Ìf* f$ Yg/Hx NHy !Ä Hx NOï t` ýB` ýJ9 ´Ìf* f$ Yg/Hx NHy !Ä&quot;Hx NOï t` üÜB` üÖJ9 ´Ìf0 f* Yg/Hx NHy !Ä$Hx NOï BN¹ !dæ` üB` ü9  ´Ìf/Hx NP YgHy !Ä&amp;Hx NPB` üjp
+°f9 G yf üXü S y` üLp°f y y|    f ü2N¹  ).` ü(ü J y` üLî&lt;ÿÄN^NuNVÿìHç&gt;&lt;&amp;n *n $K n (P r²m SB`ÔµÌcúJg  ¼ ENq` t$Kp   ¼g ro°g ` Rp   ÿg2J g ¦  g è  Àg 2  êg f  ïg Î  óg V` P|N` Vp   õg2  üg ^J g &gt;r°g Êr°g   g N  Àg v`  ÿp rD°g&quot;rP°g`rR°g  rE°g  ÈrN°g  ö`  ðN¹  ö$ pÐÄ/9 ² / 9 ²/ 9 ±+/ p / /
+N¹  Oï  p ÕÀ`  ®N¹  ö$ pÝÄ/9 µØ/ 9 µ×/ 9 µÛ/ p / /
+N¹  Oï  p ÕÀ`jN¹  ö$ pÑÄ/ 9 ²/ p / /
+N¹  VOï  p ÕÀ`6N¹  ö$  Tfpp×`pÕÄ/B§B§B§B§/
+N¹  Oï  `$L Yf î` è&amp;JB`
+S *gRJfò9 E ÁfFN¹  ö$ pÐÄJg6ü Y y/9 ² / 9 ²/ 9 ±+/ p / /N¹  Oï  p ÕÀ Yf t` n ½f f&amp;| | C | W y t |  Hx Hx /Hx N¹ !
+Oï N¹  ).` $ ½f &amp;| | W | W y t |  Hx Hx /Hx N¹ !
+Oï N¹  ).` Ú ½f Ðp   õf Ä| ÿúHnÿúHx N¹ !bP` ªZÿþ.ÿþ  f  ¦ü N &quot;Â &quot;B9 &quot;p .ÿþè  À &quot;Ú &quot;#ü {  &quot;  e cü Y &quot;B` ýJ9 &quot;fü Y &quot;9 ß &quot;b
+9  &quot;bü Y &quot; y &quot; R¹ &quot;  y &quot; R¹ &quot; ¹ &quot;`   e cü Y &quot;B` þ´9 &quot;gü Y &quot;p .ÿþè   r 9 &quot;°gü Y &quot;p R9 &quot;9 &quot;.ÿþ   °g*ü Y &quot;`  9 &quot;  |b y &quot; R¹ &quot; `R SJ fØp 9 &quot;.ÿþ   °f&lt; 9 &quot;  { r 9 &quot;T°gü Y &quot;9 N &quot;f$| { (y &quot; `$LµÌe û¨ Yf êHx %N¹ !*X` Úp   êg
+  óg` Ä| ÿúHnÿúHx N¹ !bP` ª| ÿúHnÿúHx N¹ !bP`  ½f p   êg
+  óg` r| ÿúHnÿúHx N¹ !bP` X| ÿúHnÿúHx N¹ !bP` &gt;Zÿþ.ÿþ  f  ¦ü N &quot;Â &quot;B9 &quot;p .ÿþè  À &quot;Ú &quot;#ü {  &quot;  e cü Y &quot;B` ýJ9 &quot;fü Y &quot;9 ï &quot;b
+9  &quot;bü Y &quot; y &quot; R¹ &quot;  y &quot; R¹ &quot; ¹ &quot;`   e cü Y &quot;B` þ´9 &quot;gü Y &quot;p .ÿþè   r 9 &quot;°gü Y &quot;p R9 &quot;9 &quot;.ÿþ   °g*ü Y &quot;`  9 &quot;  |b y &quot; R¹ &quot; `R SJ fØp 9 &quot;.ÿþ   °f  Ð 9 &quot;  { r 9 &quot;T°gü Y &quot;9 N &quot;f  ¢$| { (y &quot; `   g 
+fxZÿùZÿøZÿ÷ZÿöY .ÿöN¹ !³Ì/&lt;57½N¹ !²ú-_ÿòZÿùZÿøZÿ÷ZÿöY .ÿöN¹ !³Ì/&lt;57½N¹ !²ú-_ÿî&amp;| ·@|  &amp;®ÿò&#x27;nÿî B+ B9 z`p ÕÀ`$LµÌe øp`  Àü N &quot;#ü !Ä( &quot; ` y &quot; R¹ &quot; °g
+ü Y &quot;`µÌcà9 N &quot;f   rÐ°f  tü Y µL | ü S yü S yx|øÿ`Pp fDp   êg  óg`2| ÿúHnÿúHx N¹ !bP`| ÿúHnÿúHx N¹ !bP`$LµÌe°¼ ELî&lt;|ÿÈN^NuNVÿôHç&lt;&lt;&amp;|  (| ±*Kîÿö$| µà%| ½ %| µt Aîÿõ%H %| , %| $ &quot;%| % &amp;|  *|  +Bj ,Bj .B* 0B* 15|  Hx Hx /
+Hx N¹ !
+Oï $| µtJ9 %f üp áHr ÐAf ì°9 ²f Þp 9 z¬r 9 ²%&quot; ÐÐÐ | ºÂ$0 p  | µxAð  $Hp Sr°b Ð0;Nû  &amp; D  È
+:TúVvpp×Ä/B§B§B§B§/
+NOï ` DpÝÄp 9 °«À/9 µØ/ 9 µ×/ 9 µÛ/ p 9 °«/ /
+NOï ü N ³d` þpÐÄp 9 tÀ/9 ² / 9 ²/ 9 ±+/ p 9 t/ /
+NOï ` ÀppÑÄp 9 vÜÀ/9 ²&amp;/ 9 ²$/ 9 °ô/ p 9 vÜ/ /
+NOï ` ~pÑÄp À/ 9 ²/ p 9 °ª/ /
+N¹  VOï ` NpÕÄ/B§B§B§B§/
+NOï ` 4  g6xp 9 ²$r 9 ²%&quot; ÐÐÐ | ºÀÑÀ$H9 vÜ9 vÜ`4xp 9 ²r 9 ²%&quot; ÐÐÐ | ºÀÑÀ$H9 t9 t gx/* /9 µ /
+N¹ !·N/ / /
+/ N¹  ZOï `  p 9 µ×r 9 ²%&quot; ÐÐÐ | ºÀÑÀ$H/* /9 µ /
+N¹ !·N9 °«9 °«/ / /
+Hx N¹  ZOï `09 °ª/ B§Hy ¾ðHx N¹  ZOï `Hy    B§N¹  ÔPHx %N¹ !*Lî&lt;&lt;ÿÔN^NuHç  $| | R y z¬ Hx Hx /
+Hx N¹ !
+p *  @B2 
+rÐ/ N¹  (xOï $ LßNuHç  $| x| R y z¬ Hx Hx /
+Hx N¹ !
+p *  @B2 
+rÐ/ N¹  (xOï $ LßNuNVÿðHç?&lt;(. .. &amp;n Kîÿð(| |NJg  ðzY$M`  g 0f
+ YfS`zNÃSJfÞJf¼ 0x| R G Hx Hx /Hx N¹ !
+Oï , $LpÕÀRS9  ²fRSp °g|Y`&amp;M`°g|Y`SJfð YfV$LpÕÀî R9  ²fü HR&amp;M`ÛSJfø| P G Cn  DD Hx Hx /Hx N¹ !
+Oï | R y z¬ Hx Hx /Hx N¹ !
+p ,  @B4 rÐ/ N¹  (xOï ( ¸® gT/. Hy !Ä6/
+N¹ !·N( &amp;M$LpÕÀB`ÛRp °fô| W y z¬ D Hx Hx /Hx N¹ !
+|YLî&lt;üÿÈN^NuHç?&lt;&amp;/ 0*/ 8,/ 4*o ,//
+N¹  äP  Yf
+*| !Ä:  ~Y$M`  g
+ 0g~N`fì(|  YfF | E `|(| xN| R F Hx Hx /Hx N¹ !
+Oï , &amp;Lp×Àp °gxY`$M`°gxY`SJfð Yf:C $M&amp;Lp×À`Ú SJföF | W Hx Hx /Hx N¹ !
+Oï | R y z¬ Hx Hx /Hx N¹ !
+p ,  @B4 rÐ/ N¹  (xOï $ p °gFp / Hy !Ä&lt; rÐ/ N¹ !·N@ y z¬ | W Hx Hx /Hx N¹ !
+Oï xYLß&lt;üNuNVÿÜHç&gt;0&quot;n Gîÿò(. ` ae zb
+  àÀ`ÃSJfàü  R® BCîÿòGîÿèB®ÿü(. `*EîÿèzNt `
+¶fzY`R´®ÿüeð NfÃR®ÿüSJfÒB$| !ä&quot;j $`  ÔRGîÿÞ| xNzU`b Uf é	zL`P 9c_   zUp°c8ÁRp°f.Eîÿèt `
+²fxY`R´®ÿüeð Nf üg þfò` üg þf YfNx Aîÿò`&lt;GîÿÞ R$@zYt `  g
+`R  gø°gzN`R´eà Yf`R . °dº ýf ÿ(pNLî|ÿÀN^NuNVÿð/&quot;.  .  n CîÿðBBî ù ² `ü  SJfö`ØSJfø9 ±* `ü  SJföt9 ±*`BSJføHnÿðB§N¹  Ô$.ÿìN^NuHç 0$/ &amp;o $| µàü  $3Â ,B9 Ø%| µ¤ %K %| Ø %| , %| $ &quot;Bj Hx Hx /
+Hx N¹ !
+Hx N¹ !Oï #ü µ¤ z | ü G yx9 Y f y z|  ` y z|   y zt|  |øÿHx N¹ !pXLßNuNVÿôHç&lt;&lt;(. *. *n  e  b  þp-@ÿôp-@ÿøB®ÿüHx N¹ !Hx N¹ !P&amp;| ¿hp Aó S(H$K`ÝµÌcúJgp°dxBv #Ë z#Ì vÌ#Ë z¼Å Â² ÐÐé   ò#À v¸ | ü R yx y z|   y zt|  |øÿHnÿôN¹ !JX&amp; p°f.R g e( b&quot;N¹ !·   T( 9 S ygp°f ÿd y zt|  Lî&lt;&lt;ÿÔN^NuHç0 &quot;/  o Bv`ÔR¶møB Lß Nu/$/ &quot;/  o ü ½ü ÿü õR Àï ü %JgÁ  0Àï ü ÿB$NuNVÿðHç&gt;&lt;p-@ÿôp-@ÿøB®ÿüp 09 ô   r°bHÐ0;Nû    ( 4   ( 4#ü !Ä@ µ `&quot;#ü !ÄD µ `#ü !ÄH µ `
+#ü !ÄN µ Hx N¹ !*Hx N¹ !*Hx N¹ !*Oï ü D {ü T xNzN |  9  vÇ y zty vÇ 
+|øÿ y ztJ( 	 | ü N vÔB9 vÈü J yü I yx|øÿ$| }¸| R y t Hx Hx /
+Hx N¹ !
+| ÿðJ* g * W f| Äÿñ`* C f| Áÿñ`| ÐÿñHnÿðHx N¹ !b| E y t Hx Hx /
+Hx N¹ !
+Oï (ü N y*| |ó(| }HnÿôN¹ !JX$ p°f|1$| |ø&amp;| }`  Þ|2$| |T&amp;| |ò`  ÌHy zHx N¹ !äP9 z 
+fü 
+ÂxNvN`  ¦ 
+f9  ´ÌfÂü 
+xNvN`   &gt;f9  ´ÌfvYxN`h  f Yf9  ´ÌfÂxNvN`R &lt;f9  ´ÌfxNvN`&lt; fxYzN`&amp; [fzY` Kf Yf YfÂxNvN`xNvNÂµËe ÿ2BHx N¹ !pX 1fÆ {#ü |ø {#Ì `Æ {#ü |T {#Í  | 9 Y f y z|  ` y z|   y zt|  |øÿ` þ|Lî&lt;|ÿÌN^NuNVÿØHç0&lt;9 
+ ²fvu`vX*| ·HIîÿþGîÿýHnÿüHx N¹ !äPp .ÿüSr°bâÐ0;Nû  ö*jªHa ô$   g*/ 9 vÜ/ Hx 0Hx DHnÿØa üOï p 9 ²$`(/ 9 t/ Hx 0Hx DHnÿØa ûâOï p 9 ²r 9 ²%&quot; ÐÐÐ | ºÂ$0 /HnÿØHnÿäN¹ !·N$ /Hnÿäa ûxHx / Hnÿäa ú&gt;Oï  / 9 °«/ Hx 0Hx PHnÿØa ûnp 9 µ×r 9 ²%&quot; ÐÐÐ | ºÂ$0 /HnÿØHnÿäN¹ !·N$ /Hnÿäa ûOï (Hx / Hnÿäa ùÊ$| x| R y ² Hx Hx /
+Hx N¹ !
+p *  @B2Hx s9 °ª/ Hx -Hx RHnÿØa úÊOï 0 
+rÐ/ HnÿØHnÿäN¹ !·N$ /Hnÿäa ú~Hx / Hnÿäa ùDOï  a òä$  gHx Hx Hy !ÄTa ù&quot;Oï ` ýþHx Hx Hy !Ä\a ùOï ` ýäHx Hx Hy !Äda øîOï ` ýÊHx Hx Hy !Äza øÔOï ` ý°p / p / Hy !ÄHnÿäN¹ !·N$ /Hnÿäa ùÎHx / Hnÿäa øOï $` ýpHx B§N¹ !ÞHx Hx Hy !Äa ønOï ` ýJHx Hx Hy !Ä¦a øTOï ` ý0p / Hy !Ä®HnÿäN¹ !·N$ /Hnÿäa ùTHx / Hnÿäa øOï  9 vÈ   f   | ü S yü S yx|øÿ`   | ü J yü I yx|øÿ9 Y gü N Hx 
+N¹ !*XNù  $9 E ÁgNù  $Hx B§N¹ !ÞHx Hx Hy !Ä¶a ÷Oï Nù  $Hx B§N¹ !ÞHx Hx Hy !Ä¼a ÷XOï 9  z`e
+¼ 
+Nù  $R9 z`Nù  $Lî&lt;ÿÀN^Nu/ o t  HffR`&gt; 0e 9b é$    `  Ae Fb é$       	Ôf¾`&quot; 0e 9b åÔÔ   ÔfÞ $NuHç  $o B9 ² ü  ²¡NqNqNqNqNqNqJB9 ²¡9 ² LßNu | `þNuHçÀÀ | `þLßNsHçÀÀJ9 ²¡f   | `þü  ² ßü   LßNsNVÿüHç &lt;Kîÿý@À=@ÿþ(y z|&amp;y z$y z, Ä9 vÉ   ÿ g   | NqFîÿþ  g  &amp; |  y {R¹ {f|  `U Fîÿþ g  ¨ | «  y zR¹ zR9 t|9 t|°9 ´Æd 9 z°¹ zhej|   y zB#ü t ÀÐJ9 º?fJ#ü ·\ z` y z y ÀÐR¹ ÀÐR¹ z y zJfÚ y ÀÐB y yHX¹ yHp) Fîÿþ g  F |  y zÀR¹ zÀ 9 zÀ°¹ cU  y yHX¹ yHp8 |  `U Fîÿþ g  | ª  ðJg| @ ª `  äª 9  ¸f  ¨ f
+B9 ¸`  ¨ fpJ9 vÆfVü  vÆ#ü ÂX t¤B$| ¶`` y t¤R¹ t¤R 9 zl ¶`   ÿr °nÖ y yHX¹ yHp7 #ü ¶` zlB9 ¸`V#ü ¶` zlB9 ¸ y zlR¹ zl`6 f
+ü  ¸`&amp; y zlR¹ zl 9 zl°¹ z¤e
+#ü ¶` zlFîÿþB§/. N¹ !hLî&lt;ÿèN^NuNV  @Â$y zt&amp;| yH* 
+Æ9 vÇ g â | * 
+ HÀ,   -  * N¹ !Ô|  |  R9 ·l9  ·le  ¤B9 ·lN¹    Yf Sp4 À&amp; | |( 1 $gS¹ ±¬n,#ù ¶ ±¬` | | &quot;9 ¶N¹ !« Jf Sp* À&amp;9  µGf&lt; | ¯l0ü!cü  #ü ¯l {#ü ·\ zü 
+ ´ÆB9 t| y z|  R9 }¨9  }¨cHü  }¨ y z|(   9°9 ¾Pg*R9 }¡9  }¡eB9 }¡À ¾PB9 }¨ Sp: À&amp;9  ¿ÊfvR9 ·&lt;9  ·&lt;cfB9 ¿ÊB9 ·|B9 ¹B9 ·}B9 ¹B9 ·~B9 ¹B9 ·B9 ¹B9 ·B9 ¹B9 ·B9 ¹B9 ·B9 ¹B9 ·B9 ¹9  ´ÌfR9 yfN¹  ).B9 y 9 t¨Ð¹ vÀ&quot;9 vÀ  l    - #Á vÀ`* ü N vÔ#ü  -  vÀ  ¶c  º 9 z° ½   m  ¤9 Y yg  9 E vîfü F vîp(| ¾ü*|  `B9 E w4fü F w4p(| ¿*| ` 9 E w6fHü F w6p(| ¿,*|  | ½&quot;L&quot;Ø&quot;Ø&quot;Ø&quot;Ø&quot;Ø&quot;Øü Y y y z°ü ½ÑÌ* S À&amp;FÂ  g  . |  y z¨#È z¨@   
+f Sp À&amp;|  FÂ g  8 |  y z¸* À#È z¸  
+g±ù zdeB Sp À&amp;|  FÂ g &amp; | 9 R yxg9 B yxg  Î` î*   f ü9 Y vÔg ð*   gü Y vÔ` Ú* 
+ HÀ,    .n$  -  * N¹ !Ô|  |  `  
+ *  9 t¨Ð¹ vÀ&quot;9 vÀ  l    - #Á vÀ`
+#ü  -  vÀ°¹ v¸m Z y z*  gü Y vÔ` &gt; y z±ù vÌb  ®A R#È z9 R yxf 9 vÇ  ß@ 
+À vÇü B yx` ö*   g ì*  y z¼°f&amp;#È z¼9  Â²9 T f Äü Y ` ¸|  9 vÇ    @ 
+À vÇ Sp À&amp;ü I yxü J y` |  9 vÇ    @ 
+À vÇ¹ ¿h z¼f
+9 T gü I yxü V y` &gt; Sp À&amp;ü N ü S yxü S y` 9 G yxfP y z   g#È z@ `  ô9 Y f
+*  g  à Sp À&amp;ü S yx| 	 |  `  À9 P yxfR 9 ±°°¹ ye2 y ±°X #È ±° Sp À&amp;ü S yx9 D {f||  `t y ±°X #È ±°`b y {   g±ù n#È {@ `@9 Y f*  g. S9 1 {fp`p Àp À&amp;ü D {| 	 |  FÂ g  | 9 J yf p* * ü N vÔ* 
+ HÀ,    .n&amp;  - *  * N¹ !Ô|  |  `  *  *  9 t¨Ð¹ vÀ#Å t¨B¹ vÀ  Ûc  Ô 9 z° ½   m  ¤9 Y yg  9 E vîfü F vîp(| ¾ü*|  `B9 E w4fü F w4p(| ¿*| ` 9 E w6fHü F w6p(| ¿,*|  | ½&quot;L&quot;Ø&quot;Ø&quot;Ø&quot;Ø&quot;Ø&quot;Øü Y y y z°ü ½ÑÌ* S À&amp; | ½Ä#È z°ü N y` &amp; y z°  ½   b  
+Ä#È z°` 9 V yfJ* 9 vÈ*  y z¼°f#È z¼9  Â²f  Îp`  p S À&amp;ü J y|  `  ®9 G yfN*   :f | ½À#È z°`   y z°À#È z°  
+g
+±ù z e  jB Sp	 À&amp;ü S y`Tê  z´9 : z´f | ½ù z´#È z°ü G y&lt; Np&quot;| vð S`
+°f&lt; Y`³Èeò Nf À&amp;FÂB§/. N¹ !hN^NuNVÿìHç8&lt;*|  AÀvNB(| ¹¤&amp;| °¬Hy !ÄÂN¹  BÀ ±+Hy !ÄÈN¹  BÀ °ôHy !ÄÎN¹  BÀ µÛHy !ÄÔN¹  BÀ ²HHy !ÄÚN¹  BÀ µEHy !ÄàNÀ ²%Hy !ÄæNOï À ²&#x27;J9 ²%g À9 ²&#x27;°9 ²%e °9 ÿ ²&#x27;g ¤p 9 ²&#x27;r 9 ²%r&lt;²o Hy !ÄìNÀ ²Hy !ÄòNPÀ ²J9 ²g PJ9 ²g F9 ²°9 ²e 4B$| ¶@R¹ ² LTy ² Hy !ÄøNÀ ²Hy !ÄþNÀ ² J9 ²g.J9 ² g&amp;9 ² °9 ²eR¹ ² JTy ²  `vYHy !ÅNÀ ²$Hy !Å
+NÀ ²&amp;J9 ²$g.J9 ²&amp;g&amp;9 ²&amp;°9 ²$eR¹ ²$ JTy ²&amp; `vYHy !ÅNÀ µ×Hy !ÅNÀ µØJ9 µ×g.J9 µØg&amp;9 µØ°9 µ×eR¹ µ× JTy µØ `vYHy !ÅNÀ ±çHy !Å&quot;NÀ ±þJ9 ±çg.J9 ±þg&amp;9 ±þ°9 ±çeR¹ ±ç JTy ±þ `vYHy !Å(NÀ ²GHy !Å.NÀ ²PJ9 ²Gg.J9 ²Pg&amp;9 ²P°9 ²GeR¹ ²G JTy ²P `vYHy !Å4NÀ ´ÇHy !Å:NOï 0À ´J9 ´Çg*J9 ´g&quot;9 ´°9 ´ÇeR¹ ´Çy ´ `vY/ 9 ²/ 9 ²/ Hy ¶@N¹  CvOï   YfvYHy !Å@NÀ ²QHy !ÅFNPÀ ²FJ9 ²Qg ¨J9 ²Fg 9 ²F°9 ²Qe B$| ¶@R¹ ²Q LTy ²F Hy !ÅLNÀ ±ÿHy !ÅRNÀ ±æJ9 ±ÿg.J9 ±æg&amp;9 ±æ°9 ±ÿeR¹ ±ÿ JTy ±æ `vYHy !ÅXNÀ ÂUHy !Å`NÀ ÂJ9 ÂUg.J9 Âg&amp;9 Â°9 ÂUeR¹ ÂU JTy Â `vYHy !ÅhNÀ ²(Hy !ÅnNÀ ²&quot;J9 ²(g.J9 ²&quot;g&amp;9 ²&quot;°9 ²(eR¹ ²( JTy ²&quot; `vYHy !ÅtNÀ ²Hy !ÅzNÀ ²J9 ²g*J9 ²g&quot;9 ²°9 ²eR¹ ²y ² `vY/ 9 ²F/ 9 ²Q/ Hy ¶@N¹  CvOï 0  YfvYHy !ÅNÀ µIHy !ÅNPÀ µFJ9 µIg J9 µFg  ú9 µF°9 µIe  èB$| ¶@R¹ µI LTy µF Hy !ÅNÀ µeHy !ÅNÀ µdJ9 µeg.J9 µdg&amp;9 µd°9 µeeR¹ µe JTy µd `vYHy !ÅNÀ µ&lt;Hy !ÅNÀ ´ÔJ9 µ&lt;g*J9 ´Ôg&quot;9 ´Ô°9 µ&lt;eR¹ µ&lt;y ´Ô `vY/ 9 µF/ 9 µI/ Hy ¶@N¹  CvOï    YfvYHy !Å¤NÀ ²)Hy !ÅªNPÀ ²#J9 ²)g ÊJ9 ²#g À9 ²#°9 ²)e ®R¹ ²)y ²# Hy !Å°NÀ z¬Hy !Å¸NÀ ÁJ9 z¬fvY9 z¬°9 ²)e9 z¬°9 ²#cvYy z¬ | R Hx Hx /Hx N¹ !
+Oï J+ f  ð|  | W | H | 0 Hx Hx /Hx N¹ !
+| P y ² Cy ²  D|  y ±+ | 1 Hx Hx /Hx N¹ !
+| P y ²$ Cy ²&amp; D|  y °ô | 1 Hx Hx /Hx N¹ !
+Oï 0| P y µ× Cy µØ D|  y µÛ | 0 Hx Hx /Hx N¹ !
+Oï J9 z¬g6J9 Ág.9 z¬°9 ÁfvY9 Á°9 ²)e9 Á°9 ²#cvY/ 9 ²&#x27;/ 9 ²%/ Hy ¹¤N¹  CvOï   YfvYHy !ÅÂNÀ ²g(9 þ ²b9 ²°9 ²%e9 ²°9 ²&#x27;bvYHy !ÅÈNÀ ´Íg(9 þ ´Íb9 ´Í°9 ²%e9 ´Í°9 ²&#x27;bvYHy !ÅÎNÀ À2g(9 þ À2b9 À2°9 ²%e9 À2°9 ²&#x27;bvYHy !ÅØN¹  B^Oï À Át $| /Hy !ÅàHnÿöN¹ !·NHnÿöN¹  B^Oï ÀRp°lÖt $| ¨/Hy !ÅìHnÿöN¹ !·NHnÿöN¹  B^Oï ÀRp°lÖN¹  Côt $| ¹ | ÀÜB0   | ·|B0  BRp°lâ$| ®È5| 
+ %| !Åø Aîÿì%H /
+N¹  DêXJ.ÿìgHnÿìN¹ !¶îX// N¹ !²#ß ¿``
+#üDz   ¿`$| ®È5| 
+ %| !Æ Aîÿì%H /
+N¹  DêXJ.ÿìgHnÿìN¹  BøX#À ·`
+#ü  &#x27; ·B¹ ÀØ$| ®È5| 
+ %| !Æ Aîÿì%H /
+N¹  DêHnÿìN¹ ! P#À ¶p°¹ ¶mp`Dp
+°¹ ¶l8p°¹ ¶mp`,p°¹ ¶mp`p°¹ ¶mp`p&lt;°¹ ¶mp&lt;`p
+#À ¶ü 0 |@ü 
+ ·Hü N ³dB9 ðB9 x Yg hHx N¹ !Hx 	N¹ !Hx 
+N¹ !Hx N¹ !Hx N¹ !p#À |ü D Áü N µL$| ®È5| 
+ %| !Æ %| ±ô /
+N¹  DêOï J9 ±ôgHy !Æ Hy ±ôN¹ !·PJfü T ¾RHx 
+N¹ !X`  ªHy !Æ&amp;Hy ±ôN¹ !·PJf  ü J ¾R5| 
+ %| !Æ, %| ±ô /
+N¹  DêXJ9 ±ôgHy ±ôN¹  BøX#À |5| 
+ %| !Æ6 %| ±ô /
+N¹  DêHy !Æ&gt;Hy ±ôN¹ !·Oï Jfü E Á`ü N ¾RHx N¹ !Hx N¹ !è`þLî&lt;ÿÐN^NuNVÿôHç  $| ®È5| 
+ %n  Aîÿö%H /
+N¹  DêXJª gHnÿöN¹  Bø$ `t LîÿìN^NuNVÿôHç 0Gîÿö$| ®È5| 
+ %n  Aîÿö%H /
+N¹  Dê Ae Kb  `¼  Lî ÿìN^NuNVÿôHç  $| ®È5| 
+ %n  Aîÿö%H /
+N¹  DêXJ.ÿöfB`$HnÿöN¹ !   ot`HHÀrñ²otñLîÿìN^NuHç 0&amp;o $| ®È5| 
+ %K %| ±ô /
+N¹  DêX * Lß Nu/ o t  HffR`&gt; 0e 9b é$    `  Ae Fb é$       	Ôf¾`&quot; 0e 9b åÔÔ   ÔfÞ $NuHç80&quot;o / &#x27; ÿ$IxNB`$&amp;JT°cxY* k  C RT´eØ YgÊxN$I°/ e&quot;B` JT( ¶exYR´eì* °/ #cxYLßNuNVÿôHç0&lt;Kîÿöv&amp;| ³p / Hy !ÆF/
+N¹ !·N/
+a þ¤$@JgZ R `
+BB+ B+ p / Hy !ÆR/
+N¹ !·N/
+a þnOï  $@Jg6B(MÚR 	eö/
+a þP$@B(MÚR 	eö/
+N¹ ! P$ B `B+ p / Hy !Æ^/
+N¹ !·N/
+a þOï $@Jg/
+N¹  E|X&#x27;@ `B« PR c ÿ*Lî&lt;ÿÜN^NuNVÿüHç 8 n &quot;h &amp;|    &amp;k `EODTgbp ×ÀXRGLfì$k &amp;k `H n -h ÿü`4(nÿüRr`
+°gr ` vfðp°fR`Ú  e _cò` pgÆRµËc´BLî ÿðN^NuHç8 $o t B`N é$ p / N¹ !¸X  0m 9nHHÀ   0` Am FnHHÀ   7ÔRRJf® LßNuHç 0&quot;o p°lpE`z)  cpE`n) ? cpE`b &quot; çç | ÂèÑÀ&amp;H$k 2¼ )  &gt;å
+)   Ð  ) E f  `  B 6p ) rã¨  $@&#x27;J 2pPLßNuNVÿÐHç8&lt;N¹ !ÀJgHx N¹ !èX9 ²%p Ð | ·ÑÀ*H`  p r 9 ²%&quot; ÐÐÐ | ºÀÑÀ&amp;H0HÀ(@ f|   B« `R´g|   B« `BEîÿÐv `ÜRp °nôBEîÿÐ ae zbZ `| # /
+N¹  GhX&#x27;@ R´9 ²&#x27;c ÿnHy w`N¹ !tXHx %N¹ !p` ÿ6Lî&lt;ÿ´N^Nu/ o t  HffR`&gt; 0e 9b é$    `  Ae Fb é$       	Ôf¾`&quot; 0e 9b åÔÔ   ÔfÞ $NuHç0&lt;*| ³L$| ³Ô&amp;| ´N¹  M(#À }´fHx 	N¹ !èXN¹ !ÀJgHx 	N¹ !èXy ² | R Hx Hx /Hx N¹ !
+Oï +  d+ `vJf(| ¾ð9 °ªB`ü  R´eö`(KpÙÀB&amp;| ¾ð`ÜR´eøp  | ¾ðB0   9 vä ³f3ü  ôü 
+ ²By µJü N µHp 09 ô   r°b Ð0;Nû    L L   D Dü Y µHü  ±*ü  °«ü  tü  vÜü  °ª`  Àü Y µHü  ±*&amp;y ³Hy !Æj0/ Hx Hx aN¹  Qº(@/N¹  QpÀ °«Hy !Æ0/ Hx 
+Hx aN¹  Qº(@/N¹  QpOï (À tHy !Æ0/ Hx Hx aN¹  Qº(@/N¹  QpÀ vÜHy !Æ²0/ Hx Hx aN¹  Qº(@/N¹  QpOï (À °ªHx N¹ !*Hx  N¹ !*3ü  ±¤p#À ±¦Hx Hx Hy ±Hx N¹ !
+&amp;|    #ë  yØ` y yØEODTfB¹ yØ`p Ñ¹ yØ y yØXRIMfÔHx ÌHx &#x27;Hx /9 zN¹  hOï ( |  9  vÇ y zty vÇ 
+|øÿ#ü ¹ê zdHx N¹ !pB9 º@N¹  Znü N ¾úü N ·0#ü   ²/9 ²N¹  u¾PJ f8N¹ !`&amp;@ gHx Hx &lt;Hx &lt;/N¹ !`&lt;;|  ;|  +| !ÆÊ `;|  ;|  +| !Ç  Hx B§/
+Hx N¹ !
+Oï N¹  ap(MpÙÀ&amp;y ´È#ü ²¼ z¨#ü ¹¸ z¸ |  y z|   y zt|  |øÿ k (    ÿÐ/ Hx N¹ !Pr²f&amp;| þ p 0/ Hy !Ç8Hy ¹¸N¹ !·NOï `  %| ¹¸ %| ³8  rÐ%@ %| ² %| °ò &quot;%| °ó &amp;|  *B* +5|  ,Bj .|  0B* 15|  Hx Hx /
+Hx N¹ !
+Oï y ³8 J9 °óg| ý  | !ÇD&quot;| ¹¸&quot;Ø2Ø;|  ;|  (¼ ¹¸Hx Hx /
+Hx N¹ !
+#ü ²¼ z¨%| ²¼ N¹  RÞHx N¹ !Oï JfHx N¹ !XN¹  ZnHx N¹ !XJf$Hx N¹ !X y ²    fN¹  ).Hx B§N¹ !ÞP` þBLß&lt;NuNVÿüHç&lt;&lt;&amp;| !ä-Sÿüt #ü ³ vè#ü y  |#ü yL  #ü ³ vä#ü yD H#ü yp BCp 0ÐÐ®ÿü @8g :Eÿ p 0@ g@ g@ f x0/ 0/ N¹  RVP*@ 
+g `Hx 0/ 0/ N¹  ROï &amp;@ g BB§0/ 0/ N¹  ROï (@ g &amp;Hx N¹ !4$@4%M %K %L 
+5D ê  %ê  %B* Hy !ÇJ/
+N¹  P`@ #Hy !ÇP/
+N¹  P`Oï @ $E fZ3Ä ôë  ² 9 vè°¹ väb y vèX¹ vè`   9 |°¹ Hc  ~ 9  °¹ b  ~ y  X¹  `j* #  `g* 9 |°¹ HcF 9  °¹ bH y  X¹  `6 9  °¹ b y  X¹  ` 9 |°¹ Hb y |X¹ | RRCC e þR nÿüh  þfrHx Hx Hx N¹  ROï &amp;@ gVHx N¹ !4$@4¼ Bª %K Bª 
+5|  ê  %ê  %B* #Ê À4 9   ytb y  X¹   R#ù vè vä#ù | H#ù    9 vä ³g#ù ³ ´Èü Y J`F 9 H y g#ù y  ´È`$ 9  yLg#ù yL ´È`
+#ù À4 ´Èü N J#ü ³ vè#ü y  |#ü yL  ü  z Lî&lt;&lt;ÿÜN^NuNVÿìHç 0$n &amp;| ²,p 0/ /. Hy !ÇVHnÿöN¹ !·N7| 
+ Aîÿö&#x27;H Aîÿì&#x27;H Hx Hx /Hx N¹ !
+J.ÿìf 0*   ÿ    f&lt; `  t`  BEîÿì`zp rAr°bjÐ0;Nû  , 2 D ` J &gt; ` ` ` ` ` ` P ` ` 8 ` ` ` V ` \  `.  `(  `&quot;  `  `  ``   `
+  @`  RJf ÿLîÿàN^NuHç 0&amp;o $y ´ÈBy z\0/ /N¹  n%K |   Hx CN¹  iÚOï $ p°dt LßNuHç88$/ &amp;/ $(/  $o (p &amp;@(| ³h9|   am ko Am* Kn$B )D Hx Hx /Hx N¹ !
+Oï &amp;l  f0 
+g,&amp;| ¿Ìp 0æÀ  rá)Á`ÚJfú¼ þ&amp;| ¿Ì LßNu/&quot;/  | !ä h `´fJ( gpÑÀ ÿfê ÿfp ` $NuHç0 &amp;/ &quot;/  | !ä h `$´Afp ( ì   °f
+(   ?gpÑÀ4fØJBfp ` Lß NuHç &lt;&amp;|  _(|  ap*|  ).$y ´È* þ gª  %j  fNp * r°b (Ð0;Nû    X|¶¶Øp *   ýg  þg`&amp;Hx ÿHx NP` ê  %Hx ¦Hx NP` øHx ¦Hx NP` èp * g  ÿg R` Np * r°g  ýg Æ  þg ì` p * r°b Ð0;Nû    N ² Æ ü ² ü Æ::pê  %B* * %  @  @fHx ¢Hx NP` TN` NB§Hx NHx N¹ !Oï #ü ²¼ z¨#ü ¹¸ z¸ |  y z|   y zt|  |øÿHx N¹ !pB§Hx NOï ` êB* Hx ¢Hx NP` Ö*  dR* Hx ¢Hx NP` ºB* ê  %Hx ¦Hx NP`  Hx ¤Hx NP` ê  %B* N` Hx B§N¹ !ÞHx §Hx NOï ` b*  dR* Hx ¡Hx NP` FB* ê  %Hx ¦Hx NP` ,B* Hx ¡Hx NP` * / N¹  uöB§Hx NOï ` üê  %B* * %  @  @fHx ¢Hx NP` ÔN` Î* %    f*  d
+R* N` ®ê  %Hx ¦Hx NP` Hx ¦Hx NP` p * r°g  þg  `  p * r°blÐ0;Nû  R R R R R R b R   b R R R R b &gt;Hx B§N¹ !ÞHx §Hx NOï ` B* Hx ¡Hx NP` Hx ¦Hx NP` ø* / N¹  uöHx ÿHx NOï ` ÚN` ÔHx ¦Hx NP` Äp *    ¡r°b Ð0;Nû   ¬ ¬H¸2~Hp * r°g  ýg.  þg^`rp *   f
+N¹  b` fHx ¦Hx NP` V*  dR* Hx ¡Hx NP` :B* ê  %Hx ¦Hx NP`  ê  %Hx ¦Hx NP` 
+Hx ¦Hx NP` úp * r°g  ýg.  þg^`rp *   f
+N¹  fø` ÊHx ¦Hx NP` º*  dR* Hx ¢Hx NP` B* ê  %Hx ¦Hx NP` ê  %Hx ¦Hx NP` nHx ¦Hx NP` ^p * gr°g  ýg&amp;  þg0`DN¹  pL` 8B* Hx ¢Hx NP` $Hx ¤Hx NP` ê  %Hx ¦Hx NP` þHx ¦Hx NP` îp * r°g  ýg2  þg&lt;`Pp *   fB§Hx NP` ºHx ¦Hx NP` ªHx ¥Hx NP` ê  %Hx ¦Hx NP` Hx ¦Hx NP` tp * r°g  þg$`(p *   fN` NHx ¦Hx NP` &gt;N` 8Hx ¦Hx NP` (p * r°g  ýg2  þg&lt;`Pp *   fB§Hx NP`  ôHx ¦Hx NP`  äHx §Hx NP`  Ôê  %Hx ¦Hx NP`  ¾Hx ¦Hx NP`  ®p *   þf  ê  %Hx ¦Hx NP`  p *   þf  zê  %Hx ¦Hx NP`fp *   ýg  þg`&quot;Hx ÿHx NP`Dê  %Hx ¦Hx NP`0Hx ¦Hx NP`&quot;p *   þfê  %Hx ¦Hx NP`NLß&lt; NuHç0&lt;(|  ]h*|  ]ÖBB#ü º@ zXHx p 9 z¬/ p 9 z¬/ N Hx p 9 ² / p 9 ²/ N Hx p 9 ²&amp;/ p 9 ²$/ N Hx p 9 µØ/ p 9 µ×/ NOï 0 Hx p 9 ±þ/ p 9 ±ç/ N Hx  p 9 ±æ/ p 9 ±ÿ/ N Hx @p 9 Â/ p 9 ÂU/ N Hx p 9 µd/ p 9 µe/ NOï 0 Hx 9 ²/ Hy ¾ðN¹  ^ÆOï  Jg  ú#ü º@ zXB¹ zTHx p 9 z¬/ p 9 z¬/ NHx p 9 ² / p 9 ²/ NHx p 9 ²&amp;/ p 9 ²$/ NHx p 9 µØ/ p 9 µ×/ NOï 0Hx p 9 ±þ/ p 9 ±ç/ NHx  p 9 ±æ/ p 9 ±ÿ/ NHx @p 9 Â/ p 9 ÂU/ NHx p 9 µd/ p 9 µe/ NOï 0$y zXBB* Bª #ü y  |#ü yL  ü Y Jü  z&amp;| ³`*$S  f  fÀ* #f*  %gê  %X·ù väeÎ&amp;| y `*$S  f  fÀ* #f*  %gê  %X·ù HeÎ&amp;| yL`*$S  f  fÀ* #f*  %gê  %X·ù eÎLß&lt;NuHç80$/ &amp;/  (/ JgT$y zX&quot;| º¸`&lt;µÉb&lt;p 9 ²%&quot; ÒÒÒ | ºÀÑÁ&amp;H+   gk  %k  \R´oÀ#Ê zXLßNuHç&lt;&lt;$/ ,(/ (*/ $*| zX$UJg  Ê(| º¸&amp;p 9 ²%&quot; ÒÒÒ | ºÀÑÁ&amp;H`  µÌb&gt;+   gr´g*`  * °+ f * °« g`\´fµÌcö*`d\`&lt;3ü  ³\3ü  ³^#ü !Ç^ ³`Hx Hx Hy ³LHx N¹ !
+Oï *`$\R¶o ÿz´f`\´fµÌcö*`*p Lß&lt;&lt;NuNVÿôHç&lt;&lt;*. *n $| ´n  | R Hx Hx /
+Hx N¹ !
+*  d* `vJf*Eîÿö9 °ªt `ü  Rp °bòp B6 öGîÿö`p  @B2&amp;Jp×À(KB$Mt `°g `
+Rp °dêJfp `&amp;L$Mt `ÛRp °dôLî&lt;&lt;ÿÔN^NuHç00$/ &amp;/ Hx B§N¹ !Þ&amp;y ´È$| ³Ôü  °òC B %| ²¼  rÐ%@  rÐ%@ %K %| °ò &quot;Bj Hx Hx /
+Hx N¹ !
+Oï LßNuHç 0$/ &amp;o $| ³Ôü  °ò3Â ²B9 ³6%| ²¼ %K %| ³6 %| ² %| °ò &quot;Bj Hx Hx /
+Hx N¹ !
+Hx N¹ !Oï #ü ²¼ z¨#ü ¹¸ z¸ |  y z|   y zt|  |øÿHx N¹ !pXLßNu/
+$| ³ÔB9 °ò3ù ²î ²ü  ³6%| ²¼ %| ³6 %| ² %| °ò &quot;Bj Hx Hx /
+Hx N¹ !
+Hx N¹ !Oï #ü ²¼ z¨#ü ¹¸ z¸ |  y z|   y zt|  |øÿHx N¹ !pX$_NuHç 8$| J&amp;| ´È(| vè&quot;| | S0(   ÿ    f9 Y µHf
+Jy µJf  ¶ Yf. 9 vä ³c  TX&amp; °¹ väe  (¼ ³¼ N`  9  zd0 9 H y c&quot;¼ Y QX&amp; °¹ HeZ&quot;¼ y R9 z`L 9  yLc2¼ Y y  X¹  &amp; 9  °¹ e#ü yL  B9 z`¼ Y`Sy µJ S(  %g&lt; ÿ`B / Hx a ý
+PLß NuNVÿäHç0&lt;Kîÿð&amp;y ´ÈBy ²îBC$k 
+`/
+0/ a ýVPRy ²îC pÕÀ0°k f
+*   ÀgÔ0+   ÿ    f Fp 0+ à@ÿðk  y ² p 0+    r°b Ð0;Nû   22  22tEõ( ü ÿRp°nô9 
+ ²f$| !Ç`$| !Ç|  p 9 µ×r 9 ²%&quot; ÐÐÐ | ºÀÑÀ(H/, /
+ 
+X/ N¹ !·N/
+0/ a ühRy ²îC |  p 9 ²r 9 ²%&quot; ÐÐÐ | ºÀÑÀ(H/, /
+ 
+X/ N¹ !·N/
+0/ a üOï (Ry ²îC |  p 9 ²$r 9 ²%&quot; ÐÐÐ | ºÀÑÀ(H/, /
+ 
+X/ N¹ !·N/
+0/ a ûÄOï Ry ²î` ÜtEõ( ü ÿRp°nô9 
+ ²f$| !Ç`$| !Ç |  p 9 µ×r 9 ²%&quot; ÐÐÐ | ºÀÑÀ(H/, /
+HnÿæN¹ !·NHy !Ç¦0/ Hx Hx aa ìæ(@9 ±*9 °«9 °«/ / /Hnÿæ/
+N¹  fTOï 0|  p 9 ²r 9 ²%&quot; ÐÐÐ | ºÀÑÀ(H/, /
+HnÿæN¹ !·NHy !Ç¾0/ Hx 
+Hx aa ìj(@9 ±*9 t9 t/ / /Hnÿæ/
+N¹  fTOï 0|  p 9 ²$r 9 ²%&quot; ÐÐÐ | ºÀÑÀ(H/, /
+HnÿæN¹ !·NHy !ÇÖ0/ Hx Hx aa ëî(@9 ±*9 vÜ9 vÜ/ / /Hnÿæ/
+N¹  fTOï 0|  Hy !Çî0/ Hx Hx aa ë¦(@9 °ª/ B§/Hy ¾ð/
+N¹  fTOï $a ú«  %B§Hx a ùJLî&lt;ÿÌN^NuHç8&lt;&amp;/ 0(/ ,&amp;o $(o (*o  $MX`ü  SJfö`ÛSJfø9 ±*`ü  SJfö/
+B§a ùjRy ²î$y ´Èü N îBy z\0/ /N¹  nOï 9 Y îf%L |   Hx KN¹  iÚXLß&lt;NuHç0&lt;(|  mÆ*|  iÚ$| º@&amp;y ´È k ( 	ü N îBy z\By ²î|   «  %`Jg
+\ fò$* pÀgBJg&gt;Hy !È0/ p / Hx aa êJ&#x27;@ 0/ /+ N¹  nOï &#x27;k  Hx SN`  g&lt;Hy !È0/ Hx Hx aa ê&#x27;@ 0/ /+ N¹  nOï &#x27;k  Hx SN`  Ä g&lt;Hy !È0/ Hx Hx aa éÆ&#x27;@ 0/ /+ N¹  nOï &#x27;k  Hx SN`  pÀgN+  #gF gü Y ¾ú+   #g+  #gpÀg
++ #  ö`+ #  õ/ NXü N ¾ú`.+   #g+  #gpÀg
++ #  v`+ #  u/ NXy  z\c  k (  fü Y îB« Hx SNXJy z\f  ®pÀgN+  $gF gü Y ¾ú+   $g+  $gpÀg
++ $  ö`+ $  õ/ NXü N ¾ú`.+   $g+  $gpÀg
++ $  v`+ $  u/ NXy  z\c  k (  fü Y îB« Hx SNXJy z\f8Hy !È*0/ Hx Hx aa è &#x27;@ 0/ /+ N¹  n&#x27;k  Hx SNOï a ÷«  %B§Hx a õÂPLß&lt;NuHç&gt;&lt;*/ (&amp;y ´È(k $| °ø| 9 Y îgü N îp ` ¶Jl 
+g rJl g jJ, g ~5S %k  %k  B+ ` Xp 0æÀ ½8+   rá)Á ½9ü ù ½:B9 ½;5|  5S %k  %k  %k  %| ¾ð  %| ½&lt; $k   -E /y °ª 0k ! 1Hx Hx /
+Hx N¹ !
+Oï &#x27;j  J* .g  ¼p , r , 	ÀÁ | ½@ª ,  ù ½= ½&lt;ü ú ½=5|  %| ½8 %|  (Hx Hx /
+Hx N¹ !
+Oï R+  p , Ñy ²î9  gë  %9 Y ¾úf 9   BCx , éLBB` | Hp  0/ a ôPC B ´Deàj , + þ f þ¢` B+ `  Ð5|  5S %k  %k  %k  %| ¾ð  %|  (k   -E /y °ª 0k ! 1Hx Hx /
+Hx N¹ !
+Oï &#x27;j  J* .g`R+  p , Ñy ²î9  gë  %9 Y ¾úf 9   BCx , éLBB` | Hp  0/ a ó°PC B ´Deàj , + þ f ÿ*` 4J, g , KfvB+ ` 5|  5S %k  %k  %k  %| ¾ð  %| ½8 $k   -E /y °ª 0k ! 1Hx Hx /
+Hx N¹ !
+Oï &#x27;j  J* .g  ¢R+  p , Ñy ²î9  ½:gë  %9 Y ¾úf 9   ½: Cf4p 9 ½; @ g&amp;*| ½&lt;t , p , 	ÄÀ`
+ `fRSBJBfò`4 KgBCx , éLBB` | ½8Hp  0/ a òzPC B ´Deàj , + þ f þèü N î Lß&lt;|NuHç08&amp;/ &amp;| º@$y ´È`  ¨Àg  J« g  B§0/ /+ + / a ãºOï (@ fHy !È60/ Hx Hx aa ãOï (@%L 49 z\0/ /* N¹  nP9 Y îf6 j (  fJBgBª Hx Sa ûtXü Y î%j  Hx Sa û\X\f ÿVLßNuHç&lt; (/ z :æ  rá)v1 o `  1f  p   íg  ýg  ü  ûgN  ògN  üg  Þ`J`.ºf&amp;Àg&quot;ü Y îRy z\S ep ÐÑÀ`
+RS dÌv2`  T`  X`     ðf´fÀgü Y îRy z\`Rv2`fp    ír°bJÐ0;Nû  * @ @ @ @ 8 &amp; &quot; &quot; &quot; &quot; &quot; &quot; &quot; 4 &lt; VT`&amp;X`&quot;p ÐÑÀ`T`X`v1`   ðfR þf þîLß &lt;Nu/ o t  HffR`&gt; 0e 9b é$    `  Ae Fb é$       	Ôf¾`&quot; 0e 9b åÔÔ   ÔfÞ $NuHç0&lt;(|  r¤*|  _$| ³8&amp;| ³h7|  p áHr ÐA y ´È°h gHx ÿHx ` 
+°9 ²gHx ÿHx ` òHx PHx 	N¹ !zPp 9 z¬r 9 ²%&quot; ÐÐÐ | ºÂ$0 ü Y ³dp 9 ±* | ³&lt;ÑÀ$Hp Sr	°b LÐ0;Nû   2 x ¶ öZ@@@(pp×Ä/B§B§B§B§/
+NOï ` *pÝÄp 9 °«À/9 µØ/ 9 µ×/ 9 µÛ/ p 9 °«/ /
+NOï ü N ³d`  äpÐÄp 9 tÀ/9 ² / 9 ²/ 9 ±+/ p 9 t/ /
+NOï `  ¦ppÑÄp 9 vÜÀ/9 ²&amp;/ 9 ²$/ 9 °ô/ p 9 vÜ/ /
+NOï `dpÑÄp 9 ±*À/ 9 ²/ p 9 °ª/ /
+N¹  sfOï `2pÕÄ/B§B§B§B§/
+NOï `Hx Hx 	N¹ !zPHx ÿHx `0Hx %N¹ !*Hx B§N¹ !ÞHx Hx 	N¹ !zOï Hx ¨Hx NPLß&lt;NuNV  Hç&lt;8$. *. &amp;n (| ´$LpÕÀBJgTî R9  ²fü H`S  gÃRJfî| P E Cn  DD Hx Hx /Hx N¹ !
+Oï /. Hy !ÈB rÐ/ N¹ !·N@ y z¬ | W Hx Hx /Hx N¹ !
+Lî&lt;ÿäN^NuHç&gt;&lt;&amp;/ ,(/ 4,/ 0&amp;o (*| !
+//N¹  tH  Yf
+&amp;| !ÈF  zY$K`  g
+ 0gzN`fì(| ´ YfF | E `&quot;$LpÕÀC `Â SJfôF | W Hx Hx /Hx Np / Hy !ÈH rÐ/ N¹ !·NOï $@ y z¬ | W Hx Hx /Hx NOï Lß&lt;|NuNVÿÜHç&gt;0&quot;n Gîÿò(. ` ae zb
+  àÀ`ÃSJfàü  R® BCîÿòGîÿèB®ÿü(. `*EîÿèzNt `
+¶fzY`R´®ÿüeð NfÃR®ÿüSJfÒB$| !ä&quot;j $`  ÔRGîÿÞ| xNzU`b Uf é	zL`P 9c_   zUp°c8ÁRp°f.Eîÿèt `
+²fxY`R´®ÿüeð Nf üg þfò` üg þf YfNx Aîÿò`&lt;GîÿÞ R$@zYt `  g
+`R  gø°gzN`R´eà Yf`R . °dº ýf ÿ(pNLî|ÿÀN^NuHç  $o B9 ² ü  ²¡NqNqNqNqNqNqJB9 ²¡9 ² LßNuNVÿäHç?&lt;&amp;. J¹ yØg öz è  0  0 9c^ y yØ$h  y yØ-h ÿü|N` kfºf¶gµîÿücìµîÿüd ¢Hx PHx 	N¹ !zP&amp;| ´vNzN` &quot; af,9 Y ¼úg&quot;R|YIîÿìx`ÚR 0e 9cðB` ð bf  9 Y ¼úgxR Yf Ô|NIîÿä`Ú 0e 9còBHnÿäa øä Iîÿì*KpÛÀ  aÀÜfü| P y ²G Cy ²P DD Hx B§/Hx N¹ !
+Oï vY` f df \R 1er 8bl 1p ç.  | ³0  r  | ·|0 B9 ·&lt;ü  ¿Ê | ³0p    ÿrM°grS°grB°g` övY` ðzY` êvYzY` â 9f Ú9 Y ¼úf Îp r3r°b ¾Ð0;Nû DØÀ¨@ . J9 À2g #ù ·X {ü Y ·0` J9 À2g |9 Y ·0f p 9 ·X¹ {N¹ !³Ú/9 ¶&lt;N¹ !²ä/9 ¿`N¹ !²ä#ß ¹/9 ¹/&lt;?YN¹ !²ÐmL/9 ¹/&lt;?33N¹ !²Ðn8/9 ¹N¹ !³&amp;Hy !ÈL rÐ/ N¹ !·NOï @ y À2 | W `#ü?   ¹y À2 | E Hx Hx /Hx N¹ !
+Oï ü N ·0/9 ¹/9 ¶&lt;N¹ !²ú#ß Á,/9 Á,/9 Á8N¹ !²ú#ß Á0` tJ9 À2g j#ü?   ¹y À2 | E Hx Hx /Hx N¹ !
+Oï ü N ·0#ù ¶&lt; Á,/9 Á,/9 Á8N¹ !²ú#ß Á0` 9 Y víf  ü Y ·g`  ô9 Y víf  èü N ·g`  ÜS¹ ÁHHx 5N¹ !*y ÁW | W /9 ÁHHy !ÈP rÐ/ N¹ !·N@ Hx Hx /Hx N¹ !
+Hx dB§N¹ !ÞHx %N¹ !*Oï ,`nR¹ ÁHHx 5N¹ !*y ÁW | W /9 ÁHHy !ÈT rÐ/ N¹ !·N@ Hx Hx /Hx N¹ !
+Hx dB§N¹ !ÞHx %N¹ !*Oï ,`R kgµîÿüc ûÔ3ü  µJ YfHx %N¹ !*X YfHx &amp;N¹ !*X Yg YfHx B§N¹ !ÞPHx Hx 	N¹ !zLî&lt;üÿ¼N^Nu/
+$| ¿´N¹  (JfHx 
+N¹ !èXN¹ !`#À |ôfHx 
+N¹ !èX5|  p%@ Hx Hx /
+Hx N¹ !
+Hx N¹ !pHx  N¹ !pOï B9 ¶N¹  }°N¹  &amp;`ø$_NuNVÿìHç  $| ¿D n 0  ÿÿ/ /. Hy !ÈXHnÿöN¹ !·N5| 
+ Aîÿö%H Aîÿì%H Hx Hx /
+Hx N¹ !
+J.ÿìft`  BEîÿì`zp rAr°bjÐ0;Nû  , 2 D ` J &gt; ` ` ` ` ` ` P ` ` 8 ` ` ` V ` \  `.  `(  `&quot;  `  `  ``   `
+  @`  RJf ÿLîÿäN^Nu/&quot;/  | !ä h `´fJ( gpÑÀ ÿfê ÿfp ` $NuHç0 &amp;/ &quot;/  | !ä h `$´Afp ( ì   °f
+(   ?gpÑÀ4fØJBfp ` Lß NuHç88$/ &amp;/ $(/  $o (p &amp;@(| Àä9|   am ko Am* Kn$B )D Hx Hx /Hx N¹ !
+Oï &amp;l  f0 
+g,&amp;| À p 0æÀ  rá)Á`ÚJfú¼ þ&amp;| À  LßNuHç0&lt;&amp;|  þ(|  l*| z¬BB#ü ¶ ´ÐHx p / p / N Hx p 9 ² / p 9 ²/ N Hx p 9 ²&amp;/ p 9 ²$/ N Hx p 9 µØ/ p 9 µ×/ NOï 0 Hx p 9 ±þ/ p 9 ±ç/ N Hx  p 9 ±æ/ p 9 ±ÿ/ N Hx @p 9 Â/ p 9 ÂU/ N Hx p 9 µd/ p 9 µe/ NOï 0 Hx 9 ²/ Hy N¹  \Oï  Jg  ò#ü ¶ ´ÐB¹ µlHx p / p / NHx p 9 ² / p 9 ²/ NHx p 9 ²&amp;/ p 9 ²$/ NHx p 9 µØ/ p 9 µ×/ NOï 0Hx p 9 ±þ/ p 9 ±ç/ NHx  p 9 ±æ/ p 9 ±ÿ/ NHx @p 9 Â/ p 9 ÂU/ NHx p 9 µd/ p 9 µe/ NOï 0$y ´ÐBB* Bª $y LÀ* #fÀ* $f  gê  %B¹ v¬B9 }©Lß&lt;NuHç80$/ &amp;/  (/ JgT$y ´Ð&quot;| ·`&lt;µÉb&lt;p 9 ²%&quot; ÒÒÒ | ºÀÑÁ&amp;H+   gk  %k  \R´oÀ#Ê ´ÐLßNuHç&lt;&lt;$/ ,(/ (*/ $*| ´Ð$UJg  Ê(| ·&amp;p 9 ²%&quot; ÒÒÒ | ºÀÑÁ&amp;H`  µÌb&gt;+   gr´g*`  * °+ f * °« g`\´fµÌcö*`d\`&lt;3ü  ì3ü  î#ü !È` ðHx Hx Hy ÜHx N¹ !
+Oï *`$\R¶o ÿz´f`\´fµÌcö*`*p Lß&lt;&lt;NuNVÿôHç&lt;&lt;*. *n $| Àn  | R Hx Hx /
+Hx N¹ !
+*  d* `vJf*Eîÿö9 °ªt `ü  Rp °bòp B6 öGîÿö`p  @B2&amp;Jp×À(KB$Mt `°g `
+Rp °dêJfp `&amp;L$Mt `ÛRp °dôLî&lt;&lt;ÿÔN^NuNVÿüHç8&lt;*| µ@&amp;| !ä&amp;Sx *¼ P#ü t µ8BB$K6C0 gC0f  ®0/ 0/ a úP&amp;@ g  Hx 0/ 0/ a ú&lt;Oï (@ g  |Hx N¹ !4$@4%K %L %nÿü 
+5C ê  %ê  %B* Hy !È/
+a øÂ@ #Hy !È/
+a ø²Oï @ $ °¹ µ8b UX R#Ê L#Õ µ8*¼ P`
+RBB e ÿ&lt; Lî&lt;ÿàN^NuHç0&lt;(|  Z*|  ¾$| ¶&amp;y L k ( 	ü N ïBy z^|   «  %«  %`Jg
+\ fò$* pÀg&gt;Jg:Hy !È 0/ p / Hx aa ùv&#x27;@ 0/ /+ N¹  ÐOï &#x27;k  N`  Â g8Hy !È¬0/ Hx Hx aa ù8&#x27;@ 0/ /+ N¹  ÐOï &#x27;k  N`   g6Hy !È¸0/ Hx Hx aa øú&#x27;@ 0/ /+ N¹  ÐOï &#x27;k  N`FpÀg+  #g
++ #  `(+   #g+  #gpÀg
++ #  v`+ #  u/ NXy  z^c k (  fü Y ïB« NJy z^fjpÀg+  $g
++ $  `(+   $g+  $gpÀg
++ $  v`+ $  u/ NXy  z^c k (  fü Y ïB« NJy z^f4Hy !ÈÄ0/ Hx Hx aa ÷à&#x27;@ 0/ /+ N¹  ÐOï &#x27;k  NLß&lt;NuNVÿüHç&gt;&lt;-y Lÿü nÿü(h *| ¿9 Y ïf *Jl 
+gJl gJ, g ` J, g 
+ nÿüB( ` ð;|   nÿü;P  nÿü+h   nÿü+h   nÿü+h  +|   +| t¶ $ nÿüh   -| S /y °ª 0 nÿüh ! 1Hx Hx /
+Hx N¹ !
+Oï (m  nÿü!m  J- .g ZzN nÿüR(  9  t¸g
+ nÿüè  %9 t·9  t¸gZ,   ?  fL$| t¸ü ^ü Sp , r , 	N¹ !«&gt;Aò &amp;H$| t¸#  gúR å   PrN¹ !ªD `^$| t³ü ^ü Pü 1ü 5ü ^ü Iü Ip , r , 	N¹ !«&gt;Aò &amp;H$| t³ nÿü ( °¹ v¬fzY nÿü#è  v¬9 ? xd
+9 xR `B À x Yf
+J9 }©f  ÎJ, f  v , 0ÖCÖ@ÖC r °o
+p Aò &amp;H r , ÐSr , N¹ !ªD B`&gt;4J´, c, ` //
+/ / / 9 x/ N¹  Oï Rp ÕÀµËe¾`&lt;,  r °o
+p Aò &amp;H4J//
+/ B§B§9 x/ N¹  Oï  YfJ9 }©fp`
+9 }©  ÿÀ }©Hx !B§p Ð/ /9 |ôN¹ !Hx !N¹ !pHx N¹ !Oï Jf&quot;Hx N¹ !Xa õ0 nÿü( %  @  @g nÿüm ,  nÿü( þ f ýü N ïLî&lt;|ÿØN^NuHç08&amp;/ &amp;| ¶$y L`  ªÀg   J« g  B§0/ /+ + / a ôOï (@ fHy !ÈÐ0/ Hx Hx aa óüOï (@%L 49 z^0/ /* N¹  ÐP9 Y ïf8 j (  fJBgBª a ü ü Y ï%j  a ûî* %  @  @g\f ÿTLßNuNVÿüHç8&lt;$. &amp;. &amp;n *y L(| ° n J( fJ^W$KÄÃ.    é. ÿþ.ÿþ.    . ðÿþ.ÿþîÿþp ÕÀBX `\U$KÄÃp ÕÀBV @ m  |  )K )| ¾T 9|  Hx Hx /Hx N¹ !
+Hx N¹ !Oï `Hx B§N¹ !ÞP9 S yxfè#ü ¾T ±°p  | ¾SÑÀ#È y | ü P yx y z|   y zt|  |øÿHx N¹ !pLî&lt;ÿàN^NuHç&lt; (/ z :æ  rá)v1 o `  1f  p   íg  ýg  ü  ûgN  ògN  üg  Þ`J`.ºf&amp;Àg&quot;ü Y ïRy z^S ep ÐÑÀ`
+RS dÌv2`  T`  X`     ðf´fÀgü Y ïRy z^`Rv2`fp    ír°bJÐ0;Nû  * @ @ @ @ 8 &amp; &quot; &quot; &quot; &quot; &quot; &quot; &quot; 4 &lt; VT`&amp;X`&quot;p ÐÑÀ`T`X`v1`   ðfR þf þîLß &lt;NuNVÿäHç&gt;&lt;p#À (| ¹ì*|    $m `EODTfHx N¹ !èXp ÕÀXREXfà#ê  µp#ê  µhê  zê 
+ zp9 z9 zpÂ Ä ü E Hy Hy  EäN¹ !BP4* &amp;y µh$y µp`0±BµËcøJBg4B9 B9 ü D Hy Hy  EäN¹ !BHx N¹ !èOï B9 B9 ü D Hy Hy  EäN¹ !BPz  r
+N¹ !«    0&amp;  r
+N¹ !ªDá  0 ÖXR  tN$m `EODTftY`p ÕÀ¶fì Yg  ²* * 
+Â Ä ü E Hy Hy  EäN¹ !BP4* &amp;j $j `0±BµËcøJBg4B9 B9 ü D Hy Hy  EäN¹ !BHx N¹ !èOï B9 B9 ü D Hy Hy  EäN¹ !BPRpc°l ÿ3ü  ¾èp&#x27;#À ¾êHx (Hx Hy ¾ØHx N¹ !
+Hy !ÈÜN¹  ßHy !ÈâHy ¼ÌN¹ !·Oï JgHy !ÈèHy ¼ÌN¹ !·PJfP#üH²@ |D#ü !Èî vØ#ü !Èò ¼¸#ü !Èø vÐ#ü !Èü ¼Ø#üE¥   và#üB33 Á8-|D$  ÿð`N#üGÙ |D#ü !É vØ#ü !É ¼¸#ü !É vÐ#ü !É ¼Ø#üDz   và#üA    Á8-|CH  ÿðHy !ÉN¹  ßXJ9 ¼Ìf
+#îÿð {`Hy ¼ÌN¹ !¶îX// N¹ !²#ß {Hy !É(N¹  ßJ9 ¼Ìf
+ü Y ²*`
+ù ¼Ì ²*Hy !É2N¹  ßPJ9 ¼Ìf
+3ü ·(`Hy ¼ÌN¹  ßX3À ·(Hy !É&lt;N¹  ßXJ9 ¼Ìfp`Hy ¼ÌN¹  ßX#À ·4Hy !ÉDN¹  ßXJ9 ¼Ìfp`Hy ¼ÌN¹  ßX#À ¹Hy !ÉLN¹  ßXJ9 ¼ÌgHy !ÉVHy ¼ÌN¹ !·PJf
+ü Y ¾Q`ü N ¾Q9 Y ¾Qf N¹  ßÎHy !ÉZN¹  ßXJ9 ¼Ìg&amp;Hy ¼ÌN¹  ßX&amp; p°b   ÿbÃ x`ü  xN¹  Þf@ÿæ | !Éb&quot;| ¼Ì&quot;Ø&quot;ØØp .ÿæê    0À ¼ÓHy ¼ÌN¹  ßXJ9 ¼Ìf#ü?   ¶&lt;`Hy ¼ÌN¹ !¶îX// N¹ !²#ß ¶&lt;Hy !ÉlN¹  ßXJ9 ¼Ìf
+-|&lt;#×
+ÿè`Hy ¼ÌN¹ !¶îX// N¹ !²-_ÿè. ÿæg./9 ¶&lt;/&lt;?  .ÿæ   N¹ !³Ú/.ÿèN¹ !²úN¹ !³`,/9 ¶&lt;.ÿæ   N¹ !³Ú/.ÿèN¹ !²ú/&lt;?  N¹ !²ºN¹ !²ú#ß ¶&lt;/9 ¶&lt;/&lt;3Ö¿N¹ !²Ðl
+#ü?   ¶&lt;(| ¹ìJ9 À2g  y À2 | R Hx (Hx /Hx N¹ !
+Oï J, gTp ,  @B4 rÐ/ N¹ !¶îX// N¹ !²#ß ¹/9 ¹/&lt;?YN¹ !²Ðm/9 ¹/&lt;?33N¹ !²Ðo
+#ü?   ¹/9 ¹/9 ¶&lt;N¹ !²ú#ß Á,Hy !ÉvN¹  ßXJ9 ¼ÌgHy ¼ÌN¹ !¶îX// N¹ !²#ß Á8/9 Á,/9 Á8N¹ !²ú#ß Á0`\B9 µGN¹ !`*@ 
+gHx )Hx Hx /
+N¹ !`03ü  ¯ 3ü  ¯#ü !É~ ¯Hx (B§Hy ®ðHx N¹ !
+Oï Hy !ÉÀN¹  ß9 Y ¼Ìg
+ü N º&gt;`ü Y º&gt;Hy !ÉÊN¹  ßJ9 ¼Ìf
+ü Y ví`
+ù ¼Ì víHy !ÉÔN¹  ßOï J9 ¼Ìg&amp;Hy ¼ÌN¹  ßX&amp; p°b Qb#Ã t `p#À t p&#x27;#À yp&amp;#À yp)#À yp*#À yp/#À yp0#À yp1#À yp2#À yp3#À y p-#À y¤p.#À y¨p,#À y¬p+#À y°p=#À y´B¹ y¸9 Y vífv9 J ¾Rflü 
+ ·HN¹ !`-@ÿüg$Hx +Hx  9 |&quot; åÐå/ /.ÿüN¹ !`03ü  ¯ 3ü  ¯#ü !ÉÜ ¯Hx (B§Hy ®ðHx N¹ !
+Oï v $| °LN¹ !`$g|  `B* p
+ÕÀRp°bÞN¹ !`#À ÁJ¹ Áf:B¹ t 3ü  ¯ 3ü  ¯#ü !Ê ¯Hx (B§Hy ®ðHx N¹ !
+Oï Hy !Ê@N¹  ßXJ9 ¼ÌgHy ¼ÌN¹  ßXÀ 9  cB9 Hy !ÊHN¹  ßXJ9 ¼ÌgHy ¼ÌN¹  ßXÀ y`B9 yHy !ÊPN¹  ßXJ9 ¼ÌgHy ¼ÌN¹  ßXÀ y`B9 yJ9 gjJ9 ygbJ9 ygZ9 þ ybP9 þ ybF9 y°9 ²%e9 y°9 ²&#x27;c*9 y°9 ²%e9 y°9 ²&#x27;c9 y°9 ybB9 yB9 yB9 J9 g  N¹ !`#À gFHy !ÊXN¹  ßXJ9 ¼ÌgHy ¼ÌN¹  ßX&amp; p°b  cv åÐå#À }°`:B9 3ü  ¯ 3ü  ¯#ü !Ê` ¯Hx (B§Hy ®ðHx N¹ !
+Oï v $| °B|  p
+ÕÀRp°bìHx &#x27;N¹ !pX9 J yfb9 E ÁfXN¹ !`-@ÿøgHx ,HxXHx /.ÿøN¹ !`03ü  ¯ 3ü  ¯#ü !Ê ¯Hx (B§Hy ®ðHx N¹ !
+Oï N¹  ê#ù ¾&lt; Á4 | ¶T&quot;| ·pØfüü N ¼úü N ·g#ü ®¼ txN¹   îN¹  ª|9 Y ¾Qg
+9 Y víg09 / N¹  °2X9 Y vífHx PB§`Hx @Hx N¹  ÚÆHx %N¹ !*Oï J9 gVy y | R Hx (Hx /Hx N¹ !
+Oï J, g*ü Y ®ÂHx ./9 }°/9 }°/9 N¹ !Oï `ü N ®ÂHy ¶T/9 ¾&lt;Hy !ÊÚHy ¯N¹ !·N3ü  ¯ 3ü 
+ ¯#ü ¯ ¯Hx (B§Hy ®ðHx N¹ !
+Oï  B¹ ¶ #ù ÀØ {Hx  Hx N¹ !zHy yN¹ !JOï $ r&amp;r°bÖÐ0;Nû  J 0ÿÌ Jæ&lt;ÄöööööÿÌÿÌÿÌÿÌÿÌÿÌÿÌÿÌÿÌºN¹  ú  YfHx %N¹ !*X`Hx FHx N¹ !zPü N vì9 Y ¾Qf  Ðü  º?9 C tfHy tN¹  àtX#À ·XB9 º? 9 ·XN¹ !³Ú/9 Á,N¹ !²ä#ß ·$v &amp;| °+  fh//9 ·$N¹ !²ÐlX|  Bt + ê x 8+ î ? +  ÿÿ$@9 Â/ 9 ÂU/ /
+/ / N¹  ÛbOï ü Y vìp
+×ÀRp°b9 Y w5fh9   ·|g^ü N w5t 9 Âê x 89 Âî ? 9 Â ÿÿ$@9 Â/ 9 ÂU/ /
+/ / N¹  ÛbOï ü Y vì9 Y ®Âf6J9 ÀÜf.9 y/ 9 y/ N¹  ÜÂ/9 N¹ !fOï ü N ®Â9 Y ¾Qff/9 ·$/9 vàN¹ !²ä-_ÿìp 09 / /9 ¶ /9 vÐ/.ÿìN¹ !³&amp;/9 vØ/9 ·$N¹ !³&amp;/9 ·XHy !ÊðHy ¯N¹ !·NOï ,`&amp;p 09 / /9 ¶ Hy !Ë Hy ¯N¹ !·NOï 3ü  ¯ 3ü  ¯#ü ¯ ¯Hx (Hx Hy ®ðHx N¹ !
+Oï #ù ÀØ {N¹  Ê|9 Y vìf üøHx %N¹ !*X` üèHx %N¹ !*X` üØ&amp;p/ åÐÐ,  | °T¼    | °P0`    ÿê  | °P80`   ÿÿî ? | °P 0`  ÿÿ$@9 Â/ 9 ÂU/ /
+/ / N¹  ÛbHx %N¹ !*Oï ` üL9 Y ¾Qg9 Y víg ü609 / N¹  °2Hx @B§N¹  ÚÆHx %N¹ !*Oï ` ü
+y ²( Cy ²&quot; D9 y`H| R B Hx (Hx /Hx N¹ !
+Oï J, g(| A Hx (Hx /Hx N¹ !
+Oï R´9 yc°Hx %N¹ !*X` û9 E Áf û9 Y yg$9 Y µLg| ÿôHnÿôHx N¹ !bP` ûX/.ÿøN¹ !fX` ûH9 Y µLg| 	ÿôHnÿôHx N¹ !bP` û$/.ÿüN¹ !fX` ûN¹  ).` û
+Lî&lt;|ÿÀN^NuHç &lt;$| ví&amp;| ®ð(| ¶T*| N¹  ê 9 Á4°¹ ¾&lt;g tY#ù ¾&lt; Á4 L&quot;| ·pØfüN¹   î`69 Y º&gt;f*/Hy ·pN¹ !·PJgtY L&quot;| ·pØfüN¹   î`tN9 Y ³dg Yf R Yf  N¹   îB¹ ¶ J9 g89 y/ 9 y/ N¹  ÜÂP9 Y ®Âf/9 N¹ !fXü N ®Â//9 ¾&lt;Hy !Ë8Hy ¯N¹ !·N7|  7| 
+ &#x27;| ¯ Hx (B§/Hx N¹ !
+Oï  9 ±æ/ 9 ±ÿ/ N¹  ÜÂP Yg9 µd/ 9 µe/ N¹  ÜÂP9 Y vÕf Yf49 ·n`49 ·nBÿÿ`BB9 Y ¾Qg YgHx N0/ N¹  ²P:/ N¹  °2Oï `:¼  YfHx PB§`Hx @Hx N¹  ÚÆPü N ³dpY`pNLß&lt;NuHç &lt;(| ¾&lt;*| ²%p 9 z¬r &quot; ÐÐÐ | ºÀÑÀ&amp;H(«     g
+p 9 ²$`p 9 ²r &quot; ÐÐÐ | ºÀÑÀ&amp;H(«  °¹ ·f
+ü Y ¼ú`ü N ¼úB9 ¶TJ9 ²gj&amp;| ¹ìy ² | R Hx (Hx /Hx N¹ !
+Oï + g8p×À$| ¶T`RS  f
+Jfò`ÛSJføSB*   fµü ¶TdìLß&lt;NuNV  Hç8&lt;9 z9 zpÄ Ã ü E Hy Hy  EäN¹ !BHy !ËNB§N¹  ª$&amp;@ g&amp;ë  µPë 
+ µQ#ë  µRp×À#ë  µV`B¹ µR9 Y º&gt;fHy ¶T`Hy !ËO/9 ¾&lt;N¹  ª$Oï &amp;@ g&amp;ë  µZë 
+ µ[#ë  µ\p×À#ë  µ``B¹ µ\(| #Ì ¼ü#Ì ¾D#Ì räBy #ù { ±,B¹ ·8B¹ ·Lü N vÕt $| µP* &amp;j *j  g@Ä Ã ü E Hy Hy  EäN¹ !B/
+// / /N¹  £Oï (@p
+ÕÀRp°n¢ ]#À ¾83ù  ·nJ¹ ·LgR/9 ·8 9 ·LN¹ !³ÌN¹ !²ä#ß ·8/9 ·8/&lt;&lt;ú4N¹ !²úN¹ !«nX#À Á/ /9 ÁN¹ !²ú#ß ¼´#Ì ¾H#Ì ½ By t $| µP* &amp;j *j  g@Ä Ã ü E Hy Hy  EäN¹ !B/
+// / /N¹  ¦Oï (@p
+ÕÀRp°n¢#Ì t ]#À ¾LB9 B9 ü D Hy Hy  EäN¹ !BLî&lt;ÿäN^NuNV  Hç&lt;&lt;(. *. $n &amp;n Kî ` U ef/N¹  «èX  YgR·Õdâ(UTRy vN` . U ae   zb  gf ÌR UR Af  U yf úR/Hn Hx ÿHx ÿN¹  ¬Oï %@ * ð * Ï 09   ÿíR ?R/9 ·8/* N¹ !²º#ß ·8R¹ ·Lµù txd\ U xf R/Hn Hx ÿHx ÿN¹  ¬Oï %@ * ð  *  * Ï 09   ÿíR ?Rµù txd\ U zfhR/Hn Hx ÿHx ÿN¹  ¬Oï %@ * ð  *  * Ï 09   ÿíR ?R/9 ±,/* N¹ !²Ðl#ê  ±,µù txd\ Yg
+9 Y ·gf* ð  *  `* ð 09   ÿíR ?R * 0    ë*  *    ?ïjà j   ÿÿªÿ   ª µù txdJ\`F cfTü Y vÕ`4 kfRvY`( ef /N¹  «èX  Yg R(@Ry vN`R·Õd ýÐ 
+Lî&lt;&lt;ÿàN^NuNV  Hç?&lt;,. .. $n (n `  n  ef/. N¹  «èX  Yg
+R® ¹î dÚvN*n T® Ry zN` ¨ n  ae  zb  gfvR®  n R®  AfD n  yg$ xg zf&amp;` n  gg P eg HR® ¹î dà` :BD` 4 Bfx` ( Cfx` x`  hfdR® /Hn Hx ÿHx ÿN¹  ¬Oï %@ * ð  *  0   é* Ï * 09   ÿíR ?Rµù txd\vY` ¬ lfdR® /Hn Hx ÿHx ÿN¹  ¬Oï %@ * ð  *  0   é* Ï * 09   ÿíR ?Rµù txd\vY` B sftR® &amp;JT n R® Ð n R® Ð n R® Ð n R® * ð  *  0   é* Ï * 09   ÿíR ?Rµù txd\vY` È tfhR®  n R® P  n R® P B* B* * ð  *  0   é* Ï * 09   ÿíR ?Rµù txd\vY` Z wfdR® /Hn Hx ÿHx ÿN¹  ¬êOï %@ * ð  *  0   é* Ï * 09   ÿíR ?Rµù txd\vY`  ð kf
+R® zY`  à ef  Ô9 Y víg Nf4* ð  *  `, Yf   Yg
+9 Y ·gf* ð  *  `* ð 09   ÿíR ?R * 0    ë*  *    ?ïjà j  
+ ÿÿªÿ   ª µù txd\vN/. N¹  «èX  Yg  . R® *@Ry zN`R® ¹î d üT 
+Lî&lt;üÿØN^NuHç 0&quot;/ &amp;y µp y µh`6²f$$o t &quot;KX°fJf ` RRp°nè`
+²dpÿ°fp×À·ÈcÆp LßNuHç 0ü N w5$| ¹ì| C y ÂU Cy Â DHx (Hx /
+Hx N¹ !
+y ´Í | R Hx (Hx /
+Hx N¹ !
+p *  @B2 
+rÐ/ N¹  ßOï $3À 49 $y ¾D&amp;y rä`\p 0ì  ÿr 2°f2*   0f*   f&amp;J*   0  0f&quot;#Ê ¾D#Ë rä`,p 0ì  ÿr 2°b\µù ¾8b 9 ¼ü°¹ ¾8c$y ½ `@p 0ì  ÿr 2°f*   0  0f#Ê ½ `,p 0ì  ÿr 2°b\µù ¾Lb 9 ¾H°¹ ¾LcªLßNu o  ef 1f ae
+ zbpYNupNNuNVÿðHç8&lt;&amp;. (. &amp;n  ÿg. ÿg(Ä Ã ü E Hy Hy  EäN¹ !BP$SIîÿðKîÿÿ`ÂR 0e 9c +g -g .f
+¹Ídµî cÒB&amp; ÿg. ÿg(Ä Ã ü D Hy Hy  EäN¹ !BPHnÿðN¹ !¶îX// N¹ !² Lî&lt;ÿÔN^NuNVÿðHç8&lt;&amp;. (. &amp;n  ÿg. ÿg(Ä Ã ü E Hy Hy  EäN¹ !BP$SIîÿðKîÿÿ`ÂR 0e 9b
+¹Ídµî cäB&amp; ÿg. ÿg(Ä Ã ü D Hy Hy  EäN¹ !BPHnÿðN¹  ßLî&lt;ÿÔN^NuNV  Hç&lt;&lt;&amp;. (. *. Kî Å Ä ü E Hy Hy  EäN¹ !B// / N¹  ÉÞOï (@$y t U ef ê` ä U ae Ø zb Ð gfR UR Ag ¼` ¾ hfTR/Hn Hx ÿHx ÿa þOï N¹ !³Ú%_ * ð  *  * Ï 0  ÿíR ?Rµù txd d\` ^ lfTR/Hn Hx ÿHx ÿa þ&lt;Oï N¹ !³Ú%_ * ð  *  * Ï 0  ÿíR ?Rµù txd 
+\`  sfPR&amp;JT URÐ URÐ URÐ UR* ð  *  * Ï 0  ÿíR ?Rµù txd  ´\`  ® tfHR URP  URP B* B* * ð  *  * Ï 0  ÿíR ?Rµù txdb\`^ wfJR/Hn Hx ÿHx ÿa ý&gt;Oï %@ * ð  *  * Ï 0  ÿíR ?Rµù txd\` kg egR¹Õd þ 
+]#À tÅ Ä ü D Hy Hy  EäN¹ !BLî&lt;&lt;ÿàN^NuHç?&lt;$/ ,*| ¹ì:9 ·n9 Y vÕf|&gt;`&lt;RF&gt;RG$y ¾D&amp;y ½ ´Ee Ð0` Îp (@B b  ®$y ¼ü&amp;y ¾H`  p 0ì  ÿr 2°fp*   0f*   *   0  0ff*   g
+9 Y víg*  g  î9 Y víg  âx * ê v 6* î ? *  ÿÿ(@`  ºp 0ì  ÿr 2°b  ¤\µù ¾8b   9 ¼ü°¹ ¾8c ÿL`  p 0ì  ÿr 2°fX+   0  0f^+   g
+9 Y víg+  g^9 Y vígTx + ê v 6+ î ? +  ÿÿ(@`.p 0ì  ÿr 2°b\·ù ¾Lb 9 ¾H°¹ ¾Lc ÿh gL| C y µe Cy µd DHx (Hx /
+Hx N¹ !
+Hx PHx NHx Y// / N¹  ÒOï (`´Ee0`0R@4 ´Gf þ.Lß&lt;üNuNVÿðHç?&lt;$. v $| °L*  f&amp;|  /N¹ !fXr²f r/Ð/ N¹ !Xp
+ÕÀRp°nÆv $| °B|  p
+ÕÀRp°nìü N w5-| ¹ìÿò nÿò| C  nÿòy ÂU C nÿòy Â DHx (Hx /.ÿòHx N¹ !
+Oï =Bÿþ69 ·n9 Y vÕf|&gt;`&lt;RF&gt;RG$y ¾D(y rä&amp;y ½ ´Ce º0` ¸B®ÿúB b  È$y ¼ü(y ¼ü&amp;y ¾H`  ²p 0ì  ÿr 2°f  *   0f*   f(J*   0  0ft*   g
+9 Y víg*  g 9 Y víg  ø#Ê ¾D#Ì räz * ê x 8* î ? *  ÿÿ-@ÿú`  Âp 0ì  ÿr 2°b  ¬\µù ¾8b    9 ¼ü°¹ ¾8c ÿ8`  p 0ì  ÿr 2°f`+   0  0ff+   g
+9 Y víg+  gf9 Y víg\#Ë ½ z + ê x 8+ î ? +  ÿÿ-@ÿú`.p 0ì  ÿr 2°b\·ù ¾Lb 9 ¾H°¹ ¾Lc ÿ`J®ÿúg -nÿúÿö9 Y víf J9 Y ·gg &gt;/.ÿú/ / N¹  ÉÞ*@Hx NHx k/
+/.ÿú/ / N¹  ÈÂOï $-@ÿúg ¸/.ÿú/ / N¹  ÉÞOï *@/
+Hnÿú/ / a ö¬Oï / /9 Á,N¹ !²úN¹ !³J/ N¹  Üø=Bÿþp 0/ Hy !ËP .ÿòrÐ/ N¹ !·N nÿò@  nÿòy ´Í  nÿò| W Hx (Hx /.ÿòHx N¹ !
+ nÿò| C  nÿòy ±ÿ C nÿòy ±æ DHx (Hx /.ÿòHx N¹ !
+Oï 0Hx EHx NHx Y/.ÿö/ / N¹  ÒOï `  Ì=Bÿþp 0/ Hy !ËT .ÿòrÐ/ N¹ !·N nÿò@  nÿòy ´Í  nÿò| W Hx (Hx /.ÿòHx N¹ !
+ nÿò| C  nÿòy ±ÿ C nÿòy ±æ DHx (Hx /.ÿòHx N¹ !
+Oï ,Hx E. / Hx Y/.ÿö/ / N¹  ÒOï `´Ce0`0R@4 ´Gf üD0.ÿþLî&lt;üÿÈN^NuNVÿðHç?&lt;v $| °L*  f&amp;|  /N¹ !fXr²f r/Ð/ N¹ !Xp
+ÕÀRp°nÆv $| °B|  p
+ÕÀRp°nìü N w5$| ¹ì| C y ÂU Cy Â DHx (Hx /
+Hx N¹ !
+Oï  9 ¾L¹ ¾HrN¹ !ªD* *y ¾H$y ¾H`  ¼t * è  g  ¦*     f  x 8ìDÿ-j ÿø\p * è   r °fn*     f`\*   0  0fð*   gHp 0ì  ÿr 2°f4=Dÿüp * ê  @ÿÿp 0* î  ?@ÿþ *  ÿÿ(@`\B®ÿøµù ¾Lc ÿ:µù ¾Lc
+09 ` Ê$y ¾LB®ÿôvN`  Æ*   0  0f  ´*   g  ªx 8ìDÿ~ * ê | &lt;* î ? *  ÿÿ&amp;@`Z*     fL`t * è ]*     gä*     f&quot;p * è   r °f-j ÿôvY`]p 0ì  ÿr 2°g Yf`]µù ¾Hd ÿ4/.ÿøB§N¹ !²Ðoh/.ÿô/.ÿøN¹ !²ÐoX/.ÿô/.ÿøN¹ !³-_ÿô/9 ·$/.ÿôN¹ !²ä-_ÿø N¹ !³Ú/.ÿøN¹ !²úN¹ !³J* ÐÐÐÐ¹ ¾H$@µù ¾Ld*J$Mz :ìEÿ`8*   0  0f(~ * ê | &lt;* î ? *  ÿÿ-@ÿð`\p 0ì  ÿr 2°g´B®ÿøvN`  ä*   0  0f  Ò*   g  Èz :ìEÿ~ * ê | &lt;* î ? *  ÿÿ-@ÿð`t*     ff`t * è ]*     gä*     f&lt;p * è   r °f&amp;/* /9 ·$N¹ !²Ðo8-j ÿø&amp;nÿð`vY`]p 0ì  ÿr 2°g ÿv Yf`]µù ¾Hd ÿ .ÿøãf  Ü$MB®ÿø`  Èt * è  g  ¬*     f  x 8ìDÿ-j ÿø\p * è   r °ft*     ff\*   0  0fð*   gNp 0ì  ÿr 2°f:/.ÿø/9 ·$N¹ !²Ðo(~ * ê | &lt;* î ? *  ÿÿ&amp;@`\B®ÿøBDµù ¾Lc ÿ2 .ÿøãf$9 Y vÕf8.ÿü.ÿÿ.ÿþ&amp;L`
+09 ` // / N¹  ÉÞ(@Hx NHx k/// / N¹  ÈÂOï $-@ÿðg  Ü/.ÿð/ / N¹  ÉÞOï (@/Hnÿð/ / a ïFOï / /9 Á,N¹ !²úN¹ !³J/ N¹  Üø$| ¹ìp 0/ Hy !ËX 
+rÐ/ N¹ !·N@ y ´Í | W Hx (Hx /
+Hx N¹ !
+| C y ±ÿ Cy ±æ DHx (Hx /
+Hx N¹ !
+Oï 0Hx EHx NHx Y// / N¹  Ò0Lî&lt;üÿÈN^NuNVÿôHç?&lt;$. v $| °L*  f&amp;|  /N¹ !fXr²f r/Ð/ N¹ !Xp
+ÕÀRp°nÆv $| °B|  p
+ÕÀRp°nìü N w5-| ¹ìÿö nÿö| C  nÿöy ÂU C nÿöy Â DHx (Hx /.ÿöHx N¹ !
+Oï =Bÿþ&gt;9 ·n9 Y vÕf6&lt;`BCBF 9 ¾D°¹ ¼üg 9 ¾D` 9 ¾8$@ 9 ½ °¹ ¾Hg 9 ½ ` 9 ¾L&amp;@B b ²0` ²B®ÿú´Ge  È$y ¾8/9 ¾8N¹  Ê6X#À rä&amp;y ¾L`  ¤p 0ì  ÿr 2°fv*   0  0f~*   g
+9 Y víg*  g 9 Y víg #Ê ¾D/
+N¹  Ê6X#À räz * ê x 8* î ? *  ÿÿ-@ÿú`  Âp 0ì  ÿr 2°e  ¬]µù ¼üe    9 ¼ü°¹ ¾8c ÿF`  p 0ì  ÿr 2°f`+   0  0ff+   g
+9 Y víg+  gf9 Y víg\#Ë ½ z + ê x 8+ î ? +  ÿÿ-@ÿú`.p 0ì  ÿr 2°e]·ù ¾He 9 ¾H°¹ ¾Lc ÿ`J®ÿúg 
+*nÿú9 Y víf H9 Y ·gg &lt;/.ÿú/ / N¹  ÉÞ(@Hx NHx k//.ÿú/ / N¹  ÈÂOï $-@ÿúg ²/.ÿú/ / N¹  ÉÞOï (@/Hnÿú/ / a ëROï / /9 Á,N¹ !²úN¹ !³J/ N¹  Üø=Bÿþp 0/ Hy !Ë\ .ÿörÐ/ N¹ !·N nÿö@  nÿöy ´Í  nÿö| W Hx (Hx /.ÿöHx N¹ !
+ nÿö| C  nÿöy ±ÿ C nÿöy ±æ DHx (Hx /.ÿöHx N¹ !
+Oï 0Hx EHx NHx Y/
+/ / N¹  ÒOï `  Ì=Bÿþp 0/ Hy !Ë` .ÿörÐ/ N¹ !·N nÿö@  nÿöy ´Í  nÿö| W Hx (Hx /.ÿöHx N¹ !
+ nÿö| C  nÿöy ±ÿ C nÿöy ±æ DHx (Hx /.ÿöHx N¹ !
+Oï ,Hx EHx NHx Y/
+/ / N¹  ÒOï `B b0`0@ÿÿ4 ´Ff üJ0.ÿþLî&lt;üÿÌN^NuNVÿðHç?&lt;v $| °L*  f&amp;|  /N¹ !fXr²f r/Ð/ N¹ !Xp
+ÕÀRp°nÆv $| °B|  p
+ÕÀRp°nìü N w5$| ¹ì| C y ÂU Cy Â DHx (Hx /
+Hx N¹ !
+Oï  9 ¾L¹ ¾HrN¹ !ªD( *y ¾H$y ¾H`  t * è  gr*     fdz :ìEÿ\p * è   r °fD*     f6-j ÿø\*   0  0fð*   gp 0ì  ÿr 2°f`\B®ÿøµù ¾Lc ÿnµù ¾Lc
+09 ` â$y ¾LB®ÿôvN`  Ö*   0  0f  Ä*   g  ºz :ìEÿ~ * ê | &lt;* î ? *  ÿÿ&amp;@`h*     fZ`t * è -j ÿô]*     gÞ*     f*p * è   r °f=EÿüGÿÿFÿþ(KvY`]p 0ì  ÿr 2°g ÿ Yf`]µù ¾Hd ÿ$/.ÿøB§N¹ !²Ðoh/.ÿô/.ÿøN¹ !²ÐoX/.ÿô/.ÿøN¹ !³-_ÿô/9 ·$/.ÿôN¹ !²ä-_ÿø N¹ !³Ú/.ÿøN¹ !²úN¹ !³J( ÐÐÐÐ¹ ¾H$@µù ¾Ld*J$MB®ÿø`  Ìt * è  g  ¶*     f  ¦x 8ìDÿ\p * è   r °f  *     ft-j ÿô\*   0  0fð*   gVp 0ì  ÿr 2°fB/.ÿô/9 ·$N¹ !²Ðl::-nÿôÿø~ * ê | &lt;* î ? *  ÿÿ&amp;@`\µù ¾Lc ÿ. .ÿøãf V$Mx 8ìDÿ`8*   0  0f(~ * ê | &lt;* î ? *  ÿÿ-@ÿð`\p 0ì  ÿr 2°g´B®ÿøvN`  è*   0  0f  Ö*   g  Ìx 8ìDÿ~ * ê | &lt;* î ? *  ÿÿ-@ÿð`x*     fj`t * è -j ÿô]*     gÞ*     f:p * è   r °f$/.ÿô/9 ·$N¹ !²Ðl:-nÿôÿø&amp;nÿðvY`]p 0ì  ÿr 2°g ÿr Yf`]µù ¾Hd ÿ .ÿøãf$9 Y vÕf:.ÿü.ÿÿ.ÿþ&amp;L`
+09 ` // / N¹  ÉÞ(@Hx NHx k/// / N¹  ÈÂOï $-@ÿðg  Ü/.ÿð/ / N¹  ÉÞOï (@/Hnÿð/ / a ä
+Oï / /9 Á,N¹ !²úN¹ !³J/ N¹  Üø$| ¹ìp 0/ Hy !Ëd 
+rÐ/ N¹ !·N@ y ´Í | W Hx (Hx /
+Hx N¹ !
+| C y ±ÿ Cy ±æ DHx (Hx /
+Hx N¹ !
+Oï 0Hx EHx NHx Y// / N¹  Ò0Lî&lt;üÿÈN^NuHç&gt;&lt;&amp;/ &lt;(/ 8*/ ,,/ ($o 0&amp;o 4(| *L\ ÿg&quot; ÿgF E ¼ E/Hy  EäN¹ !BP efR Ng  `D gf6¶f8 gfv ÿg&quot; ÿgF E ¼ D/Hy  EäN¹ !BP 
+`x egHµËc¸`&gt;´f, ÿg&quot; ÿgF E ¼ D/Hy  EäN¹ !BP 
+`: eg
+ ggµËc¾ ÿg&quot; ÿgF E ¼ D/Hy  EäN¹ !BPp Lß&lt;|NuHç8 &amp;/ (/ &quot;o t $| µP¸f(¶* f&quot;³ê e³ê d02 åHÐAÐ@ | µV 0  `p
+ÕÀRp°nÈp LßNu/&quot;o t 4ìBÿ I`)   f I`]p 0ì  ÿr 2°f³ù ¼üdÔ $NuNVÿøHç8&lt;Iîÿü*| ü Y 9 Y ¾Qg9 Y víg J9 ·g  B9 ·9 Y víf9 Y ·gf  ì/9 ÁN¹ !fXJf
+0/ a åHXHx Y0/ a çXP:J¹ t g  Hx -B§ 9 t &quot; åÐå/ /9 ÁN¹ !Oï B§Hx @`  ~J9 ·g,B9 ·9 Y víf9 Y ·gga ÷`B0/ a ò X`6J9 ·gHB9 ·9 Y víf9 Y ·gga ë`Hx N0/ a æ²P:0/ a äXHx @B§N¹  ÚÆP9 Y ·gg |B$| ¹&amp;| ·|  R eð0/ N¹  àX:(¹ ¾H` Hx N/9 ¾LHnÿüN¹  ÏLOï   Yf Ø9 Y ¾Qg  Ê T(    fZ T(    ÿê  T8(   ÿÿî ? T (  ÿÿ&amp;@Hx EHx YHx Y// / N¹  ÒOï  T (   T4  ÿÿìBÿ:$| ¹ìp 0/ Hy !Ëh 
+rÐ/ N¹ !·N@ y ´Í | W Hx (Hx /
+Hx N¹ !
+Oï `  T(   g v9 Y vÝg þ T(    fZ T(    ÿê  T8(   ÿÿî ? T (  ÿÿ&amp;@Hx EHx YHx Y// / N¹  ÒOï  T (   T(    ÿê  T8(   ÿÿî ? T (  ÿÿ&amp;@// / a ü.$@Hx NHx k/
+// / a úøOï $-@ÿøg 0 T4  ÿÿìBÿü Y vÝ/
+Hnÿø/ / a ÞOï / /9 Á,N¹ !²úN¹ !³J/ N¹  Üø:$| ¹ìp 0/ Hy !Ël 
+rÐ/ N¹ !·N@ y ´Í | W Hx (Hx /
+Hx N¹ !
+Oï  `   T4  ÿÿìBÿ´y wXg| T(    fn T(    ÿê  T8(   ÿÿî ? T (  ÿÿ&amp;@Hx EHx YHx Y// / N¹  ÒOï  T (  ` T(  g T( ý \ °¹ ¾Lc üìB$| ¹&amp;| ·| g &gt; g &gt;RRR eàLî&lt;ÿÜN^NuNVÿüHç?&lt;(. (n *n $Tp 0ì@ÿ=@ÿþp * è@ =@ÿüvYzN|N~NB&amp;| ¹p  | ·|0 ¿   ¿R eä` ä*    Wr°b Ð0;Nû  &amp; 
+ J  ðxYzY/9 ·$/* N¹ !²Ðl  ä`  ÞxY|Y/9 ·$/* N¹ !²Ðn  Æ Nf  À`  ºxY~Y*  Ï d  ¦p * rB°grE°g6rF°gVrT°gb`  p  | ·| 0 @  p  | ·|0     `Fp  | ¹ 0 @  p  | ¹0     ` p  | ÀÜJ0  g(`$p  | ÀÜJ0  f`xY 9 {°ª g`xYvN\p * è   r 2.ÿü°g  ¦ Ng( Nf Yg Yf Nf9 Y vÕf NgvN Yf0`\*   0  0g  p 0ì  ÿr 2.ÿþ°fnµÍcÔ`hp * è@ =@ÿüvYxNzN|N~NB&amp;| ¹p  | ·|0 ¿   ¿R eäµÍb&amp;*   0  0gp 0ì  ÿr 2.ÿþ°g ýö Yf`pN  Yf&gt;B&amp;| ¹p  | ·|0   gp  | ·| 0    g  RR eÊ(Lî&lt;üÿÔN^NuNVÿÔHç?&lt;*. $n î  î  ü E Hy Hy  EäN¹ !B/
+. / . / a ÷xOï (@-| ¹ìÿÔ~ B.ÿà efR ae zcµÌcìxN`  p rq°grm°gNra°g  rb°g  Ö` XRGîÿÿKîÿð`ÂR 0e 9b»ËdµÌcæBHnÿðN¹  ßX. ` BR. Y f(/ ///
+. / . / N¹  Õ|Oï $@` R ae zc  µÌcê` øR. Y f*xYGîÿàv`ÂRR 0e
+ 9bµÌcèB` ÆR ae zc ´µÌcê` ¬R. Y f h Yf `xNGîÿØ`ÂR 0e
+ 9bµÌcêBHnÿØN¹  ß Gîÿà*nÿÔpÛÀ  aÀÛfü nÿÔ| A  Ef nÿÔy ²( C nÿÔy ²&quot; D` nÿÔy µ&lt; C nÿÔy ´Ô D nÿÔC Hx (Hx /.ÿÔHx N¹ !
+Oï ü Y vì¼9 f  Þ Ef  Ö9 Y ·gg  Ê9 N ®Âf&gt;9 y/ 9 y/ N¹  ÜÂü Y ®ÂHx ./9 }°/9 }°/9 N¹ !Oï  nÿÔ| A  nÿÔy y C nÿÔy y D nÿÔC Hx (Hx /.ÿÔHx N¹ !
+Oï `:R ae zc*µÌcì`$ ae zbµÌbR ae zcµÌcì egµÌc ýVî  î  ü D Hy Hy  EäN¹ !BLî&lt;üÿ¬N^NuNVÿøHç?&lt;&amp;. *. ,. .. $n (n -| ¹ìÿø*nÿøpCÛÀ  çf   Pg  9 Y w5f 
+` ðü Y w5   ë9  Â9 Â   ?ïyà Ây Â 
+ ÿÿ¹ÿ   Â¹ Â nÿø| A  nÿøy ÂU C nÿøy Â D` ª  äe ~  æb t Pg lzNx &amp;| °  f   æfvA`  åfvB`vC/ Hx h//
+Hx ÿHx ÿa ò Oï -@ÿüg  ÔzY/HnÿüHx ÿHx ÿa ÕLOï / 2/ 0åIÒ@ÒA  | °Að  02 åHÐAÐ@ | ° ¼      ë/ 02 åHÐAÐ@&quot; | °0   0     ?ï/ 02 åHÐAÐ@&quot; | °pà  p   
+ ÿÿ/ 02 åHÐAÐ@&quot; | °°ÿ    °  `p
+×ÀRp°n þê Nf`R aeö zcµÌcì 
+`  nÿø| A  nÿøy ÂU C nÿøy Â D` $  ãf, Pg&amp; nÿø| A  nÿøy ÂU C nÿøy Â D` ð  âf, Pg&amp; nÿø| S  nÿøy ÂU C nÿøy Â D` ¼Jg 6 Pg .zNx &amp;| °T f  ÆzY02 åHÐAÐ@ | °T¼      ë/ 02 åHÐAÐ@&quot; | °P0   0     ?ï/ 02 åHÐAÐ@&quot; | °Ppà  p   
+ ÿÿ/ 02 åHÐAÐ@&quot; | °P°ÿ    °   r/Ð/ B§ åÐå/ 02 åHÐAÐ@ | °L/0  N¹ !Oï `p
+×ÀRp°n ÿ( Nf`R aeö zcµÌcì 
+` x nÿø| A  nÿøy ÂU C nÿøy Â D`   Pf nÿøy µe C nÿøy µd D` nÿøy ±ÿ C nÿøy ±æ D9 Y f4ü N  nÿø| C Hx (Hx /.ÿøHx N¹ !
+Oï ü Y vì nÿø| A  Ae   Kb  &amp;nÿøp×À   ÀvR Hf,ÂRR 0e 9c Ae$ Fb·ÍeÜ`ÂRR 0e
+ 9b·Íeè ,fR nÿøC Hx (Hx /.ÿøHx N¹ !
+Oï ü Y vì` ÿ`R ,g ae zcµÌcæ ,fµÌc 
+`R` ÿ2Lî&lt;üÿÐN^NuNV  Hç  $| ¹ìy z¬ | R Hx (Hx /
+Hx N¹ !
+p *  @B2 
+rÐ/ N¹  ß .  . F Ä p / Hy !Ëp 
+rÐ/ N¹ !·N@ | W Hx (Hx /
+Hx N¹ !
+LîÿøN^NuNVÿüHç&lt;&lt;(. *. &amp;n Å Ä ü E Hy Hy  EäN¹ !B// / a î6Oï -@ÿü(| ¹ì*LpCÛÀ| S n  Cn  D Ae   Kb  $LpÕÀ   ÀvR Hf,ÂRR 0e 9c Ae$ FbµÍeÜ`ÂRR 0e
+ 9bµÍeè ,fRC Hx (Hx /Hx N¹ !
+Oï ` ÿpR ,f ae zc·îÿücä ,f·îÿüc(Å Ä ü D Hy Hy  EäN¹ !B`R` ÿLî&lt;&lt;ÿÜN^Nu&quot;/  /  | ¹ì@ CA D| C Hx (Hx /Hx N¹ !
+Oï NuHç88$/ &amp;| ¯l(| º?B9 µGHx B§N¹ !ÞHx )N¹ !Oï $Kü !ü CPBv   0 è$ Rp°dæB#Ë {#ü ·\ zü 
+ ´ÆB9 t| y z|  Hx 
+Hx )N¹ !Pr²fB`t¼ Hy t/N¹ !·PJgBBJg9 x$Kü !ü STB   0è    0B#Ë {#ü ·\ zü  ´ÆB9 t| y z|  Hx 
+Hx )N¹ !Pr²fB`t¼ Hy t/N¹ !·PJgBBJgü  µGLßNuHç0&lt;*| tB9 µGHx B§N¹ !ÞHx )N¹ !Oï B(MV&amp;MT$MR`b#ü !Ët {#ü ·\ zü  ´ÆB9 t| y z|  Hx 
+Hx )N¹ !Pr²g Dft é  Ö B9 º?Jgü  µGLß&lt;Nu/ o t  HffR`&gt; 0e 9b é$    `  Ae Fb é$       	Ôf¾`&quot; 0e 9b åÔÔ   ÔfÞ $Nu o &quot;| ¼à3| 
+ #H #| ¼Ì Hx (Hx Hy ¼àHx N¹ !
+Oï NuHç  B9 ² ü  ²¡$y z|p	ÕÀNqNqNqNqNqNqJB9 ²¡9  ² f
+B§N¹ !èXpÿ#À ·Xü  µGHxÿHx Hx /9 zN¹  hOï  |  9  vÉ y z|y vÉ 
+|øÿ#ü ·g zhB9 º?LßNu/ o t RR`  é$ p fì $NuNVÿØHç&lt;&lt;$. Iîÿü*| ¶ $| ·@:By wXü N vÝJf Nü N ÂTJ* f 
+Ú-Rÿô-j ÿð/9 ±,/9 |DN¹ !²ä-_ÿØ/.ÿô/.ÿØN¹ !³-_ÿè/.ÿô/.ÿØN¹ !²º-_ÿä/.ÿØ/9 ÁN¹ !²ä-_ÿØ/.ÿð/.ÿØN¹ !³-_ÿà/.ÿð/.ÿØN¹ !²º-_ÿÜ89 ·n¸y ·(d89 ·n`89 ·((¹ rä SDJ@g 
+2´y ·nc  ò9 Y vÕg9 Y ²*f 
+(¹ ¼ü T4  ÿÿìBÿ`  Â T0  ÿÿì  ÿr 2°f   T(   0f   T(   fV T#è  ®è\ T(     f6 T#è  ®ä\#ù { ®Ä T(     f T#è  ®Ä\vY`RvN`N T(     f$vN`: T0  ÿÿì  ÿr 2°cvN`\ °¹ ¾8b 9 ¼ü°¹ ¾8c ÿ( Yf t/9 ®è/.ÿèN¹ !²Ðm `/9 ®è/.ÿäN¹ !²Ðn L/9 ®ä/.ÿàN¹ !²Ðm 8/9 ®ä/.ÿÜN¹ !²Ðn $-y ®Äÿì/.ÿì/9 |DN¹ !²ä-_ÿì/.ÿì/.ÿìN¹ !²ú#ß ·/.ÿô/9 ®èN¹ !³-_ÿô/.ÿô/.ÿôN¹ !²ú-_ÿô/.ÿð/9 ®äN¹ !³-_ÿð/.ÿð/.ÿðN¹ !²ú-_ÿð/.ÿð/9 ¼´N¹ !²ú-_ÿð/.ÿô/.ÿðN¹ !²º/9 ·N¹ !²Ðn vp*p 0/ /9 ®ÄN¹ !³&amp;/9 ®äN¹ !³&amp;/9 ®èN¹ !³&amp;Hy !ËxHy ¯N¹ !·NOï $3ü  ¯ 3ü  ¯#ü ¯ ¯Hx (Hx Hy ®ðHx N¹ !
+Oï `  è T(   0  0fn T0  ÿÿì  ÿr 2°fT#Ô t T(    ÿê  T6(   ÿÿî ? T (  ÿÿ$@0/ /
+/ / N¹  ­¦Oï `  T0  ÿÿì  ÿr 2°cLBHy !Ë¢Hy ¯N¹ !·N3ü  ¯ 3ü  ¯#ü ¯ ¯Hx (B§Hy ®ðHx N¹ !
+Oï ` ¶\ °¹ ¾8c ÿ` ¤RB` üdJ* f Ú-Rÿô-j ÿðü N ÂT/.ÿô/9 ®èN¹ !³-_ÿô/.ÿô/.ÿôN¹ !²ú-_ÿô/.ÿð/9 ®äN¹ !³-_ÿð/.ÿð/.ÿðN¹ !²ú-_ÿð/.ÿð/9 ¼´N¹ !²ú-_ÿð/.ÿô/.ÿðN¹ !²º/9 ·N¹ !²Ðn ò °¹ ·4dR °¹ ¹e î(¹ tHx Y/9 tHnÿüN¹  ÏLOï   Yf º(¹ t9 Y ¾Qg  â T4  ÿÿìBÿ3Â wX T(    fZ T(    ÿê  T6(   ÿÿî ? T (  ÿÿ$@Hx EHx YHx Y/
+/ / N¹  ÒOï  T (  /9 tN¹  Ê6#À rä:$| ¹ìp 0/ Hy !ËÞ 
+rÐ/ N¹ !·N@ y ´Í | W Hx (Hx /
+Hx N¹ !
+Oï  ` Ö T(   g  T4  ÿÿìBÿü Y vÝ T(    fZ T(    ÿê  T6(   ÿÿî ? T (  ÿÿ$@Hx EHx YHx Y/
+/ / N¹  ÒOï  T (   T(    ÿê  T6(   ÿÿî ? T (  ÿÿ$@/
+/ / N¹  ÉÞ&amp;@Hx NHx k//
+/ / N¹  ÈÂOï $-@ÿøg àü Y vÝ/Hnÿø/ / N¹  ¬Oï / /9 Á,N¹ !²úN¹ !³J/ N¹  Üø/9 tN¹  Ê6#À rä:$| ¹ìp 0/ Hy !Ëâ 
+rÐ/ N¹ !·N@ y ´Í | W Hx (Hx /
+Hx N¹ !
+Oï $` B T0  ÿÿì@ÿ3À wX T(    f  T(    ÿê  T6(   ÿÿî ? T (  ÿÿ$@Hx EHx YHx Y/
+/ / N¹  ÒOï  T (  ` ¾ °¹ ¹e :(¹ tHx Y/9 tHnÿüN¹  ÏLOï   Yf (¹ t T(   g x T4  ÿÿìBÿü Y vÝ T(    fZ T(    ÿê  T6(   ÿÿî ? T (  ÿÿ$@Hx EHx YHx Y/
+/ / N¹  ÒOï  T (   T(    ÿê  T6(   ÿÿî ? T (  ÿÿ$@/
+/ / N¹  ÉÞ&amp;@Hx NHx k//
+/ / N¹  ÈÂOï $-@ÿøg ü Y vÝ/Hnÿø/ / N¹  ¬Oï / /9 Á,N¹ !²úN¹ !³J/ N¹  Üø:$| ¹ìp 0/ Hy !Ëæ 
+rÐ/ N¹ !·N@ y ´Í | W Hx (Hx /
+Hx N¹ !
+Oï  `   T0  ÿÿì@ÿ3À wX T(    ff T(    ÿê  T6(   ÿÿî ? T (  ÿÿ$@Hx EHx YHx Y/
+/ / N¹  Ò T (  `(¹ t T( ý 9 Y ¾QfV9 Y ÂTf8 9 ·X¹ Á$N¹ !³Ú/9 Á0N¹ !²ä/&lt;?  N¹ !²Ðm8#ù ·X Á$`ü Y ÂT#ù ·X Á$`JgSJf(¹ t T( ý 0Lî&lt;&lt;ÿ¸N^NuHç8&lt;N¹ !ÀJgHx N¹ !èXN¹  îÆü @  Hx B§N¹ !ÞPN¹  ïB§Hx N¹ !ÎP*@$Mp * rR°g4rW°g  rE°g  ÆrC°g  ÚrA°g  îrS°g brP°g ú` ^* g V ÿg Np Ð@ | ·00  HÀ&amp;@ fB* | P ` .´f &quot; /cB* ` C (JpÙÀ`Û SJ fö| P ` ø* g ê ÿg â* / b Ø/
+N¹  ôXN¹  ô¦| P ` Ä* / * / N¹  òöP@ ` ¨* D/ * C/ N¹  òöP@ ` * C°* Db z* Dg r ÿg j* Cg b ÿg Z* / b Pj C * C`p Ð@ | ·Jp  fB `R´* Dcà/
+N¹  ôXN¹  ô¦| P ` * C°* Db  þ* Dg  ö ÿg  î* Cg  æ ÿg  Þ* / b  Ô* C`\xNp Ð@ | ·00  HÀ&amp;@ g(´f$* ¶f(JpÙÀxY`
+°gxN` SJ fî Yf/ / N¹  òöP`xR´* Dc`n* C°* Db^* DgX ÿgR* CgL ÿgF* / b&gt;j C /
+N¹  ôX* D°* Cc* D/ * CR / N¹  òöPN¹  ô¦| P `| E /
+N¹ !VX` ý@Lß&lt;Nu#ü    ¶#ü    v°&quot;y ¶ |  ófp ØR   mô&quot;y v° |  ó´p ØR   môNuNVÿüHç?&lt;(| ·KîÿþBC&amp;LBB6ÃRBB möBB4&lt;  :Eÿ0HÀ$@`\6
+JgN ÿfB  f:`L=Cÿü`Fp ÐAô &amp;HJSg0/ 0/ / N¹  ïÔOï 6`6B0 lR`Rp ÕÀ0HÀ°dB B0 o ÿU  g9Uþ`9nÿüþLî&lt;üÿÔN^NuHç&lt;0&amp;/  (/ $*/ &amp;| v°0  ð 2  ð °f
+¶Dm 46`0  ÿ2  ÿ°l46`40HÀ$@ºf* /b&quot;` ÿg SJ fòB§0HÀ/  SNP0`B§0HÀ/  SNP0Lß&lt;Nu&quot;o  o `
+ ÿgpFNu³ÈcòpTNuNVÿ8Hç?&lt;BCBE(| ·t&gt;gG0 lRC`RER ÿeè¶En&lt;6&lt;  :&lt;/ÿ`
+&lt;6&lt;0 :&lt;?ÿJFfB0HÀ/ 0HÀ/ a ÿP  Tg 0HÀ&amp;@/ y ¶NXJ f
+/ y ¶N3Ã ¹`  ÄBFt(| ·Eîÿ8Kîÿÿ`V&gt;¾CmF¾EnB0HÀ&amp;@´f6g. /b(p T&quot;
+°nÂÄ`Û SJ föBTRF`
+BT`BT`RRT ÿdµÍc¦0HÀ&amp;@/ y ¶NXJ f/ y ¶NX3Ã ¹Eîÿ8`/
+/ / N¹  òHOï p ÕÀ SFJ@nÚLî&lt;üÿN^Nu/
+&quot;/ 09 ¹HÀ$@p Aò R&quot;Hµü    eµü  /ÿb³ü  /ÿc$pF`*µü  0 eµü  ?ÿb³ü  ?ÿcpF`pF`
+/	/
+a þ.P$_NuHç8&lt;&amp;/ $(/  &amp;o (tP09 ¹HÀ$@p Ð@ | ·00  HÀ(@/ /
+R y v°NP  EftE`/ /
+R y v°NP  EftE SJ fÞ | ¹*H0r ÒA | ·1 : gB§/ y v°NP  EftELß&lt;NuHç80&amp;/ (/ Jg ÿfpE`PJg ÿfpE`BtPp Ð@ | ·Að  &amp;H`&amp;0HÀ$@ 
+gBSB§/
+ y v°NP  EftETR¶cÖLßNuHç  Eï t R¼ P |  R¼   R¼ Ð R¼ p R   gô R gB R¼ ÿ|øÿLßNu/
+Eï  R¼ P |  R¼ @ R¯  R¼ p R   gô R g   R¼ ÿ|øÿpE`   R¼ ÿ|øÿpP$_NuHç08$o | W Ep * Ð@ | ·00  HÀ&amp;@ g&gt;°* f6´* f.(JpÙÀvN`
+°gvW` SJ fî Nf| N E`2a ü* / a ýhX  Tfê 
+rÐ/ * / * / a ý®Oï LßNuNVÿÐHç8&lt;*| ·4-þB0 mB?ÿn
+4&lt;  6&lt;/ÿ`B  mB/ÿn
+4&lt;0 6&lt;?ÿ`a û¤0HÀ$@ ÿg  ¸p $@(MIìþ&amp;M`´Sn¶Sm0HÀ$@`T·Ìeê 
+f&lt;0HÀ/ 0HÀ/ a ûBP  Tg  v0HÀ$@/
+ y ¶NXJ f^/
+ y ¶N`RGîÿÐ /c/ / a ý`6t `Ú SBJ@nö`a û / a üPX  TfìHnÿÐ/ / a üLî&lt;ÿ´N^NuNV  Hç 8(| z­$| u°t Eê 
+B*ÿöRp°nð$| w`t BRp°löN¹ !`¼ NB§Hx N¹ !ÎP$@&amp;J0+ HÀr°b  ¶Ð0;Nû   $ . @ d n x   ª   /
+N¹  öä`  /
+N¹  ÷|`z Yf  v/
+N¹  ù`h Yfd&amp;| !Ëê`/RHx N¹ !8PJfì`F/
+N¹  úH`:/
+N¹  ý~`0/
+N¹ !`&amp;/
+N¹ !â`/
+N¹ ! `/
+N¹ !p`/
+N¹ !X/
+N¹ !VX` ÿ LîÿðN^NuHç&lt;&lt;&amp;o $*|  øä$k (k ü : k &quot;/ /
+NT k :t 4à/ /
+NTÖ/ /
+NOï TÖ k `/ /
+NPTÖ SJ fèFR/ /
+NPTü 
+ü 
+BLß&lt;&lt;NuHç&lt;&lt;(o $$l *l &amp;l &amp;BHx :/
+N¹ !·P$@ 
+f  `  ÖR//
+N¹  øP  l &quot;Jf  º¸, +e¸, *c  `  ¦T//
+N¹  ø z áMTÔ//
+N¹  øOï  p @ l 0ºl .eºl ,c  `\TÔ//
+N¹  øP  l ¶, 1e¶, 0c  `2//
+N¹  øP ÃTÔ SJ fä//
+N¹  øPÔ Jg  Lß&lt;&lt;NuHç0 &quot;o  o Br 0d  `  9c Ad  ` Fc  `_ Jgé ÖSJl¼Lß Nu/&quot;/  o pJgt è`  
+e 7` 0ÂSJlÖ$NuNVÿüHç0&lt;&amp;n (| !8Kîÿý | !ËòCîÿþ2Ø6+ JClDC$| !Ëô`/
+RHx NPJfðC n4`t$| !Ëø`/
+RHx NPJfðSBJBnâ$| !Ëü`/
+RHx NPJfð0HÀrdN¹ !« 6 HÀr
+N¹ !ªD  0HnÿýHx N0HÀr
+N¹ !«   0HnÿýHx NHnÿþHx NOï $k tg&amp; 
+g 
+gHnÿý`HnÿþHx NPRBB HoÖ$| !Ëþ`/
+RHx NPJfðLî&lt;ÿäN^NuNVÿøHç8&lt;&amp;n Kîÿú+ &amp;+ $| u°BJg ´* f¶ª f&#x27;j   ÿg ¢R` Rp
+ÕÀp°bÐ| 1ÿÿ$| !ä ae
+ kb   Ae Kb Ap å @$r`p $@p*`  ´| 1ÿÿ(Jp   þg   ûg&amp;  òg2  ýgN  ügL  ígN`V¶fp $@R`rp ár Ð*(J``p ár Ðár Ðár Ð*(J`&gt;p `8| 1ÿÿ`p ÐÕÀ`   ðfR| 2ÿÿHnÿÿHnÿú/
+N¹  ü0Oï $@¶e 
+f ÿF. Yÿÿf  &#x27;L &lt; ÿ$| u°BJfB(`´c(Rp
+ÕÀp°bâ ÿf $| uºp*¼ Rp
+ÕÀp°bðtx `R åÐÐ | u°ÑÀ$Hk  %k  %k  `B« Lî&lt;ÿÜN^NuHç  $o &quot;o  o ` $ 1f  p   íg  ýg&amp;  ûg&amp;  òg2  üg  ø`Jp ÐÕÀ¼ 2`  æp `  òp ár Ð `  Þp ár Ðár Ðár Ð `  ¼   ðfR¼ 2`  p    ír°b  zÐ0;Nû  * n n n n H &amp; &quot; &quot; &quot; &quot; &quot; &quot; &quot; 8 h 4T`TX`Pp ÐÕÀ`Fp `Tp ár Ð `Bp ár Ðár Ðár Ð `&quot;¼ 1`   ðfR þf þÖR¼ Y 
+LßNuNVý°Hç?&lt; n -h ÿü n *h -| ¶$ÿø n &amp;h $ n è - R-@ýÌ R-@ýÈ R-@ýÄ-KýÀ-Ký¼ nÿü(  nýÌ nÿü( 
+ nýÈ nÿü(  nýÄ n ( S /f&gt; nýÄ /  n ( 0/  n /(  HnýÔN¹ !
+öOï AîýÔ-Hÿô n ( 0 nýÈ g.-   ?f$&amp;Mp×À0°Sf+   ?  f
+*K n !M &amp;nýÀp - r - 	N¹ !«&gt;Ð®ýÀ-@ý°`ü  ·îý°eöp - é n Ð¨ $-@ý°`ü ÿ·îý°eö n $h  
+f&amp; nÿü(  nýÌ n |  . n | þ ,` 2 n B( .AîýÑ&quot;nÿø#H B.ýÑB.ÿó(nýÀp - Aô -Hý´BD n 0(   ÿÿæ@ýÓ n 0(   rá)AýÒz1` ¦ 1f   ífT`2°.ýÓf&amp;À.ýÒg  n |  .S ep ÐÕÀz2`
+RS dÈ 1f T/
+N¹ !
+X$@` D   ðf´.ýÓfÀ.ýÒg n |  .z2`R 1f /
+N¹ !
+X$@`  %f@ nýÈ   @g2 þg ö üg î/ HnÿÞN¹ !@P-Jý¸EîÿÞ| ÿóp    ír°b JÐ0;Nû 4&gt;&gt; ô 00, ,,,&quot;ü,J.ýÑg/N¹ !2X(@ ÿgv `6ný¾ ÿgx p 0r - N¹ !«&gt;Ð®ýÀ-@ý¼p 0Ð®ý¼(@p - Ð®ý¼-@ý´` J.ýÑg/N¹ !2X(@ nÿø-h ý´ nÿø  nÿø!ný´ IîýÞ nÿø!L     -@ý´ nÿø!ný´ | ýÑ nÿüJ( g ¾/
+N¹ !
+X$@` ®J.ýÑg  ¸ AîýÞ°gV/N¹ !2X(@6ný¾p - 	SlRâ8 p 0r - N¹ !«&gt;Ð®ýÀ-@ý¼p 0Ð®ý¼(@p - Ð®ý¼-@ý´` F nÿø&amp;ný¾p - 	SlRâ8 p 0r - N¹ !«&gt;Ð®ýÀ-@ý¼p 0Ð®ý¼ nÿø p - Ð®ý¼ nÿø!@ ` ð6ný¾p - 	SlRâ8 p 0r - N¹ !«&gt;Ð®ýÀ-@ý¼p 0Ð®ý¼(@p - Ð®ý¼-@ý´` ¦f nýÈB nýÄBR` nýÈ nýÄ n ( S /fJp  nýÄ   °g6 nýÄ /  n ( 0/  n /(  HnýÔN¹ !
+öOï AîýÔ-Hÿô nýÈ g -   ?f &amp;Mp×À0°Sf +   ?  f  ôJ.ýÑg/N¹ !2X(@*K n !M p - Ð®ý¼-@ý´&amp;Lp - r - 	N¹ !«&gt;Ð®ýÀ-@ý°`ü  ·îý°eöp - é n Ð¨ $-@ý°`ü ÿ·îý°eö`~R nýÌ`tT`pX`lp ÐÕÀ`bJ.ÿógJf
+$ný¸B.ÿó`N   ðfR`@ `f n ( S /fJg nÿôR®ÿôS¹îý´dH | !á+0  H@ WgÂ þg üf ûNJ.ýÑg/N¹ !2 n B , n !J Lî&lt;üýN^NuHç08&quot;o (| ¶$&amp;l $T&quot;, &amp;, $	´o$´o$`  RlRâ&amp; `ü  SJnö`ÛSJfø l B 
+LßNuNVýHç?&lt;-| !äÿü n -h ÿø n -h ÿô nÿü-h ÿð nÿü-h ÿì-| ¶$ÿè nÿø0(   ÿÿ^l^æ=@ý n (h ( nÿø(    ÿéAô $H n è - R-@ý² R-@ý® R-@ýª-Lý¦ nÿø0( 
+  ÿÿr 2.ýN¹ !«&gt;Aô *H nÿô(  ný² nÿô( 
+ ný® nÿô(  nýª n ( S /fF nýª  @ý¿/  n ( 0/  n /(  HnýÀN¹ !
+öOï AîýÀ-Hÿä n h 0ý¾`B¹Íeú`ü ÿ¹Êeø n $h  
+f&amp; nÿô(  ný² n |  . n | þ ,` ø n B( .Aîý»&quot;nÿè#H B.ý»B.ÿã nÿè1ný &amp;ný¦ nÿø0( 
+  ÿÿr 2.ýN¹ !«&gt;Aó *H nÿô=h ýp 0.ýçÐ®ÿð(@-TÿÊl ý½l ý¼, l ýp .ý½^l^æ=@ýB.ýº n 0(   ÿÿæ@ý¹ n 0(   rá)Aý¸| 1ý·Bný BF`  . 1ý·f  ¨ ífZ`6°.ý¹f*À.ý¸g$ n |  .S ep ÐÕÀ| 2ý·`
+RS dÄ. 1ý·f ¦/
+N¹ !
+X$@`    ðf&quot;´.ý¹fÀ.ý¸g n |  .| 2ý·`R. 1ý·f `/
+N¹ !
+X$@` P %f@ ný®   @g2 þg B üg :/ HnÿÎN¹ !@P-Jý¢EîÿÎ| ÿãp    ír°b Ð0;Nû h` Üb p \Ât\PÈ\J.ý»g/N¹ !
+X&amp;@ nÿè*h  ÿg| 0HÀr 2.ýN¹ !«&gt;Ð®ý¦&amp;@ ÿg p =@ý ` ~J.ý»g/N¹ !
+X&amp;@ nÿè*h z áMp Ú@0HÀÿÿ g&lt;0HÀr 2.ýN¹ !«&gt;Ð®ý¦&amp;@z áMp Ú@0HÀÿÿ g =Eý ` J.ý»g/N¹ !
+X&amp;@ nÿè*h  nÿè  nÿè!M GîýÊ nÿè!K  nÿè (  nÿèAó *H    °d*KKí  nÿè!M | ý» nÿôJ( g /
+N¹ !
+X$@` J.ý»g AîýÊ°g/N¹ !
+X&amp;@ nÿè*h  nÿø0(   ÿÿr .ý½°o$ nÿø0(   ÿÿr .ý½lRâ=@ý ` .Bný ` &amp;f ný®B nýªBR` ný® nýª n ( S /f òp .ý¿ nýª   °g Ú nýª  @ý¿/  n ( 0/  n /(  HnýÀN¹ !
+öOï AîýÀ-Hÿä` R ný²` T` X` p ÐÕÀ` zp áHr ÐA=@ýp 0.ýçÐ®ÿð(@-TÿÊl ý½l ý¼, l ýp .ý½^l^æ=@ý` ,z áMp Ú@p 0çÐ®ÿì(@-TÿÊl ý½l ý¼~ |  ýp .ý½^l^æ=@ý| ýºt J.ÿãgJf$ný¢B.ÿã` Ì   ðfR` ¼ `f  n ( S /fJ.ý¾g nÿäR®ÿäS.ý¾·Íd ´e ´.ýb p ÐÐ®ÿÊ @8p ÐÐ®ÿÊ @0(   ÿÿr 2r 2.ýN¹ !ªD: p 0Ð®ÿÊ(@`  ¦JFm   nÿø0( 
+  ÿÿ2HÁ°otv 8.ý` á&amp; p SDJDfîJný m0.ý HÀ&quot;á©`0.ý HÀD&quot;à©&amp;8.ý`.J.ý»gÃ` R-@ý ný   ÿ ný à&amp; SDJDfÎ`p 0.ýÙÀp 0.ý×ÀRFSEJEg·Íe ÿTJ.ý»g8.ýp .ý¼ÈÀ`BSDJDg ·Íeô`p 0.ýr .ý¼N¹ !«&gt;×À·Íc&amp;MJ.ýºg&gt;p 0.ýçÐ®ÿð(@-TÿÊl ý½l ý¼, l ýp .ý½^l^æ=@ýB.ýºp .ý¼Ü@ þg üf ùôJ.ý»g/N¹ !
+ n B , n !J Lî&lt;üýlN^NuHç0&lt;*o &amp;| ¶$(k $S&amp;
+$+ r 2+  N¹ !ªD$ RJlRâr 2+  N¹ !«&gt;$ ÕÂ` 
+R*@   ÿSJfè k B 
+Lß&lt;Nu/ o `XRp    ír°b:Ð0;Nû  &amp; 0 0 0 0 &quot; &quot;        T`X`p ÐÑÀ`   ðfR þg üf $NuNVÿìHç8&lt;(. &amp;n (n KîÿìEîÿöB`Jfü  `ÃRR´eêBp . r°gr°g$r°g:`dHnÿö/
+N¹ !ÆP B§/ /
+`PHnÿö/
+N¹ !ÆP / B§/
+`4Hnÿö/
+N¹ !ÆP v p  â/  Râ/ /
+`B§B§Hnÿö/N¹ !Lî&lt;ÿÐN^Nu/
+&quot;o  o `R  gø$HB`ÀRRföBJg`B&quot;  gø$HB`RJfú$_Nu&quot;o  o / `ü  S J fö`Àfú/ `ü  S J föBNuNV  Hç &lt;$. (n *| !·N$| |&amp;| ·@HHÀr%rU°b äÐ0;Nû ÌØØØØØØØØØØØØØØØØØØØØØØØØØØØ âNØ®è0Ø°&quot;zØ¨DØÚØØL¨â\ØØØØØØØØ ¬ØØøØhøLØ¨ØrØØ~ÒòJØnØ* 1 $f * &quot; åÐÐ À&lt; @&quot;LØfü`  | !Ì&quot;LØfü` ø* 1 $f * &quot; åÐÐ ¯È @&quot;LØfü` Ò | !Ì&quot;LØfü` Â* 1 $f * &quot; åÐÐ yÜ @&quot;LØfü`  | !Ì
+&quot;LØfü` * 1 $f * &quot; åÐÐ ´ @&quot;LØfü` f | !Ì&quot;LØfü` V* 1 $f/* Hy !Ì/N` &lt; | !Ì&quot;LØfü` ,* 1 $f/* Hy !Ì/N`  | !Ì &quot;LØfü`  y vÐ&quot;LØfü` ò y ¼Ø&quot;LØfü` â 9 ·XN¹ !³Ú/9 Á,N¹ !²ä/9 vàN¹ !²äN¹ !³&amp;Hy !Ì$/N` ª 9 ·XN¹ !³Ú/9 Á,N¹ !²ä/9 vàN¹ !²äN¹ !³&amp;Hy !Ì,/N` r* 1 $f0Jª ft`p
+°ª n
+$* p`$* /Hy !Ì4/N` : | !Ì8&quot;LØfü` ** 1 $f0Jª ft`p
+°ª n
+$* p`$* /Hy !Ì&lt;/N` ò | !ÌB&quot;LØfü` â* 1 $f/* Hy !ÌF/N` È | !ÌJ&quot;LØfü` ¸* 1 $f/* Hy !ÌN/N`  | !ÌT&quot;LØfü` * 1 $f * R/ Hy !ÌX/N` p | !Ì\&quot;LØfü` `* 1 $f * R/ Hy !Ì`/N` B | !Ìf&quot;LØfü` 2J+ f&quot; lf/`/+ N¹ !³&amp;Hy !Ìj/N` 
++  f | !Ìr&quot;LØfü` ò+ 
+ f | !Ìz&quot;LØfü` Úp + / Hy !Ì/N` Ä* 1 $f * R/ Hy !Ì/N` ¦ | !Ì&quot;LØfü` * 1 $f * R/ Hy !Ì/N` x | !Ì&quot;LØfü` h/9 ·XHy !Ì¢/N` T/9 ·XHy !Ì¦/N` @* 1 $f(p°ª o | &quot;LØfü`   | ø&quot;LØfü`  | !Ì¬&quot;LØfü`  * 1 $f(p°ª o | }&quot;LØfü` à | |H&quot;LØfü` Ð | !Ì°&quot;LØfü` À9 d ·Tbp 9 ·T/ Hy !Ì´/N`  | !Ì¸&quot;LØfü` 9 d ·Tbp 9 ·T/ Hy !Ì¼/N` l | !ÌÂ&quot;LØfü` \* 1 $f/* Hy !ÌÆ/N` B | !ÌÊ&quot;LØfü` 2* 1 $f/* Hy !ÌÎ/N`  | !ÌÔ&quot;LØfü`  y vØ&quot;LØfü`  ø y ¼¸&quot;LØfü`  è 9 ·XN¹ !³Ú/9 Á,N¹ !²äN¹ !³&amp;Hy !ÌØ/N`  ¼ 9 ·XN¹ !³Ú/9 Á,N¹ !²äN¹ !³&amp;Hy !Ìà/N`  /9 ÀØHy !Ìè/N`|/9 ÀØHy !Ìì/N`j* 1 $f * rdN¹ !« / Hy !Ìò/N`H | !Ìø&quot;LØfü`:* 1 $f *   l/ Hy !Ìü/N` | !Í &quot;LØfü` | !Í&quot;LØfüLî&lt;ÿìN^NuNVÿäHç &lt;&amp;| !p(| yÜ*| ´Eîÿæ%| !Í %| ¯È /
+NX j Jf | !Í&quot;j Øfü%| !Í %| ¯Ò /
+NX j Jf | !Í&quot;j Øfü%| !Í$ %| ¯Ü /
+NX j Jf | !Í*&quot;j Øfü%| !Í2 %| ¯æ /
+NX j Jf | !Í8&quot;j Øfü%| !ÍB %| ¯ð /
+NX j Jf | !ÍH&quot;j Øfü%| !ÍR %| ¯ú /
+NX j Jf | !ÍX&quot;j Øfü%| !Í` %| ° /
+NX j Jf | !Íf&quot;j Øfü%| !Íp %| À&lt; /
+NX j Jf | !Ív&quot;j Øfü%| !Íz %| ÀF /
+NX j Jf | !Í&quot;j Øfü%| !Í %| ÀP /
+NX j Jf | !Í&quot;j Øfü%| !Í %| ÀZ /
+NX j Jf | !Í&quot;j Øfü%| !Í %| Àd /
+NX j Jf | !Í&quot;j Øfü%| !Í¢ %| Àn /
+NX j Jf | !Í¨&quot;j Øfü%| !Í¬ %| Àx /
+NX j Jf | !Í²&quot;j Øfü%| !Í¶ %M /
+NX j Jf | !Í¾&quot;j Øfü%| !ÍÆ  
+r
+Ð%@ /
+NX j Jf | !ÍÎ&quot;j Øfü%| !ÍØ  
+rÐ%@ /
+NX j Jf | !Íà&quot;j Øfü%| !Íæ  
+rÐ%@ /
+NX j Jf | !Íî&quot;j Øfü%| !Íô  
+r(Ð%@ /
+NX j Jf | !Íü&quot;j Øfü%| !Î   
+r2Ð%@ /
+NX j Jf | !Î&quot;j Øfü%| !Î  
+r&lt;Ð%@ /
+NX j Jf | !Î&quot;j Øfü%| !Î  
+rFÐ%@ /
+NX j Jf | !Î$&quot;j Øfü%| !Î,  
+rPÐ%@ /
+NX j Jf | !Î4&quot;j Øfü%| !Î&gt;  
+rZÐ%@ /
+NX j Jf | !ÎF&quot;j Øfü%| !ÎN  
+rdÐ%@ /
+NX j Jf | !ÎV&quot;j Øfü%| !Î`  
+rnÐ%@ /
+NX j Jf | !Îh&quot;j Øfü%| !Îr %L /
+NX j Jf | !Îz&quot;j Øfü%| !Î~  r
+Ð%@ /
+NX j Jf | !Î&quot;j Øfü%| !Î  rÐ%@ /
+NX j Jf | !Î&quot;j Øfü%| !Î  rÐ%@ /
+NX j Jf | !Î&quot;j Øfü%| !Î¢  r(Ð%@ /
+NX j Jf | !Îª&quot;j Øfü%| !Î®  r2Ð%@ /
+NX j Jf | !Î¶&quot;j Øfü%| !Îº  r&lt;Ð%@ /
+NX j Jf | !ÎÂ&quot;j Øfü%| !ÎÆ  rFÐ%@ /
+NX j Jf | !ÎÎ&quot;j Øfü%| !ÎÒ  rPÐ%@ /
+NX j Jf | !ÎÚ&quot;j Øfü%| !ÎÞ  rZÐ%@ /
+NX j Jf | !Îæ&quot;j Øfü%| !Îê  rdÐ%@ /
+NX j Jf | !Îô&quot;j Øfü%| !Îø  rnÐ%@ /
+NX j Jf | !Ï&quot;j Øfü%| !Ï %| } /
+NX j Jf | !Ï
+&quot;j Øfü%| !Ï %|  /
+NX j Jf | !Ï&quot;j Øfü%| !Ï %| |H /
+NX j Jf | !Ï&quot;j Øfü%| !Ï  %| ø /
+N j Jf | !Ï&amp;&quot;j ØfüLî&lt; ÿÔN^NuHç  &quot;o t &quot;) $| w`²g Jf0åH | w`!©   `
+XRp°nÜLßNuHç 0&amp;o &quot;| w`r  å @ 1 °« f&quot; åAñ $H`$ê Rp°nô å @B± Rp°nÆLß NuNVÿüHç 8&amp;|     n &quot;h &amp;k `EODTgbp ×ÀXRGLfì$k &amp;k `H n -h ÿü`4(nÿüRr`
+°gr ` vfðp°fR`Ú  e _cò` pgÆRµËc´BLî ÿðN^NuHç   o $h &quot;h Bè Ô( è Ô( ( `ÒÔSJföF R LßNuNVÿôHç &lt;*| ¼Dp#À ¹$| ±Ì5| 
+ Aîÿö%H %| !Ï* Hx #Hx /
+Hx N¹ !
+HnÿöN¹ ! À Á%| !Ï4 Hx #Hx /
+Hx N¹ !
+Oï $. HÿöfB9 µÚü  µÙ`ü  µÚB9 µÙB.ÿ÷B.ÿø%| !Ï&gt; Hx #Hx /
+Hx N¹ !
+Oï . Hÿöf
+ 9  µÙ` 9  µÚ. Hÿ÷f
+ 9   µÙ` 9   µÚ. Hÿøf
+ 9 @ µÙ` 9 @ µÚN¹ !%\9 Y ¼@g y z|y µÙ  y z|y µÚ 9 Y z­f*;|  ;|  +| !ÏH Hx #B§/
+Hx N¹ !
+Oï B¹ üB¹ øN¹ !`#À w\f
+B§N¹ !èXHx =HxXHxX/9 w\N¹ !N¹ !&quot;&lt;N¹ !&#x27;Â3ü  ²p&quot;#À ²Hx #B§Hy ²Hx N¹ !
+Hx &quot;N¹ !pOï $N¹ !4&amp;N¹ !*tB¹ ±2$| ·~(MpÙÀ&amp;Mp×ÀHx Hx &quot;N¹ !Pr²f HxHx/9 w\N¹ !êOï N¹ !+0`ÊR¹ ø9 Y z­fHp°¹ ød&gt;/9 øHy !ÏVHy ¼dN¹ !·N;|  6¼ 
+(¼ ¼dHx #B§/
+Hx N¹ !
+Oï HxHx/9 w\N¹ !êB9 x  g
+BHy ±0`N¹ !-&amp;Hy ´ØN¹ !.Oï N¹ !*tS¹ ø` ÿ$Lî&lt; ÿäN^NuNVÿüHç8&lt;(|    $l `&quot;EODTfHy !ÏzN¹ !4PB§N¹ !èPp ÕÀXRCTfÖ-j ÿü*j * * 
+4* Ã ¹ Ä ¹¡ü E ¹¢Hy ¹Hy  EäN¹ !BP&amp;M$nÿü`0±BµËcøJBg&gt;B9 ¹ B9 ¹¡ü D ¹¢Hy ¹Hy  EäN¹ !BHy !ÏN¹ !4PB§N¹ !èOï /
+/.ÿüN¹ !(æB9 ¹ B9 ¹¡ü D ¹¢Hy ¹Hy  EäN¹ !BOï $l `&quot;EODTfHy !Ï¦N¹ !4PB§N¹ !èPp ÕÀXP00fÖ#ê  ¶#ê  µÜê  Áê 
+ ¿d9 Á   ?ïyà rèy rèp 9 ¿d ÿÿ¹ÿ   rè¹ rè 9 ¶   ë9  rè9 rè4* ù Á ¹ ù ¿d ¹¡ü E ¹¢Hy ¹Hy  EäN¹ !BP&amp;y µÜ$y ¶`0±BµËcøJBg&gt;B9 ¹ B9 ¹¡ü D ¹¢Hy ¹Hy  EäN¹ !BHy !Ï¼N¹ !4PB§N¹ !èOï B9 ¹ B9 ¹¡ü D ¹¢Hy ¹Hy  EäN¹ !Bx r
+N¹ !«    0&amp;  r
+N¹ !ªDá  0 ÖXP  tN$l `l¶fd*    ë2åI | rè0  0 * 
+   ?ï2åI | rèpà p  *  ÿÿ2åI | rè°ÿ   ° tY`p ÕÀEODTf Ng
+Rpc°l ÿJLî&lt;ÿàN^NuNV  Hç 0&amp;| ²¡¼ $|  ¼ þNqNqNqNqNqNq$|  ¼ NqNqNqNqNqNq$|  ¼ ÿNqNqNqNqNqNq$|  ¼ þNqNqNqNqNqNq$|  ¼ NqNqNqNqNqNq$|  ¼ ÿNqNqNqNqNqNq$|  ¼ þNqNqNqNqNqNq$|  ¼ NqNqNqNqNqNq$|  ¼ ÿNqNqNqNqNqNq$|  ¼ þNqNqNqNqNqNq$|  ¼ NqNqNqNqNqNq$| ¤ ¼ ÿNqNqNqNqNqNq$| ¤ ¼ þNqNqNqNqNqNq$|   ¼ NqNqNqNqNqNq$| ¬ ¼ ÿNqNqNqNqNqNq$| ¬ ¼ þNqNqNqNqNqNq$| ¨ ¼ NqNqNqNqNqNq$| ´ ¼ ÿNqNqNqNqNqNq$| ´ ¼ þNqNqNqNqNqNq$| ° ¼ NqNqNqNqNqNq$| ¼ ¼ ÿNqNqNqNqNqNq$| ¼ ¼ þNqNqNqNqNqNq$| ¸ ¼ NqNqNqNqNqNq B9 ² ¼ $| X JNqNqNqNqNqNqBB9 ² ¼ $y z|p	ÕÀJNqNqNqNqNqNqBü N ¼@Lî ÿøN^NuHç &lt;*| ¼Dü  P Hx B§N¹ !ÞP9 X    r²gN¹  ).`ü ð P 9 ð P fî(MpÙÀ&amp;Mp×À$MpÕÀ`&lt;9 Y z­f$4¼ 6¼ (¼ !ÏÜHx #B§/
+Hx N¹ !
+Oï Hx B§N¹ !ÞP9 X    r²g²B9 P Lß&lt; NuHç00$/ &amp;/ $o JgN&quot;| µ2`BµÉbBp 9 ²%&quot; ÒÒÒ | ºÀÑÁ&amp;H+   g+   @ %k  \R´oº 
+LßNuNVÿøHç8&lt;&amp;n (| ²TKîÿøv $LBB* B* B* XRp°lèx $n ` BHHÀrn°Agrv°AgBrs°Ag  ~rr°Ag  ì` v ` CR  0m 9oêB58 /
+N¹ ! X( `  ðv ` CR  0m 9oê +gä -gÞB58 /
+N¹ ! X&quot;å A`  ®    ÿr1°gr2°gr3°g`D å @ 4  ` å @ 4   ` å @ 4 À  å @J4f  Ð&quot;å A 0mB 9n&lt;µËcî`6v ` CR  0m 9oêB58 /
+N¹ ! X&quot;å A`µËc þºLî&lt;ÿÜN^NuHç00&amp;| ¹$y ¶y Á y ¿d | E /Hy  EäN¹ !BB`Ú ` R´côB+ B+ | D /Hy  EäN¹ !BOï  9  P `Hx B§N¹ !ÞP9 X    gä9 ý P `Hx B§N¹ !ÞP9 X    r²gàLßNuHç 8$| ¼D&amp;| t(| ±Ê9 P  p æ 9 X    ðèp 2 Ð@ÐAr ÐA9 X    ðè | ¼\  Jf
+ 9  P `9 ÷ P R eBp 9 ÁHHÁ°mV9 Y z­fLp / p / Hy !Ð Hy ¼dN¹ !·N5|  p X@5@ %| ¼d Hx #B§/
+Hx N¹ !
+Oï  LßNuNVÿüHç&lt;0&amp;. &amp;| ¼D0åH | ²U0  0åH | ²W0   BBp 2 Ð@ÐA | ¼\Að  $HÖR eöp rN¹ !ªD p éHr ÐA | 0  Ð9 ÁÐ  ovJlB 9 Y z­f@HHÀ/ Hy !ÐHy ¼dN¹ !·N7|  7|  &#x27;| ¼d Hx #B§/Hx N¹ !
+é 9 P  À P .ÿÿLî&lt;ÿäN^NuHç &lt;(| !
+*| !(|$| ²ð&amp;| ´Øp 9 ²P/ p 9 ²G/ /N&amp;@| C y ²G Cy ²P DHx #B§/
+Hx Np 9 ²&quot;/ p 9 ²(/ /NOï (&amp;@| C y ²( Cy ²&quot; DHx #B§/
+Hx Np 9 ´Ô/ p 9 µ&lt;/ /N&amp;@| C y µ&lt; Cy ´Ô DHx #B§/
+Hx NOï ,BB+ B« Lß&lt; NuHç0&lt;$o (| ²ðR¹ üp°¹ üdV9 Y z­fL/9 üHy !ÐHy ¼dN¹ !·N3ü  ¼T3ü  ¼V#ü ¼d ¼XHx #B§Hy ¼DHx N¹ !
+Oï &amp;| ±0*JpZÛÀvN` Jª g vYù }¯ }­ù }® }¯ù }« }®ù }ª }«ù }¬ }ªÒ }¬ù { { ù { {ù { {ù { {ù { {ê  {#ù ÁD Á&lt;#ù Á@ ÁD#ù ÁP Á@#ù ÁL ÁP#ù ÁX ÁL#ê  ÁXR | E Hx #B§/Hx N¹ !
+p * / a ü¨Oï p * åH | ²T0  À9 µÚ   ÿ y z|@ À9 µÙ   ÿ y z|@ p * åH | ²V0  R`/* N¹ !0JX SJ nì9 Y ¼@g y z|y µÙ  y z|y µÚ Hx 
+B§N¹ !ÞPj  &#x27;j  \\µÍe þh YfB« S¹ üLß&lt;NuNV  Hç0&lt;$y ¶ù Á ¹ ù ¿d ¹¡ü E ¹¢Hy ¹Hy  EäN¹ !BPB`RR´cø&amp;J . åY×Àpÿ°g  ú$Ô¹ ¶$B/
+N¹ !1ÒX$@&amp;J*| ¹¢(| ¹¡`  ¼$Kp åH | rè 0   ÿÿ&quot; ÿÿÿÐ$@p åH | rè0     ÿê  À ¹ p åH | rè00    ÿÿî  ?¼ EHy ¹Hy  EäN¹ !B/
+N¹ !1ì$@/
+N¹ !2rù Á ¹ ¹ ¿d¼ EHy ¹Hy  EäN¹ !BOï Xpÿ°f ÿ@X$K/
+N¹ !3FXB9 ¹ B9 ¹¡ü D ¹¢Hy ¹Hy  EäN¹ !BLî&lt;ÿèN^Nu o B`Ø ` R² cô NuHç00&amp;o $KX#Ò u¬B`bÛ ` 9 h    f&gt;HxHx/9 w\N¹ !êOï `$9 X    f 9  P Hx B§N¹ !ÞP9 h    gÎR´c LßNuHç8&lt;$o  *| ¼D(9 u¬v `  °Ú ` 9 h    fHxHx/9 w\N¹ !êOï t (MpÙÀ&amp;Mp×À`b9 X    f 9  P Hx B§N¹ !ÞPRp2°d69 Y z­f&amp;;|  6¼ (¼ !Ð&gt;Hx #B§/
+Hx N¹ !
+Oï N¹  ).9 h    gR¶e ÿNLß&lt;NuHç00$o &amp;| !ÞB`^Ú ` 9 h    f:HxHx/9 w\N¹ !êOï ` 9 X    f 9  P Hx B§NP9 h    gÒR´c9 P    f 9  P 9 X    f
+Hx B§NP9 ý P HxHx/9 w\N¹ !êOï `
+Hx B§NP9  X fìLßNuB  | ¼\B&quot;HBR eöVR   eèB9 tNuNuHç &lt;*o (| ¼X&amp;| ¼V$| ¼T9 Y z­f$4¼ 6¼ (Hx #B§Hy ¼DHx N¹ !
+Oï Hx dB§N¹ !ÞP`ÂLß&lt; NuHç 0&amp;| ¼¼N¹ !`$@ 
+f
+B§N¹ !èXN¹ !BÚ#ü ·@ ¯À#ü | ·PN¹ !Cp5#À ¼¼p4&#x27;@ p7&#x27;@ B« N¹ !CúN¹ !;xHx 5HxpHx°/
+N¹ !Oï /N¹ !JX$ p7°f,p 9 ÂXrF°grJ°g
+`N¹ !5`N¹ !9öB9 vÆ`Âp5°fN¹ !;x`´p4°f®N¹ !:ü`¦LßNu 9 t¤ ÂXr²f y ¯Ày ÂY J9 ·*f y ¯ÀJ( fN¹ !;xü  ·*NuNVÿØHç&lt;&lt;*| ·PAîÿæ&quot;| !Ð^ Ù Ù ÙAîÿÚ&quot;| !Ðj Ù Ù Ù$| ÂX Af ¢$| ÂYGîÿüÚÚÚ/.ÿüN¹ !³:* $| Â]GîÿöÚ4.ÿöHÂ$| Â_GîÿøÚÚÚ/.ÿøN¹ !³:&amp;  9 Á(&quot; éå&quot; éåÚ 9 ÁH&quot; éå&quot; éåÚ 9 w´&quot; éåÚÚ¹ yJl
+ 	:S` 	:o 	:R U| 3 $ &quot;&lt; QN¹ !ªD UrÑÁ(H  çÐ$ pP-@ÿò\HnÿòN¹ !:²X( &amp;  m´oR®ÿò`Þ U!nÿò  S U!@ p°fEîÿÚ`Eîÿæv `
+HHÀRHHÀ°mì U!C  U!B  &quot;&lt;  N¹ !ªDrN¹ !«  U!@  r&lt;N¹ !ªDr&lt;N¹ !«  U!@  r&lt;N¹ !«  U / N¹ !8´XJ g  ð Up!@   UR¨  ( r²n  Ü UB¨  UR¨  UR¨  ( r²n UB¨  U ( r°bvÐ0;Nû   8  (  (   (  (  UR¨  ( r ²`: UR¨  ( r²`* UR¨  ( r²n$ rÐ/ N¹ !:²    U°¨ n Up!@  U ( r²f* UR¨  ( r²n UB¨  UB¨  UR¨ ` UB¨   U| 1 $Lî&lt;&lt;ÿ¸N^NuNVÿèHç8&lt;(. (| ·PKîÿèJ¹ À8g J¹ Ág  T ( °¹ ÀÌm  þ T ( °¹ ÀÔn  î T ( °¹ ÀÌo T ( °¹ ÀÔlp`  Î T (  T¨ ^rN¹ !« $ Jftv$MX&amp;MHHÀ°m$`$^XXRp°lâ TpÑÀ$H °¹ ÀÌf6 9 À8å @$5  T ( °op`Z T ( °mN T ( r²nBp`@ °¹ ÀÔf4 9 Áå @$5  TpÑÀ$H °lp`´m T ( r²op`p Lî&lt;ÿÌN^NuNVÿüHç 8&amp;| ÂX(| ¯À 9 t¤ ÂXr²f  Eîÿüë ë ë «  T(  T|  /.ÿüN¹ !³&amp;/&lt;]#r/&lt;@L¥ÜN¹ !²TN¹ !² T Eîÿüë ë ë « /.ÿüN¹ !³&amp;/&lt;]#r/&lt;@L¥ÜN¹ !²TN¹ !² T!_  TB LîÿìN^Nu/ o $  l rN¹ !« Jf( rdN¹ !« Jf &quot;&lt;  N¹ !« Jfp`p`p $NuHç 0$| ·P&amp;| 0 R (   l/  R/(  R ( R/  R/(  R/( Hy !ÐvHy Â´N¹ !·N7|  7|  &#x27;| Â´ Hx 6B§/Hx N¹ !
+Oï ,Lß NuNVÿÐHç&lt;&lt;Hy !ÐN¹ !@X JfzHy !ÐN¹ !ALX-@ÿäãf-|@   ÿä/.ÿäN¹ !³&amp;/&lt;Æ?/&lt;@L¥ÜN¹ !²6N¹ !²-_ÿä/.ÿäN¹ !³&amp;-_ÿÐ-_ÿÔ/.ÿÔ/.ÿÐp / Hy !Ð¢Hy Â´N¹ !·N3ü  @3ü  B#ü Â´ DHx 6B§Hy 0Hx N¹ !
+Oï $Hy !ÐÂN¹ !ALX-@ÿàãf-|@  ÿà/.ÿàN¹ !³&amp;-_ÿÐ-_ÿÔ/.ÿÔ/.ÿÐHy !ÐÌHy Â´N¹ !·N3ü  @3ü  B#ü Â´ DHx 6B§Hy 0Hx N¹ !
+Oï  Hy !ÐÚN¹ !ALX-@ÿÜãf-|A@  ÿÜ/.ÿÜN¹ !³&amp;-_ÿÐ-_ÿÔ/.ÿÔ/.ÿÐHy !ÐäHy Â´N¹ !·N3ü  @3ü  B#ü Â´ DHx 6B§Hy 0Hx N¹ !
+Oï  Hy !ÐòN¹ !ALX-@ÿØãf-|A   ÿØ/.ÿØN¹ !³&amp;-_ÿÐ-_ÿÔ/.ÿÔ/.ÿÐHy !ÐüHy Â´N¹ !·N3ü  @3ü  B#ü Â´ DHx 6B§Hy 0Hx N¹ !
+Hy !ÑN¹ !@ JfBHy !ÑN¹ !@Oï (-@ÿèJ®ÿèf-|  ÿè/.ÿèp / Hy !ÑHy Â´N¹ !·N3ü  @3ü  B#ü Â´ DHx 6B§Hy 0Hx N¹ !
+Oï  vKîÿýIîÿüGîÿû`  ÈB| 9ÿì| ÿíB.ÿît/ HnÿìN¹ !B&lt;| ,ÿìEÿíEîÿäZÿîZÿïZÿðRÿñEîÿàZÿòZÿóZÿôRÿõEîÿÜZÿöZÿ÷ZÿøRÿùEîÿØZÿút/ HnÿìN¹ !B&lt;Hx &lt;Hx 7N¹ !Oï r²fv`$ 9 t¤ ÂXr²f
+9 L ÂXgvB9 vÆ g ÿ4vKîÿðIîÿïGîÿî`   B| 9ÿì| ÿíBt/ HnÿìN¹ !B&lt;| &quot;ÿìDÿít/ HnÿìN¹ !B&lt;| 5ÿìEîÿèZÿít/ HnÿìN¹ !B&lt;Hx &lt;Hx 7N¹ !Oï  r²fv`$ 9 t¤ ÂXr²f
+9 U ÂXgvB9 vÆ g ÿ\vEîÿîGîÿí`zB| 9ÿì¼ Bt/ HnÿìN¹ !B&lt;| !ÿìt/ HnÿìN¹ !B&lt;Hx &lt;Hx 7N¹ !Oï r²fv`* 9 t¤ ÂXr²f
+9 A ÂXgv`a õ|B9 vÆ g ÿ| 9ÿì| ÿíB.ÿît/ HnÿìN¹ !B&lt;Lî&lt;&lt;ÿ°N^NuHç 0&amp;o $| Â5| 
+ %K %| ° Hx 6Hx Hy ÂHx N¹ !
+Oï J9 °ft `Hy °N¹ !AÔX$  LßNuHç 0&amp;o $| Â5| 
+ %K %| ° Hx 6Hx Hy ÂHx N¹ !
+Oï J9 °ft `Hy °N¹ ! X$  LßNuNVÿôHç &lt;&amp;n IîÿôKîÿü$| Â5| 
+ %K %| ° Hx 6Hx Hy ÂHx N¹ !
+Oï J9 °f
+p ()@ `Hy °N¹ !¶îX()A /, /N¹ !²* Lî&lt; ÿäN^NuHç8 $o t B`N é$ p / N¹ !¸X  0m 9nHHÀ   0` Am FnHHÀ   7ÔRRJf® LßNuHç00&amp;/ $o &amp;| zÀHx B§N¹ !Þ&amp;¼ L SR¼ B` SR f SRRR´eæ SR¼  S¼ #Ó &amp;¼ LHx 7N¹ !Oï B9 vÆ |  y z|  |øÿHx 8N¹ !pXLßNuHç  B9 ² ü  ²¡$y z|p	ÕÀNqNqNqNqNqNqJB9 ²¡9  ² f
+B§N¹ !èXHx »Hx Hx /9 zN¹  hOï #ü ¶ z¤B9 ¸#ü ¶` zlB9 vÆ |  9 0 vÉ y z|y vÉ 
+ y z|  |øÿLßNu/
+$| ·P&quot;| ¯À Q ¼     Q!|      Q| 
+  RB RB¨  RB¨  RB¨  RB¨  RB¨  RB¨  RB¨  RB¨   R| 0 $B9 ·*$_NuNV  Hç &lt;&amp;| Á(| À8*| °Hy !Ñ0a üÐ#À Á(Hy !Ñ:a üÀ#À w´Hy !ÑBa ü°#À yHy !ÑJa ü Oï #À ÁTgT$| ¯xy ÁW | R Hx 6B§/
+Hx N¹ !
+Oï J* g$p *  @B2 
+rÐ/ N¹ ! X#À ÁH`B¹ ÁHHy !ÑTa ü0#À ÀÌS¹ ÀÌJ¹ ÀÌm
+p°¹ ÀÌlp#À ÀÌ$| Â5| 
+ %| !Ñ^ %M Hx 6Hx Hy ÂHx N¹ !
+Oï J9 °g2/
+Hy !ÑhN¹ !·PJfp(`/
+N¹ ! X(p°mp°oBHy !Ñna û#À ÀÔS¹ ÀÔJ¹ ÀÔm
+p°¹ ÀÔlp	#À ÀÔ5| 
+ %| !Ñx %M Hx 6Hx Hy ÂHx N¹ !
+Oï J9 °g0/
+Hy !ÑN¹ !·PJfp&amp;`/
+N¹ ! &amp;p°mp°oBLî&lt; ÿðN^NuHç &lt;$| ¾P&amp;| }¢(| !J¢*| !H&lt;B9 ¿ÊN¹ !G.N¹ !GzN¹ !GB9 ´Hx :N¹ !pX      °g  À µMHx NHx NP      °g  À µMHx NHx NP      °g  À µMHx NHx NP        °g   À µMHx NHx NP9  ´gHx &amp;N¹ !*X9   ´g ÿHx %N¹ !*X` ÿLß&lt; NuHç  B9 ² ü  ²¡$y z|p	ÕÀNqNqNqNqNqNqJB9 ²¡9  ² f
+B§N¹ !èXLßNuü  ¾PB9 }¡ü  }¨ü  }¢NuNVÿüHç00Aîÿü| ÿü|  |  |   B$| ³&amp;| ÀÜ&quot;H9 ¾P RfJÄ   ÿJg* P gJf* N f* ` Jg* N gJf* P f* F ÁRRPR e¢LîÿìN^NuNVÿ°Hç8&lt;&amp;. *| ³Iîÿºp çQ(  @5 R f &amp;J9 µMgp ç @5 PùgJ9 µMfnp ç @5 Nùf^p  | ÀÛ0  AõH X$H r  | ÀÛ0 p  | ÀÛ0  °g Èp *  | ·{0  B9 ·&lt;ü  ¿Ê` ¤J9 µMgp ç @5 NùgJ9 µMf p ç @5 Pùf pp  | ÀÛ0  AõH  ( F r  | ÀÛÁ0 p  | ÀÛ0  °g 6AõH  ( r  | ¹0 B9 ·&lt;ü  ¿Ê` 5 PH f AõH h  | R Hx 9B§/Hx N¹ !
+B$LpÕÀGîÿ°`ÚR´, eöp B6 °Hnÿ°N¹ !JÞ$ J9 µMgp ç @5 PùgJ9 µMfp ç @5 NùfAõH  ( `&lt;J9 µMgp ç @5 NùgJ9 µMfp ç @5 PùfAõH  ( FÄAõH h  | W /Hy !Ñ rÐ/ N¹ !·N@ Hx 9B§/Hx N¹ !
+Lî&lt;ÿN^Nu&quot;| ´p / çH | ³0   Mf  Nu Sf  Nu Bf  Nu/ o t  HffR`&gt; 0e 9b é$    `  Ae Fb é$       	Ôf¾`&quot; 0e 9b åÔÔ   ÔfÞ $Nu/
+$| ´ÌBHy &quot;ZN¹ !Hx N¹ !pHy &quot;ZN¹ !#À &quot;Z¼ /9 !ÜHx N¹ !öHx Hx N¹ !Hx Hx N¹ !Oï $N¹ !KÎ`$_NuNVÿØHç 0$| !d &amp;| !Hy !ÑNXN¹ !/ NXHy !ÑNHnÿØN¹ !cÐP.ÿØHHÀrz°b ¦Aù !Lnr°SÉÿüf Ò0;Nû  Øl R f p \ z  Î ìl  Øl R f p \ z  Î ìl   â ¢!#$CGHKMPQRSTXZcghkmpqrstxz N¹ !MÔ` ÿfN¹ !S*` ÿ\N¹ !Ud` ÿRN¹ !W6` ÿHN¹ !X` ÿ&gt;N¹ !YÜ` ÿ4N¹ !Zæ` ÿ*N¹ !`(` ÿ /9 !ÜHx N¹ !öHx Hx NHx Hx NOï ` þôN¹ !bx` þêN¹ !]n` þàN¹ !^
+` þÖHy !ÑªNHy !Ñ¬NHy !Ñ¸NHy !ÑÈNHy !ÑØNHy !ÑäNHy !ÑôNHy !ÒNHy !ÒNHy !Ò*NHy !ÒXNHy !ÒvNOï 0Hy !ÒNHy !Ò¨NPHy !Ò²` þRHy !ÒÄNB9 ´Ì/9 !ÜHx N`
+Hy !ÒÞ` þ,Lî ÿÐN^NuNVÿèHç&gt;&lt;KîÿüHy !ÒìN¹ !d Hy !ÓN¹ !d Pp*|` p°l.|Hy !Ó N¹ !d HnÿèN¹ !cÐP. Xÿèg ô. xÿèg ê &quot; çç | Âø-p ÿøHnÿø/N¹ !eX/ HnÿüHy !Ó,N¹ !dÀOï  &quot; çç | Ã 00 @ gHy !ÓDN¹ !d X &quot; çç | Ã 00 @ gHy !ÓPN¹ !d X &quot; çç | Ã 00 @ @g @Hy !ÓZN¹ !d Xt&amp;| Á`z	`  °f  | !Þ&lt;HpX Hy !ÓfN¹ !dÀ//Hx N¹ !dü//Hx N¹ !düOï  x$| wìv	`  ´ª $f | !à¬Hp8 Hy !ÓpN¹ !dÀP´ª f | !à¬Hp8 Hy !ÓN¹ !dÀP´ª  f | !à¬Hp8 Hy !ÓN¹ !dÀP´ª (f | !à¬Hp8 Hy !Ó¢N¹ !dÀPp	Öp4ÕÀR¸¹ !àxo ÿvx$| zäv	`&amp;´f | !áHp8 Hy !Ó´N¹ !dÀPp	ÖpÕÀR¸¹ !àþoÒp	ÚR´¹ !Þ4o þà &quot; çç | Ã 00 @ gxt(| wìv	`d$l &amp;Lp×À`J * °f@JfHy !ÓÈ`Hy !ÓÔN¹ !d  | !à¬Hp8 Hy !ÓàN¹ !dÀ//Hx N¹ !düOï $R 
+f²p	Öp4ÙÀR´¹ !àxo &quot; çç | Ã 00 @  gfHy !ÓêN¹ !d Xt&amp;| zÜv	`D$S`2 * °f( | !áHp8 Hy !ÓöN¹ !dÀ//Hx N¹ !düOï $R 
+fÊp	Öp×ÀR´¹ !àþo´ &quot; çç | Ã 00 @ gHy !ÓþN¹ !d //B§N¹ !düOï  &quot; çç | Ã 00 @ gfHy !ÔN¹ !d Xt&amp;| wXv	`D$S`2 * °f( | !ànHp8 Hy !ÔN¹ !dÀ//Hx N¹ !düOï $R 
+fÊp	Öp ×ÀR´¹ !àjo´ &quot; çç | Ã 00 @ gfHy !Ô&amp;N¹ !d Xt&amp;| xðv	`D$S`2 * °f( | !àìHp8 Hy !Ô2N¹ !dÀ//Hx N¹ !düOï $R 
+fÊp	Öp×ÀR´¹ !àÐo´ &quot; çç | Ã p  fHy !Ô:N¹ !d X &quot; çç | Ã Jp fHy !ÔBN¹ !d X &quot; çç | ÃJ° g8 &quot; çç | ÃHp  &quot; çç | ÃHp Hy !ÔHN¹ !dÀOï Hy !ÔjN¹ !d XRR 9 !ÜÐ¹ !Ü °l úæLî&lt;|ÿÄN^NuNVÿìHç0&lt;Gîÿü(| w¸*| !dÀHy !ÔlN¹ !d Hy !ÔN¹ !d Pp&amp;v` êp°l.vHy !Ô²N¹ !d HnÿìN¹ !cÐP. Xÿìg Ì. xÿìg Â &quot; éÐåAô Aè ,/ &quot; éÐåAô Aè 0/ &quot; éÐåAô P/ &quot; éÐåAô Aè / &quot; çÐ | !à¬Hp HnÿüHy !Ô¾NOï  &quot; éÐå @$t`/* N¹ !eX/ Hy !ÔäNP$R 
+fâ &quot; éÐå @$4$g* å | Á\J° o çÐ | !Þ&lt;Hp Hy !ÔîNP &quot; éÐå @$4g* å | Á\J° o çÐ | !Þ&lt;Hp Hy !Õ NP &quot; éÐå @$4 g* å | Á\J° o çÐ | !Þ&lt;Hp Hy !ÕNP &quot; éÐå @$4(g* å | Á\J° o çÐ | !Þ&lt;Hp Hy !Õ$NPHy !Õ6N¹ !d XRR °¹ !àxo þLî&lt;ÿÔN^NuNVÿìHç8&lt;Gîÿü(| !dÀ*| !d Hy !Õ8NHy !ÕRNPp&amp;x` p°l*xHy !ÕnNHnÿìN¹ !cÐP. Xÿìg p. xÿìg f &quot; çÐ | !Þ&lt;Hp HnÿüHy !ÕzNOï  å | Á\ 0 grÿ°g`Hy !Õ` Hy !Õ`  å | Á\&amp;0 /N¹ !eX/ Hy !ÕN//Hx N¹ !düOï v$| wìt	`z °ª $f | !à¬Hp( Hy !Õ¦NP °ª f | !à¬Hp( Hy !Õ¸NP °ª  f | !à¬Hp( Hy !ÕÊNP °ª (f | !à¬Hp( Hy !ÕÜNPp	Ôp4ÕÀR¶¹ !àxo ÿ~v$| zät	`$ °f | !áHp( Hy !ÕîNPp	ÔpÕÀR¶¹ !àþoÔHy !ÖNXRR °¹ !Þ4o þnLî&lt;ÿÐN^NuNVÿìHç &lt;Gîÿü(| w8*| !d Hy !ÖNHy !ÖNPp&amp;t` p°l*tHy !ÖPNHnÿìN¹ !cÐP. Xÿìg  è. xÿìg  Þ ëAô Aè / ëAô Aè / &quot; çÐ | !ànHp HnÿüHy !Ö\N¹ !dÀ ë @ 4r²fHy !Öx`Hy !Ö~NOï  ë @J´gT ë @ t/( N¹ !eX/ Hy !ÖN¹ !dÀP ë @$t `/* N¹ !eX/ Hy !ÖN¹ !dÀP$R 
+fÞHy !ÖNXRR °¹ !àjo þöLî&lt;ÿØN^NuNVÿèHç0&lt;Gîÿü(| xÔ*| !d Hy !ÖNHy !Ö²NPp&amp;v` B®ÿø &quot; ÐÐç @$t $.ÿø`$RR 
+fø-Bÿøp°l*vHy !ÖèNHnÿèN¹ !cÐP. Xÿèg  Ô. xÿèg  Ê &quot; ÐÐå | !àØHp  &quot; ÐÐçAô Aè / &quot; ÐÐçAô Aè / &quot; ÐÐå | !àÜHp Hnÿø &quot; çÐ | !àìHp HnÿüHy !ÖôN¹ !dÀOï   &quot; ÐÐç @$t`/* N¹ !eX/ Hy !×N¹ !dÀP$R 
+fÞHy !×$NXRR °¹ !àÐo þäLî&lt;ÿÐN^NuNVÿèHç0&lt;Iîÿü*| !d Hy !×&amp;NHy !×&gt;NPp(v&amp;| zØ`  ÂB®ÿø$S$.ÿø`$RR 
+fø-Bÿøp°l*vHy !×dNHnÿèN¹ !cÐP. Xÿèg  . xÿèg   &quot; åÐå | zÔHp Hnÿø &quot; çÐ | !áHp HnÿüHy !×pN¹ !dÀOï $k `/* N¹ !eX/ Hy !×N¹ !dÀP$R 
+fÞHy !×NXRRp×À °¹ !àþo ÿ6Lî&lt;ÿÐN^NuNVÿäHç &lt;&amp;| !dÀ(| !d KîÿèHy !×N &lt;  è&quot;9 !á&quot;N¹ !ªD-@ÿüHy !á&quot;HnÿüHy !×¬NHy v¼Hy !áHy !×êNHy v´Hy &quot;ZHy !ØNHy !ØNNHy !ØNOï 0Bt$y }¤` è * °¹ v¼c * ¹ v¼`pÿ¹ v¼Ðª R*&quot;9 !á&quot; N¹ !«&gt;*p°l*tHy !Ø²NHnÿìN¹ !cÐP. Xÿìg . xÿìg R * &quot;9 !á&quot;N¹ !«&gt;-@ÿä/* N¹ !eX/ HnÿäHnÿèHy !Ø¾NOï  * r°b 0Ð0;Nû  0 L  ° n  * &quot; çÐ | !Þ&lt;Hp Hy !ØÒNP`  /* N¹ !eX/ Hy !ØèNP`  ä * &quot; çÐ | !Þ&lt;Hp Hy !ØþNP`  Â * &quot; çÐ | !áHp Hy !ÙNP`    * &quot; çÐ | !àìHp Hy !Ù*NP`~Hy !Ù@N * &quot; éÐå | wÈJ° fHy !ÙF`Hy !ÙLN * &quot; çÐ | !à¬Hp Hy !ÙRNOï `* * &quot; çÐ | !ànHp Hy !Ù\NP`
+Hy !ÙrNX$R 
+f þLî&lt;ÿÐN^Nu/t | xì&quot;9 !àÐ`B¨ B¨ pÑÀR´oît | wì&quot;9 !àx`B¨ ,B¨ 0p4ÑÀR´oît | wX&quot;9 !àj`B¨ B¨ p ÑÀR´oît | zè&quot;9 !àþ`BpÑÀR´oôB9 ·UHy !ÙN¹ !d X$NuNVÿüHç 8Eîÿü&amp;| !d (| !dÀN¹ !_$ g  Ð çç | Âü$° f
+Hy !Ù`  ¸Hy !Ù¨NHy !ÙÆNHnÿü r8Ð/  r4Ð/  r0Ð/  r,Ð/  r(Ð/  r$Ð/  r Ð/ Hy !ÚNOï , rÐ/  rÐ/  rÐ/  rÐ/  rÐ/  P/  X/ /Hy !Ú*N r&lt;Ð/  r&gt;Ð/ Hy !ÚFN`Hy !ÚhNLîÿìN^NuNVÿðHç 0EîÿðGîÿðHy !ÚxN¹ !d /N¹ !cÐHy !ÚN¹ !d Oï  -fpÿ`Z 0m&amp; 9n /N¹ ! X$ p°n´¹ !Üot  `.t` /N¹ !eX/ /N¹ !·PJf `R´¹ !ÜoØp LîÿäN^NuNVÿð/Hy !ÚN¹ !d HnÿðN¹ !cÐHy !ÚN¹ !d HnÿðN¹ ! $ $.ÿìN^NuNVÿð/Hy !ÚN¹ !d HnÿðN¹ !cÐHy !Ú´N¹ !d HnÿðN¹ ! $ $.ÿìN^NuNVÿðHç0&lt;$| !d &amp;| !_(| !Ü*| !Hy !Ú¶NXHy !Ú¸NHnÿðN¹ !cÐP.ÿðHHÀrx°b ðAù !`¸r°SÉÿüf ÞÒ0;Nû È l : Xj ¦  ºÈ l : Xj ¦  ºF/BCEHRSTUXbcehrstux N$ Jg ÿ~p°g ÿv/N¹ !Ì` ÿhN$ g ÿb/N¹ !Ô` ÿTN$ g ÿN/N¹ !è` ÿ@N$ Jg ÿ8´n ÿ2a þ&amp; //N¹ !zP` ÿN$ g ÿ/N¹ !` ÿN$ pÿ°f0ü  ´Ì/Hx N¹ !öHx Hx NHx Hx NOï ` þÎJg þÈ´n þÂ//N¹ !öP` þ²N$ pÿ°f/Hx NPB9 ´Ì` þJg þ´n þ//NP` þ|N$ Jg þr´n þla þ/ /N¹ !P` þXHy !ÚÄNHy !ÚÆNHy !ÚÔNHy !ÚàNHy !ÚðNHy !ÚþNHy !ÛNHy !Û,NHy !ÛBNHy !ÛRNOï (Hy !Û\` ýöHy !ÛxN`
+Hy !Û` ýâLî&lt;ÿØN^NuNVÿàHç0&lt;GîÿôIîÿüKîÿàHy !Û¢N¹ !d Hy !ÛºN¹ !d Pp(t`  ªp°l*tHy !ÛÜN¹ !d HnÿàN¹ !cÐP Xg   xg   &quot; çç | Ã-p ÿøB &quot; çç | Ã$p &amp;.ÿø`JfRR¶bô .ÿø-@ÿðHnÿôHnÿðHnÿø/N¹ !eX/ HnÿüHy !ÛèN¹ !dÀOï RR °¹ !Üo ÿNp°l$Hy !ÛþN¹ !d HnÿàN¹ !cÐP Xg&gt; xg8Hy ·UHy !Ü
+N¹ !dÀB$| vð$`RXJfø&amp;HnÿôHy !Ü4N¹ !dÀLî&lt;ÿÈN^NuNVÿüHç0&lt;&amp;n Iîÿÿ*| !8v$Kt`  HnÿÿHx N¹ !äP 
+gl gb f
+p°lSS9 Y g6HnÿÿHx NP g f|  ÿþHnÿþHx NHnÿÿHx NOï   m ~nÔR`tv Jf ÿx 
+f9 Y g
+HnÿÿHx NBLî&lt;ÿäN^Nu/
+$o `/
+RHx N¹ !8PJfì$_NuNV  Hy &quot;
+Hn /. N¹ !eâHy &quot;
+a ÿÀN^Nuü  ´ÌHx N¹ !*XNuNVÿüHç88$. &amp;. (. Gîÿü(| v¼$y }¤`P¸ª fH´ª fB¶ª f&lt; * °c * `
+pÿÐª R&amp;&quot;9 !á&quot; N¹ !«&gt;&amp;HnÿüHy !Ü^a ÿTP$R 
+f¬LîÿäN^NuNVÿü/$. ´¹ !Ün çÐ !Ý¬` -BÿüHnÿüHy &quot;^Hy !ÜnN¹ !eÈ &lt; &quot;^$.ÿøN^NuNV  /. Hn /. N¹ !eâN^NuNVÿÄHç?&lt;$n |  ÿÿIîÿæ*J~z
+x B¬ B n HHÀr(r2°b Ð0;Nû  f | ¢üüüN ¶ ¶ ¶ ¶ ¶ ¶ ¶ ¶ ¶ ¶üüüüüüüüVüüüüüÐrüü:ü Þ ê Ì8^lüü$üLP LR® !n  (~` ÿfSo
+-l  ` ÿXQ LJ¨ f ` lR® ` ÿ@R®  n X®  P.` ÿ,Hn Hn N¹ !j4P. ` ÿR®  n X® $P` ÿR® BR` þøR®  n X® &amp;P n  *f n X®  P&amp;R® `Hn Hn N¹ !j4P&amp; Øt`ÛR´oø` þªR®  n X®  P ` þR®  n  -fp0`p @ÿÿR® ` þvR® Hn Hn N¹ !j4P&amp; Eõ8 S` þVR® ` þNR®  n HHÀrL°AgrI°Ag,ri°AgBrB°Ag^`  Ô/HnÿÄ n X®  P/N¹ !©¾`  ´/HnÿÄ n X®  P/N¹ !©¾`  /HnÿÄ n X®  P0  ÿÿ/ N¹ !©¾`t/HnÿÄ n X®  P   ÿ/ N¹ !©¾`RHx 
+HnÿÄ n X®  P/N¹ !«h`6Hx 
+HnÿÄ n X®  PHHÀ/ `Hx 
+HnÿÄ n X®  P/N¹ !©¸Oï R®  n  *f n X®  P&amp;`Hn Hn N¹ !j4P&amp; AîÿÄ,JfüFØ¶m@GîÿÄ -f. 0ÿÿfÓ¼ 0St`îÿÿRHHÀ°lðt`ÛR´oø` üÐt`ü *R´oö` ü¾R® Hn Hn N¹ !j4P&amp; t`ü  R´oöØ` üü 
+R*JR® ` üR® Hn Hn N¹ !j4P&amp; p°n üfp$°m ü^*` üXR®  n X® &amp;Pt Hn Hn N¹ !j4P&amp; `ÛRRJg´mò`ü  R R°mò` üR®  n R® ` n R® ÐR n ´fìR® ` ûæR® ` ûÞLî&lt;üÿN^NuHç 8(o &quot;o $T&amp;Qt  *f$R [$&quot;`&amp; åÐÐHHÁÐ   0$ R 0m 9oÚ( LßNuR9 ·mHçÿþ/N¹ !k.@LßÿS9 ·mNsR9 ·mHçÿþ/N¹  ,.@LßÿS9 ·mNsR9 ·mHçÿþ/N¹  )n.@LßÿS9 ·mNsNsN@Nu0/ á@ | 3À vÄ@ÁAøÿ@FÁNuNVÿôHç8&lt; n *h B|øÿ3ü  vÄ y · !n   r+°cNù !àÐ0;Nû  Ò X^&quot;
+RV$L Ô ^n¤	Î	&lt;æ`&gt;ÀDêðzôª
+
+ö*VÌô
+¸ 	Î¸$-  å | Á\J° fp+@ Nù !à |  y yHX¹ yH |øÿNù !à$m `  , å | Á\J° g   |  y yHX¹ yH |øÿXJf ÿÒNù !à$-  å | Á\ 0 rÿ²f  $y · J­ gJ - %@ -@ÿü @!m   nÿüB¨  nÿüp!@  nÿü!B  nÿü!j  /.ÿüN¹ !xXp+@  å | Á\!ª  5| @  y · #Ð ·  y · !| ·  Nù !à å | Á\J° f årÿ | Á\! Nù !àp+@ Nù !à$m `  å | Á\ÑÀ(Hpÿ°f y · (¨ XJfÜJf, y · 1| @  y · #Ð ·  y · !| ·  Nù !àJf*+R ` m  årÿ | Á\! X­ µí dâNù !à y · 1| @  y · #Ð ·  y · !| ·  Nù !à$-  å | Á\J° gNù !à årÿ | Á\! Nù !à$m `&quot; å | Á\J° f årÿ | Á\! XJfÚNù !à$- f$y · `$ çç | ÂèÑÀ$HJj g j  Nù !à j   R!j   j  Nù !à - &quot; çç | ÂèÑÀ$HJj fNù !àjÿþ gNù !à | $¹ ô#Ê ô|øÿNù !à - &quot; ÐÐç | xÔÑÀ-Hÿô&amp;P g0 nÿô  nÿôR¨  (  nÿô°¨ o   nÿô (  nÿô!@ `vJ­ gp$y · 5|   .ÿôX/ N¹ !üXJ­ gN%m  -j ÿü nÿü!m   nÿüB¨  nÿüp!@  nÿü!m   nÿü!j  /.ÿüN¹ !xXp+@ +K Nù !à&amp;m  - &quot; ÐÐç | xÔÑÀ-HÿôR¨  nÿô$h  
+g  j j (h B)K  nÿô!R g .ÿôX R!@ jÿý f   | $¹ ô#Ê ô|øÿ-j ÿüfNù !àB¬ /.ÿüN¹ !ÖXBª Nù !à nÿô&amp; nÿô  nÿôS¨ Nù !à - ë | w8ÑÀ&amp;HR« J« f&#x27;y ·  p&#x27;@ Nù !à + °¹ · f
+R« Nù !àR« J­ g  òp°« f  r k $H (  y · °¨ o  ZJ« f&#x27;j   y · %h  Jj f  &amp; R!j   j   | $¹ ô#Ê ô|øÿ`0* @ ªg
+/
+N¹ !BX$y · 5|  /N¹ !üXJ­ fNù !à%m  -j ÿü nÿü!m   nÿüB¨  nÿüp!@  nÿü!m   nÿü!j  /.ÿüN¹ !xXp+@ Nù !àp+@ Nù !à - ë | w8ÑÀ&amp;H + °¹ · gNù !àS« gNù !àp°« f  `J« g  X y ·  + !@  y ·  P°¨ o  6$y ·  y · #Ð ·  y · !| ·   | $¹ ô#Ê ô|øÿB« $S 
+g  d&amp;g R!K jÿ÷ f   | $¹ ô#Ê ô|øÿ&#x27;J p&#x27;@ -j ÿüfNù !à j (h BB¬ /.ÿüN¹ !ÖXBª Nù !àB« Nù !à - ë | w8ÑÀ&amp;HJ« fNù !à k +h  Nù !à - ë | w8ÑÀ&amp;HJ« f&#x27;m  Nù !àp+@ Nù !à(- f
+ y · (( $- f
+ y · $(  çç | ÂèÑÀ$H`. y ·  ( °gJj f R!j   j   j  Rp8ÕÀ´oÎNù !à(- f
+ y · (( $- f
+ y · $(  çç | ÂèÑÀ$H`  .Jj g   jÿï f   | $¹ ô#Ê ô|øÿRp8ÕÀ´o ÿÐNù !àN¹ !¼+@ Nù !à-m ÿü nÿü(  f/.ÿüN¹ !ÖX nÿü ¹ ·h#îÿü ·hNù !à-m ÿüfN¹ !¼-@ÿüfNù !à+nÿü  nÿü!m   nÿü!m   nÿüp!@  y ·  (  nÿü!@  nÿü - !@ å | Á\J° fJ­ f nÿü ( årÿ | Á\! /.ÿüN¹ !xXNù !à$- f$y · $* %m  ` çç | ÂèÑÀ$H * r%@ -j ÿüJj f R!j   j   j   nÿü!m   nÿüB¨  nÿüB¨  nÿü!B  nÿü!B /.ÿüN¹ !xXNù !à-m ÿü nÿü (  y · °¨ gp+@ Nù !à nÿüJ( fp°fp+@ Nù !à/.ÿüN¹ !ÖXp)°gNù !à nÿü!m   nÿü!m   y ·  (  nÿü!@  nÿü ( å | Á\J° fJ­ f nÿü ( årÿ | Á\! /.ÿüN¹ !xXNù !à | $9 v¼|øÿ  m +@  m  Nù !à-m ÿü nÿü(  f  &quot; |  nÿü ( ¹ v¼+@ |øÿNù !àB­ Nù !à | +y v´ |øÿNù !à | #í  v´|øÿNù !àJ­ f y ·  (  m !@ `
+ m !m   m !m   y ·  (  m !@  - &quot; åÐå | zÄÑÀ-HÿøJf  v nÿøJ¨ g  j nÿø ( å | Á\ 0 rÿ²f nÿø ( å | Á\B° `  8 nÿø ( å | Á\J° g    |  nÿø (  y yHX¹ yH |øÿ nÿø$h  
+g   j (h BJ¬ g y ·  ( °¬ f  b)m   nÿøR¨  nÿø!R g .ÿøX R!@ jÿß f   | $¹ ô#Ê ô|øÿ-j ÿüg&amp;B¬ /.ÿüN¹ !ÖXBª `/- /.ÿøN¹ !ðP$- J­ g  $y ·  å | Á\!ª  5| @  y · #Ð ·  y · !| ·  J­  fNù !à%m $ -j ÿü nÿü!m    nÿüB¨  nÿüp!@  nÿü!B  nÿü!j  /.ÿüN¹ !xXp+@ Nù !àJfNù !à årÿ | Á\! Nù !à - &quot; åÐå | zÄÑÀ-Hÿø/- /.ÿøN¹ !P(@ f|J­ g  ¼$y · 5|    .ÿøX/ N¹ !üXJ­  g  %m $ -j ÿü nÿü!m    nÿüB¨  nÿüp!@  nÿü!m   nÿü!j  /.ÿüN¹ !xXp+@ `F nÿøR¨  nÿøJ¨ g4 nÿøJf nÿø ( årÿ | Á\! ` nÿø ( å | Á\B° +L Nù !à - &quot; éÐå | w¸ÑÀ&amp;H(+ ¸« f  J­ fNù !à$y · 5|   rÐ/ N¹ !üXJ­ fNù !à%m  -j ÿü nÿü!m   nÿüB¨  nÿüp!@  nÿü!m   nÿü!j  /.ÿüN¹ !xXNù !àB­ &amp;+ J« gNù !{$k  
+fNù !{&#x27;R g rÐ R!@ jÿ f   | $¹ ô#Ê ô|øÿ-j ÿüg/.ÿüN¹ !ÖXBª  j (h BB¬ p¶b@ Ð0;Nû  F 
+  4 &amp; m  l `. m 0 l 0`  m   l  `  m &quot;l `ØSlúR« ,J«  g  X +  å | Á\ 0 rÿ²f +  å | Á\B° `  . +  å | Á\J° g   |  y yHX¹ yH «  |øÿJ« (fNù !à + (å | Á\B° Nù !àR« R«  + °fB« $+ p¶bH Ð0;Nû  ` 
+  &lt; * m  SÑÂ`H m 0&quot;ÒÒ A0`6 m  &quot;åÒ A `$ /  m / &quot;N¹ !«&gt;Ð&quot;@ _&quot;`ØSlúR« , + °« 0o&#x27;k  0¸« f  nJ« (g + (årÿ | Á\! J« g  d + å | Á\ 0 rÿ²f + `  : + å | Á\J° g  2 |  y yHX¹ yH « |øÿ`J« (g + (å | Á\B° p°« gNù !àJ« $g + $årÿ | Á\! J«  fNù !à +  å | Á\ 0 rÿ²f +  å | Á\B° Nù !à +  å | Á\J° fNù !à |  y yHX¹ yH «  |øÿNù !à - &quot; éÐå | w¸ÑÀ&amp;HJ« f  J­ fNù !à$y · 5|   rÐ/ N¹ !üXJ­ fNù !à%m  -j ÿü nÿü!m   nÿüB¨  nÿüp!@  nÿü!m   nÿü!j  /.ÿüN¹ !xXNù !àB­ $+ S« « JlÔ«  + &amp; r°bFÐ0;Nû  \ 
+  &lt; * SÑÂ m `D ÐÐ @0 m 0`2 åÐ @  m  `  /  &quot;N¹ !«&gt;Ð @&quot;m &quot;`ØSlúJ« f  nJ«  g +  årÿ | Á\! J« $g  d + $å | Á\ 0 rÿ²f + $`  : + $å | Á\J° g  2 |  y yHX¹ yH « $|øÿ`J«  g +  å | Á\B°  + S°« gNù !$k  
+fNù !&#x27;R g rÐ R!@ jÿ f   | $¹ ô#Ê ô|øÿ-j ÿüg/.ÿüN¹ !ÖXBª R« R«  + °« fB« $+  j (h BB¬ p¶bH Ð0;Nû  ` 
+  &lt; * l  SÑÂ`H l 0&quot;ÒÒ A0`6 l  &quot;åÒ A `$ /  l / &quot;N¹ !«&gt;Ð&quot;@ _&quot;`ØSlúR« , + °« f  nJ« (g + (årÿ | Á\! J« g  d + å | Á\ 0 rÿ²f + `  : + å | Á\J° g  2 |  y yHX¹ yH « |øÿ`J« (g + (å | Á\B° p°« gNù !àJ«  fNù !à +  å | Á\ 0 rÿ²f +  å | Á\B° Nù !à +  å | Á\J° fNù !à |  y yHX¹ yH «  |øÿNù !àJ« g + årÿ | Á\! J« (fNù !à + (å | Á\ 0 rÿ²f + (å | Á\B° Nù !à + (å | Á\J° fNù !à |  y yHX¹ yH « (|øÿNù !àJ« (fNù !à + (å | Á\ 0 rÿ²f + (å | Á\B° Nù !à + (å | Á\J° fNù !à |  y yHX¹ yH « (|øÿNù !à - &quot; éÐå | w¸ÑÀ&amp;H&amp;­ &#x27;m  &#x27;m   + S&#x27;@ B« Nù !à - &quot; éÐå | w¸ÑÀ&amp;H - r°cNù !àÐ0;Nû   B º &#x27;m   J« g +  å | Á\B° Nù !à +  årÿ | Á\! Nù !à&#x27;m  ( + °« g + (å | Á\B° Nù !à + (årÿ | Á\! Nù !à&#x27;m  $J« f + $å | Á\B° Nù !à + $årÿ | Á\! Nù !à&#x27;m   + °« f + å | Á\B° Nù !à + årÿ | Á\! Nù !à - &quot; åÐå | zÄÑÀ-Hÿø!m   nÿøJf nÿø ( årÿ | Á\! Nù !à nÿø ( å | Á\B° Nù !à - &quot; éÐå | w¸ÑÀ&amp;H + S&#x27;@ $+ B« J« $g  X + $å | Á\ 0 rÿ²f + $å | Á\B° `  . + $å | Á\J° g   |  y yHX¹ yH « $|øÿ(+ ´gNù !àJ« (g  X + (å | Á\ 0 rÿ²f + (å | Á\B° `  . + (å | Á\J° g   |  y yHX¹ yH « (|øÿ&amp;+ Nù !&#x27;R g rÐ R!@ jÿ f   | $¹ ô#Ê ô|øÿ-j ÿüg/.ÿüN¹ !ÖXBª  j (h BB¬ R« R«  + °fB« $+ p¶bH Ð0;Nû  ` 
+  &lt; * l  SÑÂ`H l 0&quot;ÒÒ A0`6 l  &quot;åÒ A `$ /  l / &quot;N¹ !«&gt;Ð&quot;@ _&quot;`ØSlúR« , + °« 0o&#x27;k  0p°« f  `J«  g  X +  å | Á\ 0 rÿ²f +  å | Á\B° `  . +  å | Á\J° g   |  y yHX¹ yH «  |øÿ$k  
+gNù !ÀNù !à - &quot; çç | ÂèÑÀ$HJj f R!j   j  *j &amp;Ûê *ü   B%M +j &quot; &gt;;|   &lt;Bª Bª Bj %|   2|  6 | $¹ ô#Ê ô|øÿ` :$- f
+p	+@ ` * çç | ÂèÑÀ$H0*       g
+p
++@ ` ü%m  J­ g%m  &amp;%m  *%m  &quot;Bª Bª Bª ` Î$- f
+ y · $(  çç | Ã+p  ` ¦$- f
+ y · $(  çç | Ã!­  ` ~$y ¾@ 
+g#Ò ¾@+j  ` dB­ ` \$- f$y ·  y · $( ` çç | ÂèÑÀ$H-j ÿüg nÿü(  f/.ÿüN¹ !ÖXBª Jj g
+0* @ ªg j  g R!j  jÿU  j  ´¹ !Ün é | !ÜÈ%p  `  Æp~%@ $¹ ¾@#Ê ¾@`  ° y ·  P (  y · °¨ f  B­ $y · %j   y · #Ð ·  y · !| ·   | $¹ ô#Ê ô|øÿ`Tp°­ np°­ np~+@ $- f$y · ` çç | ÂèÑÀ$H/- /
+N¹ !DP`/-  m N+@ N¹ !ôLî&lt;ÿØN^Nu/
+&quot;o  o $Q 
+g&quot;( `&quot;J$Q 
+g²ª lò&quot; $_Nu&quot;/  o &quot;P 	g$Jg²© f  	Nu I&quot;P²© f  	NuJfìp NuHç 8(| · &quot;| ¾@(¼ Âè T!|   2 T|  6#Ô ²L T!| ·   Tp!@  TB¨  TB TBh B¹ ôt$| Ã &amp;| !ÜÌ`H5|  %B Bª %k  %|   2|  6Bª Bª %k  &amp;%k  *%S &quot;Bª .p×ÀRp8ÕÀ´¹ !Üo°J¹ !Ü g 9 !Ü&quot; çç | Ã ÑÀ&quot;`Bt$Q`2 
+r8Ð$5|   9 !ÜÐ%@ Bª p~%@ Bª Bª Rp8ÕÀ´¹ !Ü oÆJ¹ !Ü gBB9 ·mB9 ·UBy vÄLßNur | wX`$B¨ BB¨ B¨ B¨ B¨ B¨ B¨ Rp ÑÀ²¹ !àjoÔNur | zØ`BB¨ B¨ B¨ B¨ RpÑÀ²¹ !àþoàNuHç  r&quot;| !àà$| xì`&gt;$ R gt` Ð©  R P´© mîBBª Bª Bª Bª Bª RpÓÀpÕÀ²¹ !àÐoºLßNur | !à&quot;| wì`F&quot;#h  #h   ) S#@ B© B©  B© B© (B© $B© B© B© ,B© 0RpÑÀp4ÓÀ²¹ !àxo²Nu/t | Á``pÿ RX´¹ !Þ4oð &lt; vð#À y#À yHt  | vð&quot;9 !Þ8`BR´mø$Nu/ | ~ #È ·ht` rÐ RpÑÀ´¹ !ámêBB¹ }¤B¹ v¼B9 râB¹ v´B¹ rÞB¹ w0$Nu@À |  y yHX¹ yH ¯ FÀNuHç  $/ $o 9 ·m°9 ·Uo
+ù ·m ·U | Jg y yHX¹ yH p 09 vÄ2* &lt;   °f    y · !J 3ü  vÄ|øÿN¹ !ô` 
+LßNu /  o / /a ÿzPNuHç0&lt;J9 râgN¹ !B9 râ | Nù !â|øÿ y yX¹ y$ å | Á\ÑÀ$Hpÿ°gJfB`  &amp;pÿ$ çç | ÂèÑÀ&amp;H k $h B*k  
+g p°­ f´­ fBª /
+N¹ !ÖXB« p°f,%B (j ` å | Á\ÑÀ$Hpÿ°gJgpÿ$XJfÞkÿ¿ f   | &amp;¹ ô#Ë ô|øÿ |  9 yH°¹ ygNù ! &lt; vð#À y#À yH|øÿ | `  4#Ó ô|øÿ$| · `$R R ( °« oò&amp;&#x27;J  R!K $ | &amp;y ô f ÿÄ 9 yH°¹ ygNù !â y ²L h 2¼  y · ( 6 y ·  h 2#ù ·  ²L y ·  h 0( &lt;@ 3À vÄ y ·  ( Lß&lt;Nu y ·h g
+#Ð ·hB(  NuHç 8&amp;| w0(| · &quot;| v¼J9 ´Ìf  RR¹ rÞ 9 rÞ°¹ !á&amp;mB¹ rÞR¹ v´ TJ¨ g TS¨ f&amp; S (  S!@ $y }¤`$R 
+gJ* gô 
+g( * °f `B* $R 
+g * °gîü  râp`Jgü  râp`p Lß NuHç &lt;(| w0*| ôNù !$y }¤ |  y }¤#Ð }¤g y }¤!| }¤ |øÿ * r°b 6Ð0;Nû  B f      |  y yHX¹ yH ª |øÿJª g  þ%j  /
+N¹ !xX`  ê * &quot; çç | ÂèÑÀ&amp;HB« kÿû `  À * årÿ | Á\!  * &quot; çç | ÂèÑÀ&amp;HB« kÿ¿ `   * &quot; çç | ÂèÑÀ&amp;Hp°ª fP k $h Bp%@ $*  ë | w8ÑÀ$HJª g*·Òf&amp; RJg R P$( ´ª o$* //* N¹ !DPB«  k  g S!k  kÿU f&amp;*J¹ }¤g y }¤J( fNù !¢Jg  H TJh f  &lt; T (  T P°¨ f  * T (  T P!@  T  T h   |  T *|øÿBLß&lt;NuHç08(o |  &amp;| }¤ | &amp;9 v¼`J* g$* ´¬ b&amp;J$S 
+fæ 9 v¼Ñ¬ ()K &amp; 
+g%L |øÿLßNu/
+$o  | B*  j  g R!j  |øÿ$_NuHç 8&amp;o &quot;| · (Q&quot;,  Q&quot; Q!| ·  `&amp;J$S 
+g²ª lò&amp;)K (g%L Lß Nu/
+$o  j J¨ fJgf R ( °ª lZ`NJf j  ( °ª oF/
+N¹ ! `: j  ( °ª n R ( °ª l&quot; j  ( °ª o
+/
+N¹ ! `/
+N¹ !ÀX$_NuHç 0&quot;o &quot;) &amp;Q Q!i   i  `&amp;J$S 
+g²ª lò&amp;#K &quot;g%I Lß NuHç 0&quot;o  ) &amp;i  Q!i   i  `&amp;J$k Jª g°ª mî&#x27;I &quot;#J $Lß NuHç 8$/ $o &amp;| ô(| · %B  T ( °ª f  2 R ( °ª mNù !ð T( T!| ·   | $&amp;|øÿ`  TJj f  : j  ( °ª n R ( °ª l  0 R!j   j   | $&amp;|øÿ`0* @ ªg/
+a þVXLßNuNVÿôp-@ÿô-n ÿø-n ÿüHnÿôN@XN^Nu &lt; !ÜNuNVÿðB®ÿðHnÿðN@XN^NuNVÿà/
+Eîÿàp-@ÿà%n  Bª HnÿàN@X * $_N^NuNVÿèp-@ÿèHnÿèN@X .ÿüN^NuNVÿðp-@ÿð-n ÿø-n ÿüHnÿðN@XN^NuHç0 $/ &amp;/ Jf&quot;y · ` &quot; ÒÐéÐ | ÂèÑÀ&quot;HJ© f#B #B Lß NuNVÿÌHç  $. EîÿìJfp `  *p-@ÿì%n  %B Bª AîÿÎ%H HnÿìN@X * LîÿÄN^NuNVÿà/
+Eîÿàp	-@ÿà%n  %n  Bª p%@ HnÿàN@X * $_N^NuNVÿà/
+Eîÿàp-@ÿà%n  %n  Bª p%@ HnÿàN@X * $_N^NuNVÿðp-@ÿð-n ÿøHnÿðN@XN^NuNVÿà/
+Eîÿàp-@ÿà%n  %n  %n  %n  %n  Bª HnÿàN@X * $_N^NuNVÿðp-@ÿðHnÿðN@X .ÿøN^NuNVÿàp-@ÿà-n ÿè-n ÿìHnÿàN@XN^NuNVÿèp
+-@ÿè-n ÿüg  
+HnÿèN@XN^NuNVÿà/
+Eîÿàp
+-@ÿà%n  Bª Bª HnÿàN@X * $_N^NuNVÿìp-@ÿì-n ÿôHnÿìN@XN^NuNVÿØ/
+EîÿØp-@ÿØ%n  %n  Bª HnÿØN@X * $_N^NuNVÿðp-@ÿð-n ÿøHnÿðN@XN^NuNVÿØ/
+EîÿØp-@ÿØ%n  %n  %n  %n  Bª HnÿØN@X$_N^NuNVÿì/
+Eîÿìp-@ÿì%n  Bª HnÿìN@X * $_N^Nu o /( a ÿÊXNuNVÿè/
+Eîÿèp-@ÿè%n  Bª HnÿèN@X * $_N^NuNVÿè/
+Eîÿèp-@ÿè%n  %n  %n  %n  HnÿèN@X * $_N^NuNVÿðp-@ÿð-n ÿøHnÿðN@XN^NuNVÿðp-@ÿð-n ÿøHnÿðN@XN^NuNVÿôp-@ÿô-n ÿø-n ÿüHnÿôN@XN^NuNVÿàp-@ÿà-n ÿèHnÿàN@XN^NuNVÿð/
+Eîÿðp+-@ÿð%n  %n  HnÿðN@X * $_N^NuNVÿì/
+Eîÿìp-@ÿì%n  Bª Bª HnÿìN@X * $_N^NuNVÿðp-@ÿðp-@ÿôHnÿðN@X .ÿôN^NuNVÿà/
+Eîÿàp-@ÿà%n  p%@ Bª HnÿàN@X * $_N^NuNVÿà/
+Eîÿàp&quot;-@ÿà%n  Bª HnÿàN@X * $_N^NuNVÿà/
+Eîÿàp#-@ÿà%n  %n  Bª HnÿàN@X * $_N^NuNVÿàp$-@ÿà-n ÿèHnÿàN@X .ÿüN^NuNVÿàp%-@ÿà-n ÿè-n ÿüHnÿàN@XN^NuNVÿØp-@ÿØ-n ÿä-n ÿàHnÿØN@XN^NuNVÿä/
+Eîÿäp-@ÿä%n  %n  %n  HnÿäN@X$_N^NuNVÿà/
+Eîÿàp	-@ÿà%n  %n  Bª p%@ HnÿàN@X$_N^NuNVÿôp-@ÿô-n ÿøHnÿôN@X .ÿüN^NuNVÿà/
+Eîÿàp-@ÿà%n  %n  Bª p%@ HnÿàN@X$_N^Nu / &quot; ÐÐå | !àØ 0 NuNVÿà/
+Eîÿàp
+-@ÿà%n  p%@ Bª HnÿàN@X$_N^NuNVÿàp-@ÿà-n ÿìHnÿàN@XN^NuNVÿØ/
+EîÿØp-@ÿØ%n  %n  Bª p%@ Bª  HnÿØN@X * $_N^NuNVÿØ/
+EîÿØp-@ÿØ%n  %n  %n  %n  p%@ Bª  HnÿØN@X$_N^NuNVÿðp-@ÿð-n ÿüHnÿðN@X .ÿøN^NuNVÿøp -@ÿøHnÿøN@X .ÿüN^NuNVÿøp!-@ÿø-n ÿüHnÿøN@XN^NuNVÿèp&amp;-@ÿè-n ÿüHnÿèN@X .ÿôN^Nup NuNVÿÀ/
+Eîÿàp-@ÿà%n  p%@ %n  Bª AîÿÂ%H HnÿàN@X n  ª  * $_N^NuNVÿä/
+Eîÿäp*-@ÿä%n  %n  %n  %n  HnÿäN@X$_N^NuNVÿÀ/
+Eîÿàp	-@ÿà%n  %n  %n  p%@ p%@ AîÿÂ%H HnÿàN@X * $_N^NuNVÿÀ/
+Eîÿàp-@ÿà%n  %n  %n  p%@ p%@ AîÿÂ%H HnÿàN@X * $_N^NuNu/$/ Jf y ·  ( ` &quot; ÒÐéÐ | Âø 0 $Nu / &quot; éÐå | wÈ 0 Nu / å | Á\ 0 Nu y ·  ( NuNVÿÀ/
+Eîÿàp
+-@ÿà%n  p%@ %n  Bª AîÿÂ%H HnÿàN@X * $_N^NuNVÿðp(-@ÿð-n ÿüHnÿðN@XN^NuNVÿ¸/
+EîÿØp-@ÿØ%n  %n  Bª p%@ %n   Bª Aîÿº%H $HnÿØN@X n  ª  * $_N^NuNVÿè/
+Eîÿèp)-@ÿè%n  %n  %n  Bª HnÿèN@X * $_N^NuNVÿ¸/
+EîÿØp-@ÿØ%n  %n  %n  %n  p%@ %n   Bª Aîÿº%H $HnÿØN@X * $_N^NuNVÿðp&#x27;-@ÿð-n ÿüHnÿðN@XN^NuNVÿÌ/
+Eîÿìp-@ÿì%n  %n  Bª AîÿÎ%H HnÿìN@X * $_N^Nu/$/ Jf
+ y · $(  &quot; ÒÐéÐ | Ã 0 $NuN¹ !üN¹ !²N¹ !RN¹ !ÆN¹ !òN¹ !RN¹ !Hy !jHx  N¹ !8PNuNup  @ / åÑÀ ¯ NuA Hçþ ãUÂãUÃ°cÁAÅCááBBD fJgvJf´fÒÓ`j`f&lt; â&lt; â ÿgd&lt;DF mQFàfôì¨´fÒd$âREE ÿm`XkgNã[ÍÿüSEngBEââ   d
+âREE ÿg.ãàââ XOLß ~NuãJfèºfä´gà&quot;&lt; `àB`Ü&quot;&lt;   ÿ`Î o /p r t &quot;@  gø 
+n 	lì +g -ft 0gøe&amp; 	n Ð 0e 	n
+Ð&quot;@åÐ`æJgD$Nuo  Hçÿ Lï  $ãUÄãUÅ°cÁBÃCÉEH¹N¹ !¤¦JGf( g  ããJFf
+ãã`2À Fÿg  Â FDGQGm ààfôJfð`^GkââQÏÿúJkÖÕd ââRFFÿm`ZdFED@N¹ !¤ÖN¹ !¥
+ãMâ/B $/C (Lß ÿ / &quot;/ ..NuÂ N¹ !¥8`Ö(fò¾FfîJjê$&lt;ð B`Â$&lt;ÿà  B`´Hçü ãã ³ááBCBD @þ Aþ RSDoFR RSCoTRäèC6HAÁ4 ÆÂB@äÁHÂHÀHBåÐãD N¹ !¨XàââXOLß &gt;Nuf
+SDãbúRD`°¸g*Jg`$gJfB`ÒJg
+SCãdúRC`Jg &lt;   ÿ`¸²eJgÃ@àâ`p   `¤Hçÿ Lï  $* µãã°cÁBÃCN¹ !¤¦:,ÜGEÿg  ¨JGg  ¸À Â Hçð L :/ ÀÅÂÅÄÅÆÅB:/ Êï 
+ÖÓ:/ Êï ÖÓ:Êï ÖÓ:/ Êï 
+ÔÑ:Êï ÔÑH@:Êï 
+ÒÑGH@Þü 6HCBAHAÖÑÐ$ FþN¹ !¥ ãâ/B $/C (Lß ÿ / &quot;/ ..Nu*Gg &lt;&lt;ÿN¹ !¥8`Ì. gSFããjøRF` ÿ&lt;$&lt;ð `´BB`ªHçø &quot; N¹ !¨È`Hçø &quot; N¹ !§a POLß NuHçø a  ¬N¹ !¨Ú`&gt;    g&quot;n/8  /&lt;¿à  Nù !£/8  /&lt;?à  N¹ ! N¹ !£hNuHçø ajN¹ !¨ XOLß NuLï  aRN¹ !©^N¹ !¨Ú/A ..NuLï  a4N¹ !©^`Lï  a$N¹ !©azHï  ..Nu o LÐ aNù !§$&lt;ÿð  &amp; HCÄµ(ãf&lt; Jg,&lt; `&amp;HBêJBÿf4&lt;` &lt; Jg&lt; `À SB&lt; B2NuN¹ !§äaHÐ Nu mã ÿà  `B&gt;ÁBÁFÃCa@a  r,  ÇAãKâNuxé¸éºé¹é»,&lt;  ÿ.Ì½(È¹â(Î¿È¹âNuJfF  mF  ÇBJgkãã[ÎÿúZÎ Nu&lt;&lt;÷RNuJkSFããJFnFÿËmJDFââQÎÿúBF   d
+RdââRFFÿl,(&lt;ÿÿø ÆÈ¹$ãeFÿgBFxè»FèºNuBBNu$&lt;ÿà  BNuåï åï äï /o  /o  /_ Þü NuHçÿ Lï  $ÁBÃC* µBa`:G8&lt; a  ø,8&lt; a  îágÇ ãã$&amp;&lt;FÿN¹ !¥ ` &gt;.  ÿÿHGèOÎDfJfJgRGSGãã  gôNu8&lt;ÿÅ@ÇAaÎÁBÃCÏFg¼DgÂ a¼g&quot;¾Dg.À ããNuaªJk0¾Fg,Jf(Jf$`JkDg@$&lt;ÿà  `JJfJf
+Jj&lt;XO`  ¤¼Gf´l&lt;$ &amp;HBéNFHBãÿà  bJn  $&lt;ÿà JjTB`BBXO`  tBÖÕ´\Ìÿø	Ç[ÌÿîjÖÕ	JD]ÌÿàNu/_ a/o  /o  /_ NuHçÿ Lï  $*xÿa ÿ8SGGo
+ãã&lt;SFaF N¹ !¤ÖN¹ !¥
+ãâ/B $/C (Lß ÿ / &quot;/ ..Nu ALï /W PafJk±É`³ÈegDü  NuDü NuJlÿÿÿDJlÿÿÿD°Nu&quot;/ a o HB4HÐ  _PNÐ&amp;HCãáBBf&lt; Jg*&lt; `$ ÿf4&lt;` B&lt; Jg&lt; `&lt; SB&lt; B âàBNu o LÐ 6HB o Nuaìa  _PNÐ8 m   ã`$Jg
+ PDààfö gkSDãjúD a&quot;à&quot; ãKâNuåï åï äï /o  ..NuJkSDãJDnDÿèm&quot;DRè¨BD   dâRDD ÿlãUÀÀNuBNu &lt;   ÿNuHçø &quot; a(N¹ !¨ XOLß NuHçø &quot; N¹ !§a XOLß NuBBvJjDÃ BNu la(BJfJkJCjDNu&quot;&lt;   NuN¹ !§äaNù !§x JBk&amp;´Dm
+JfDDÃ@`òå¸å¹xå¤S$ Äf.È¹`$DB´Dm&quot; BD`ôxå¤SFÂÈ¹ä¼ä¹ BNuJBjRBa¤ââÓÑNu&quot;/ N¹ !§aâa ÿ\/A .Nu&quot;/ N¹ !§aÊ`JBk ÿpNu&quot;/ N¹ !§aìN¹ !¨/A .NuNù !¾H /  o &quot;/ Hç0 &lt;     e   $cr
+  ÿÿb°e.ÁH@  0    H@`êv tãã¶eR QÊÿò 0`Æ  0   9c^ ÀfòLß  S¯ Nu&quot;ÁA  ÿnÿÿ mÁiHÀNu/BJlDFJlDFaJgD$Nu&quot;ÁA   d0Áir 2 B@H@ÁANu/$&quot; B@H@ÂH@HA2 HAÂ0BAHA$NuHç0 &amp;&quot; H@B@BAHAtÐÓ²eR QÊÿòLß Nu&quot;ÁA   d
+ÁiB@H@Nua Nu&quot;ÁA  ÿnÿÿ m
+ÁiH@HÀNu/BJlDJlDRa ÿR JgD$Nu&quot;Hç  $ ÀÁBBHBgÄÁHBBBÐ$BAHAgÄÁHBBBÐ$NuNù !¾HNVÿøHç &lt;EîÿüGîÿøIîÿüKîÿø$®  ÿÿÿ  c//&lt; Ë@ N¹ !®ÌP` 2ÿÿÿ ÿÿÿ  f/&lt; Ë  N¹ !®ÌX` 
+FI¸c/&lt; Ë N¹ !®ÌX`  ð//9 !â0N¹ !²º/9 !â,N¹ !²ú/&lt;?   N¹ !²ºN¹ !³J*$   g$&lt;   `t  N¹ !³Ú/&lt;?   N¹ !³&amp;///9 !âDN¹ !²úN¹ !³$ ÿÿÿ*9  eh//N¹ !²ú&amp;//9 !â@/N¹ !²ú/9 !â&lt;N¹ !²º/N¹ !²ú/9 !â8N¹ !²º/N¹ !²ú/9 !â4N¹ !²º/N¹ !²ú/N¹ !²úN¹ !²º$ ± Lî&lt;ÿäN^NuHç&gt; $/ ,/   o Jmx `xÿÿÿp°n  È*    ÿÿ    p5°l
+x  ¨ `@p!°n$ r!vá«(ÈJ¨ fS Àfp `p` Svá«(( ÈS À¨ p5°nBB¨ `4p °n r &quot;à©!A B` ( ì¨!@ p &quot;á©¨  ì¨ JgJf (    gR¨ fR ¨ fp&quot;#À Á ÿÿÿ   d &lt;   `p &quot;g&quot;&lt;   `r Lß |NuNVÿøHç0&lt;Gîÿø(| Á*| !âHEî  . $   
+gp!(`n gp&quot;(&amp;¼ð  &#x27;|     `\ g(X J$(ÿüP J&amp;¨ÿø&#x27;hÿü &amp;//HnÿøN¹ !¬è`. 
+gp&quot;(&amp;¼ð  &#x27;|     ` f 	f&amp;&#x27;m  &quot;+  Lî&lt;ÿàN^NuNVÿüHç0&lt;Gîÿü(| Á*| !âPEî  . $   
+gp!(`Z gp&quot;(&amp;¼  `J g$X J$(ÿüX J-hÿüÿü&amp;//HnÿüN¹ !¯b`  
+gp&quot;(&amp;¼  ` f 	f&amp; Lî&lt;ÿäN^NuNVÿüHç&gt; $. ,. &quot;n Aîÿü Jmx `xÿÿÿp°nZ*    ÿÿ    p°lx ` Svá«(ÈS Àp°nB` ì¨ JgJf
+    gRJfp&quot;#À Á&quot; ÿÿÿ   d &lt;   `p &quot;g&quot;&lt;   `r Lî |ÿèN^NuNVÿøHç80$n GîÿøCîÿø IX-n ÿø-n ÿüB ð  ð  f(  ÿÿg/.ÿü/.ÿø/&lt; Ö@ N¹ !®Oï `  Ø ÿÿÿg  Â ÿÿÿð  fJf/&lt; Ö  N¹ !®X`  ¤ ð  râ¨  þ$ ð  fp  ÿÿgd    ( ±R  ÿÿg&amp;pá«t`RÖJnø å¨&amp;`&amp;t`RÖJnø å¨  rÐtp &quot;à© å¨ ÿÿ ?à  &quot;.ÿü .ÿøLîÿäN^NuHçü * ³ãã°cÁAááBD BCØC ÿgBJ gP&lt; â&lt; â4 6H@HAÆÀÄÁÀÁÖ×C HCÐD ~N¹ !¨XàãâXOLß &gt;NuBJfJg&lt; ÿ `àJgÜk°SDãjú`¨ &lt; `ÐB`Æ / &quot;/ /_ N¹ ! //@ /A Nu / &quot;/ /_ N¹ !§8 _Nu / &quot;/ /_ N¹ !¥//@ /A Nu / &quot;/ /_ N¹ !¢6//@ /A Nu / &quot;/ /_ N¹ ! //@ /A Nu / &quot;/ N¹ !£ª _&quot;.NÐ / &quot;/ N¹ !£h _PNÐ / &quot;/ .N¹ !N/@ Nu / &quot;/ N¹ !§d _PNÐ / &quot;/ .N¹ !¡v/@ Nu / &quot;/ .N¹ !±n/@ Nu / &quot;/ .N¹ !J/@ Nu / N¹ !£P W./A NÐ / N¹ !¨° _XNÐLß &quot;@     @ÿÿÿ HAîIA Aÿÿo  : ÿÿ    A n  DAA â¨`  A  l  A ã¨`  
+pÿ`  B±ü    g  DNÑ N¹ !£B W./ NÐ N¹ !¨ W.NÐ JgX |   &quot;|   &quot;&lt;K   °e6Hç0 BB âÒ°dô ÿÿ g
+  gRLß `ã°eø ÿÿ W.NÐNVÿÜHç?&lt;(n *n -|C0  ÿà-|    ÿäB.ÿß~ | t p -@ÿè-@ÿì$n `R  gø 	m 
+oì -fR` +fR-y !âTÿø-y !âXÿü`ZpR°n/.ÿì/.ÿè/.ÿä/.ÿàN¹ !² l2 r0N¹ !³¼/.ÿì/.ÿè/.ÿü/.ÿøN¹ !²TN¹ !²-_ÿè-_ÿì`R| ÿßHHÀ&amp; r0²np9°lp.°f  -y !âTÿð-y !âXÿô`XpR°n/.ÿì/.ÿè/.ÿä/.ÿàN¹ !² l8 r0N¹ !³¼/.ÿì/.ÿè/.ÿô/.ÿðN¹ !²TN¹ !²-_ÿè-_ÿìS| ÿßHHÀ&amp; r0²np9°lx z pE°gpe°fNHHÀ&amp; r+²fR`p-°fRR` åÐÐÐ   0( HHÀ&amp; r0²np9°lÚJg`Ôz Jl ÐÿÿþÌnp&quot;(r p `  ¬RDJg^(&lt;   v&amp;| !â`8Jg/.ÿì/.ÿè/+ /N¹ !²6`/.ÿì/.ÿè/+ /N¹ !²T-_ÿè-_ÿì´lÄJg â( QSJlê 
+gJ.ÿßf . ` 
+S*/.ÿì/.ÿèB§/&lt;ð  N¹ !² fp&quot;(Jg
+. ÿè&quot;.ÿì .ÿèLî&lt;üÿ´N^Nu&quot;o  o Hy Á/	/a ýVOï NuNVÿüHnÿüB§/. a ý&gt;Oï N^Nu/
+$| ² &quot;&lt;AÆNmN¹ !«&gt;  09$râ   ÿ$_Nu#ï  ²Nu o  R @¯ NuNV  Hç  Eî Hy !·&gt;/
+/. Hn N¹ !¿`$  n B LîÿøN^Nu o / °g
+Jføp `   Nu o &quot;o 02	³    f&gt;0   g
+°f@J g&lt;/4&lt;ÿ  °fJ gÀBg
+H@J gÀBfèp $`  $YY°f
+J föp `  !HHÀNu/$/  | !á+0( H@ g r ` $NuNVÿÔHç?&lt;.. &amp;n n ÿó-n ÿÔ-n ÿØ .ÿÔð  ð  fZ .ÿÔ ÿÿfJ®ÿØg | !ã&quot;KØfüp-@ÿô`(B®ÿô .ÿÔ  gü -R®ÿô | !ã&quot;KØfüpÑ®ÿôS®ÿô .ÿô` p-@ÿü.ÿóH@ g
+B®ÿü. ÿóB®ÿôB.ÿòB.ÿñB.ÿðJl~. gÿóg. Gÿóf| ÿñJfR`R. fÿóf| ÿò-Gÿìp°lp-@ÿì/. /. B§B§N¹ !² lü -R®ÿô
+.  -n ÿà-n ÿä .ÿàã®ÿäfB®ÿè| ÿð` HnÿÜ/.ÿä/.ÿàN¹ !°0Oï  .ÿÜ&quot; åÐçÐår
+â -@ÿÜB-nÿÜÿèjD®ÿÜRt $| !â¼`N .ÿÜ   g6Jg/.ÿä/.ÿà/* /N¹ !²T`/.ÿä/.ÿà/* /N¹ !²6-_ÿà-_ÿä .ÿÜâ-@ÿÜPRJ®ÿÜf¬/.ÿä/.ÿàB§/&lt;?ð  N¹ !² lS®ÿè/.ÿä/.ÿàB§/&lt;@$  N¹ !²T`2/.ÿä/.ÿàB§/&lt;@$  N¹ !² m&quot;R®ÿè/.ÿä/.ÿàB§/&lt;@$  N¹ !²6-_ÿà-_ÿäJ.ÿñgpü°®ÿèn¾®ÿèo| ÿò$K-JÿøJ.ÿðgü 0` &lt;tJ.ÿòf-nÿà -nÿä `$.ÿèjt(`&quot;/. /. B§/&lt;AÍÍeN¹ !²6-_ -_ p	p	°oØ| /. /. N¹ !²¦* Jgv `ü 0R0åH | !â 0  °nèJg,/
+/N¹ !¾HPÕÀ/. /.  N¹ !³¼N¹ !²r-_ -_ g0x	p°o/. /. B§/&lt;AÍÍeN¹ !²T-_ -_ Rp°n ÿnJ.ÿògTp°®ÿèl(nÿøpÙÀ`ü 0¹ÊeøJ®ÿèlt`ü 0Sjø .ÿèÐ®ÿìr²np®ÿè-@ÿìnp@ÿðHHÀ-@ÿì*Jü .J.ÿðg$`ü 0Sfø` J.ÿòg2J®ÿèl,/.ÿä/.ÿàB§/&lt;@$  N¹ !²6-_ -_ $.ÿè`ü 0Rføt  . ã® fx	`ü 0Sjø`  /. /. B§/&lt;AÍÍeN¹ !²T-_ -_ /. /. N¹ !²¦* v `ü 0R0åH | !â 0  °nè/
+/N¹ !¾HPÕÀp	°l,Jf/. /.  N¹ !³¼N¹ !²r-_ -_ Rp°n ÿ\J.ÿñgJ.ÿòg .ÿè®ÿì(MÙîÿì`¼ 0R¹ÊeöBJ.ÿñg¾®ÿìl..ÿì(nÿøÙÇ¹ÍeRµÌd(J`Iõx `ü 0µÌcø$MÕîÿì*J 5mJ&quot; .fSR  9o8¼ 0µËfæRR&amp;M`«ÿÿS·Êfö¼ 1-JÿøJ.ÿòfRü .¼ 0R®ÿèS¼ 0B$LJ.ÿñgJ®ÿüg&quot; 0gúRBU.ÿó* .ÿÿfJ®ÿügB&quot;J.ÿòfbîÿóJ®ÿèmü +`ü -D®ÿè .ÿè$ rc²l rdN¹ !ªD  0À rdN¹ !« $  r
+N¹ !ªD  0À r
+N¹ !«   0ÀB$
+®ÿø .ÿôÐLî&lt;üÿ¬N^Nu/ o  / jDü -&lt;    ÿÿbr
+°e2ÁH@  0    H@`êr tãã 
+e 
+R QÊÿî 0`À  0Àßfü S¯ $NuNVÿÜHç&gt; (. *. p°np$°lz
+EîÿÿB| p°f $è`Dp°f $æ`2p
+°f r
+N¹ !ª$ ç ` &quot;N¹ !ª$ ÀÅ   0  9o^R¸e(` J&quot;n Øfü Lî|ÿÄN^NuNVþ¸Hç?&lt;$n (n *n ~ ` tR. %ÿûg/
+.ÿûHHÀ/ NPR` TB.þ¾B.þ½B.þ¼B.þ»| HHÀr-°Agr0°Agr+°Ag$r °Ag*r#°Ag2`8R.þ¾| R`ÐJ.þ¾f|0R`ÄR.þ½B.þ¼R`¸J.þ½fR.þ¼R`ªR.þ»R`¢ *fX®  n *(ÿüJlDR.þ¾R`*z ` åÐÐHHÁÐ   0* R 0m 9oÚxÿ .fBR *fX®  n ((ÿüR`*x ` åÐÐHHÁÐ   0( R 0m 9oÚBB.þ¿ lfR.þ¿` hfR` LfRAîþÀ&amp;H-Hÿü@ÿûHHÀrx°b pAù !Ár°SÉÿüf ^Ò0;Nû  æ Þ .ð â n n T æEGXcdefginopsux X®  n &amp;hÿü f&amp;| !Ü K&amp;JfüF` X®  n  (ÿü@þÀB.þÁv` üR/J.þ¿fJgX®  n  (ÿüHÀ/ `X®  n /(ÿüN¹ !¾HP&amp;  -gJ.þ½fJ.þ¼gJ.þ½gp+`p  RJm ¸l(ºl*|0` t
+`t`tB.þ½B.þ¼J.þ¿fJgX®  n  (ÿü  ÿÿ`X®  n  (ÿü&amp; Jg2J.þ»g,/
+Hx 0NPp°f/
+. xÿûf/&lt;   x`/&lt;   XNP//.ÿü/N¹ !¾´Oï Ð®ÿü&amp; . xÿûf ÿR` Am  RJfðGîþÀ` ÿ8/.ÿûHHÀJ.þ»gr`r / R/P®  n /(ÿü/(ÿøN¹ !¸.Oï &amp;  -gJ.þ½fJ.þ¼gJ.þ½gp+`p  Rxÿ`xHx /X®  n /(ÿüN¹ !¾´Oï &amp; ` þ¶J.þ¿gX®  n  hÿü `  ÊJgX®  n  hÿü0`  ´X®  n  hÿü `  ¢/
+.ÿûHHÀ/ NPR`  ¸lJm&amp;$oÞJ.þ¾fB 0f&amp; -gJ.þ½fJ.þ¼g/
+HHÀ/ NPRRSR`/
+HHÀ/ NPSnîÞR`/
+HHÀ/ NPRSfìR`/
+HHÀ/ NPSnîRÿûf û Lî&lt;üþN^NuJ1708_RS ÿX 
+ X 
+ &lt; 
+ &lt; 
+ 
+ 
+ 
+ 
+ 
+ 
+ &lt; ÿõ	LUMINATORÙ %1d 0 %1d %4u %4X %-8u ÿ%-8X ÿ½ÿõET´ ½ÿõEFÂ ½êLUMINATOR412574-1ø ½ó½     *LUMINATOR*Ó ½Å¼%1c%1cÿ ÿ½Å¼½ ÿ½Å¼ÿÁ ÿ½ÿ%1cÿ ½ÿ üH ½ ïT ÿDATBL DBTBL PRTBL ADTBL PMTBL MPBEG MPEND DGBEG DGEND DABEG DAEND DBBEG DBEND PRBEG PREND ADBEG ADEND ANBEG ANEND DSBEG DSEND EGBEG EGEND EMBEG EMEND EMTBEG ÿEMTEND ÿEABEG EAEND EDBEG EDEND PGBEG PGEND PMBEG PMEND PABEG PAEND FGBEG FGEND CODE_FS IVA_FLAG ÿDIRRT EVENT DRC_PARM ÿMSTVOL ÿMIC_IN%02u ÿMICOUT%02u ÿDRC_DIST ÿMAINT_NO ÿAUTOSEMA ÿGPS_TYPE ÿTSIP ÿJ1708 GPS08DLY ÿPID_508 ENABLE ÿDSIIN%01u_A DSIIN%01u_P DSIIN%01u_M ú P/R:            ```` ú Destination A:  ```` ú Destination B:  ```` ú Route:          ```` Download card detect NOT ACTIVE, No Timer Available. ÿDownload card detect NOT ACTIVE, No Card Drive Present ÿTIMEOUT %1u ERROR GTIS ÿGTID ÿ%1s%1u ÿWARNING: Too many event message codes for GTI signs %4u %4X %-8u ÿ%-8X ÿú P/R:            ```` ú Destination A:  ```` ú Destination B:  ```` ú Route:          ```` A2 MESSAGE? A5 MESSAGE? A6 MESSAGE? A3 MESSAGE? A1 MESSAGE? %1d 0 %1d %1f %1d %1d %1s%1u ÿWARNING: Too many event message codes for SRS signs SRSS ÿSRSD ÿA2 MESSAGE? A5 MESSAGE? A6 MESSAGE? A3 MESSAGE? A1 MESSAGE? UNITS FEET ÿFOOT ÿFT ÿFEET ÿMI ÿMILES M. ÿMETERS ÿKM ÿKILOMETERS ÿRAD_DFLT ÿGPS_LOOP ÿEV_AHEAD ÿHIT_MAX HIT_THR DR_EXIST ÿYES PIC_SC ÿDR_ADJ_? ÿDR_ADJ_P ÿDR_UPHD Scheduler pic auto-poll Semaphore NOT ACTIVE, No Timer Available. DIRRT_EN ÿSCH_AUTO ÿSCH_PD ÿScheduler GPS Semaphore NOT ACTIVE, No Timer Available. Proof Delay NOT ACTIVE, No Timer Available. REACTRL REABEG ÿREAEND ÿREATIME Repeat Event Announcement NOT ACTIVE, No Timer Available. Scheduler identifier semaphore NOT ACTIVE, No Timer Available. ÿSCH dest=%1d, rt=%8s ÿDR=%8d = %1.1f %1s = %1.3f %1s HIT=%1d  EV=%1d ÿNO DR, HIT=%1d  EV=%1d ÿSCH dest=%1d, rt=%8s ÿ  %1d %1d %1d %1d %1d %1d %1d %1d %1d !d ÿLAT=%1.5f  LON=%1.5f  RAD=%1.1f  no.=%1d ÿScheduler, missing event pointer in event list, first hit. ÿ%1d %1d %1d [H[2J   [H [B L [K ... ... ... ... %1d .. ÿ%02d ÿ.. ÿ%01.3f ÿ%06.3f ÿ%1d    ÿ%02d ÿ   ÿ%1d    ÿ%02d ÿ   ÿ%1d ... %03d ÿ... %01.5f ÿUP_DATE NO GPS ÿHEALTH = %1d ÿ%1d .. ÿ%02d ÿ.. ÿ%1d %07d ÿ   ÿ   ÿ%1d -- ÿ%03d ÿ--- %1d .. ÿ%02d ÿ.. ÿ%01.1f ÿ%06.1f ÿ%1d %05d ÿ%02d ÿ.. ÿ%4d .... ÿ% DAY0 ÿSUNDAY ÿDAY1 ÿMONDAY ÿDAY2 ÿTUESDAY DAY3 ÿWEDNESDAY DAY4 ÿTHURSDAY ÿDAY5 ÿFRIDAY ÿDAY6 ÿSATURDAY ÿDAY0A SUN DAY1A MON DAY2A TUE DAY3A WED DAY4A THU DAY5A FRI DAY6A SAT MONTH0 ÿJANUARY MONTH1 ÿFEBRUARY ÿMONTH2 ÿMARCH MONTH3 ÿAPRIL MONTH4 ÿMAY MONTH5 ÿJUNE ÿMONTH6 ÿJULY ÿMONTH7 ÿAUGUST ÿMONTH8 ÿSEPTEMBER MONTH9 ÿOCTOBER MONTH10 NOVEMBER ÿMONTH11 DECEMBER ÿMONTH0A JAN MONTH1A FEB MONTH2A MAR MONTH3A APR MONTH4A MAY MONTH5A JUN MONTH6A JUL MONTH7A AUG MONTH8A SEP MONTH9A OCT MONTH10A ÿNOV MONTH11A ÿDEC AM ÿAM ÿAM_L ÿam ÿPM ÿPM ÿPM_L ÿpm ÿMIC_DBUG ÿAMPL_SEN ÿSPKR_SEN ÿstart IVADRV ÿFOUND IT!!!! (loop) IVjunk_bcnt=%x ÿNO XRCT ENTRY IN DAT ÿCHECKSUM ERROR IN RCT NO XP00 ENTRY IN DAT ÿCHECKSUM ERROR IN P00 BUS ERROR ivainit() Wait for STA_INI to reset amb%1x=%2d ÿIVA vol=%2x  ÿFOUND IT!!!! (annc) IVjunk_acnt=%x ÿERROR: IVA lockup, Pxx corrupt ÿ%2d:%02d  %2d/%2d/%2d  ÿGPS_DYNC ÿGPS_ELEV ÿdyn_code=%2X elev_mask(rad)=%2f GPS_SIGL ÿsig_mask=%2f ÿGPS_PDPM ÿpdop_mask=%2f GPS_PDPS ÿpdop_sw=%2f GPS_MODE ÿGPS_IO ÿmode=%2X io_code=%8X ÿADJ_HOUR ÿADJ_MIN ADJ_SEC ADJ_HR_P ÿDLSSTRTM ÿDLSSTRTS ÿLAST ÿDLSSTOPM ÿDLSSTOPS ÿLAST ÿH%1X ÿ
+** RTXCbug -  ÿ
+RTXCbug&gt;  ÿ
+ T - Tasks
+ ÿM - Mailboxes
+ ÿP - Partitions
+ Q - Queues
+ R - Resources
+ ÿS - Semaphores
+ C - Clock / Timers
+ K - Stack Limits
+ Z - Zero Partition/Queue/Resource Statistics
+ $ - Enter Task Manager Mode
+ ÿ# - Task Registers
+ G - Go to Multitasking Mode
+ ÿH - Help
+ X - Exit RTXCbug
+ 
+Returning from RTXCBug
+ ÿ
+Bad command
+ 
+** Task Snapshot **
+   #   Name  Priority  State
+ ÿ-- More --
+ (I3,X1,S8,X2,UI3,X5,N) ÿSUSPENDED  ÿINACTIVE  Semaphore  ÿ(X1,S8,N) (H&#x27;&lt;QE&gt; &#x27;,S8,N) (H&#x27;&lt;QF&gt; &#x27;,S8,N) (H&#x27;&lt;QNE&gt; &#x27;,S8,N) ÿ(H&#x27;&lt;QNF&gt; &#x27;,S8,N) ÿ(H&#x27;&lt;MBXNE&gt; &#x27;,S8,N) ÿQueueEmpty ÿQueueFull  ÿ(X1,S8,N) Mailbox     (S8,N) ÿDELAY               Resource    (S8,N) ÿPartition   (S8,N) ÿ-READY  READY (X1,H&#x27;(&#x27;,I4,H&#x27;/&#x27;,I4,H&#x27; ticks)&#x27;,N) 
+ 
+** Queue Snapshot ** 
+  #   Name  Current/Depth Worst Count Waiters
+ -- More --
+ (I3,X1,S8,X2,I5,H&#x27;/&#x27;,2(I5,X1),UI5,N) ÿ(X1,S8,N) (X1,S8,H&#x27;&lt;E&gt;&#x27;,N) ÿ(X1,S8,H&#x27;&lt;F&gt;&#x27;,N) ÿ(X1,S8,H&#x27;&lt;NE&gt;&#x27;,N) (X1,S8,H&#x27;&lt;NF&gt;&#x27;,N) 
+ 
+** Semaphore Snapshot ** 
+  #   Name  State  Waiter
+ -- More --
+ (I3,X1,S8,X1,N) DONE
+ PEND
+ (H&#x27;WAIT &#x27;,S8,N) (H&#x27; &lt;QE&gt; &#x27;,S8,N) ÿ(H&#x27; &lt;QF&gt; &#x27;,S8,N) ÿ(H&#x27; &lt;QNE&gt; &#x27;,S8,N) (H&#x27; &lt;QNF&gt; &#x27;,S8,N) (H&#x27; &lt;MBXNE&gt; &#x27;,S8,N) 
+ 
+** Resource Snapshot ** ÿ
+  #   Name   Count Conflicts   Owner   Waiters
+ ÿ-- More --
+ (I3,X1,S8,X1,UI5,X3,UI5,N) ÿ **  ÿ     ÿ(S8,N) ÿ(X1,S8,N) 
+ 
+** Partition Snapshot ** 
+  #   Name   Avail/Total Worst Count  Bytes Waiters
+ -- More --
+ (I3,X1,S8,X1,I5,H&#x27;/&#x27;,3(UI5,X1),UI6,N) (X1,S8,N) 
+ 
+** Mailbox Snapshot ** 
+  #   Name   Current Count Waiters
+ ÿ-- More --
+ (I3,X1,S8,2(X2,UI5),N) ÿ(X1,S8,N) 
+ 
+** Clock Snapshot **
+
+ (H&#x27;Clock rate is&#x27;,I5,H&#x27; Hz, Tick interval is&#x27;,I4,H&#x27; ms, &#x27;,N) ÿ(H&#x27;Maximum of&#x27;,I3,H&#x27; timers
+Tick timer is&#x27;,UL9,N) (H&#x27;, ET is &#x27;,UL9,H&#x27; ticks, RTC time is &#x27;,UL9,//N)    Time        Cyclic   Task   Timer      Object
+  Remaining      Value   Name   Type        Name
+ ÿ-- More --
+ (2(L10,X1),S8,X1,N) (H&#x27;Timer      &#x27;,S8/N) (H&#x27;Delay      &#x27;,S8/N) (H&#x27;Semaphore  &#x27;,S8/N) (H&#x27;Mailbox    &#x27;,S8/N) (H&#x27;Partition  &#x27;,S8/N) Queue Empty Full  (X1,S8/N) (H&#x27;Resource   &#x27;,S8/N) Unknown timer type
+ 
+ Task Register set is undefined
+ ** Task Register Snapshot **
+       0        1        2        3        4        5       6        7
+ ÿ(H&#x27;A &#x27;,R16,Z-,8(UL8,X1),/N) (H&#x27;D &#x27;,R16,Z-,8(UL8,X1),/N) (R16,Z-,H&#x27;PC &#x27;,UL8,H&#x27; SR &#x27;,Ui4/N) Undefined Task
+ 
+Task (# or name)&gt;  
+ Priority&gt;  ÿ
+ Time slice (in ticks)&gt;  
+ 
+ 
+$RTXCbug&gt;  
+ S - Suspend
+ ÿR - Resume
+ T - Terminate
+ ÿE - Execute
+ ÿC - Change task priority
+ B - Block (-1=All)
+ U - Unblock (-1=ALL)
+ / - Time slice
+ H - Help
+ X - Exit Task Manager Mode
+ 
+Re-entering RTXCbug mode
+ ÿ
+Bad command
+ 
+** Stack Snapshot **
+ ÿ  #   Task    Size  Used  Spare
+ ÿ-- More --
+ (I3,X1,S8,3(UI6),/N) ÿ-- More --
+ (H&#x27;Worst case interrupt nesting =&#x27;,B2,/N) (H&#x27;Worst case signal list size =&#x27;,I3,/N) ÿ(L10,H&#x27; ms&#x27;,N) ÿ(H&#x27;Task&#x27;,Z-,I4,N) RTXC 3.1f 11/07/96 ÿ(null) ÿ                                           !K\ &quot;h        Ê &amp;h       !4 +|        $^ /|        õ¶ 3|     
+  ëÂ &lt;      	  5@ @       !B D  Ü     Gæ Ið  Ü     {
+ OÌ         SÌ  @      Fv Z     2 !4® ]  @   Z !Eö cÐ  °   Z         RTXCBUG  D0RBDRV  D0TBDRV  J17SEND  TOOLS    RW_FLASH STARTUP  IVADRV   GTIDRV   SRSDRV   SCHEDULE MIXER    TSPDRV   DSIDRV   ÿ   =            CBUGSEMA D0RASEMA D0TASEMA D0RBSEMA D0TBSEMA BUF1SEMA BUF2SEMA GIPBSEMA GIPRSEMA GIPTSEMA GIPMSEMA GIPISEMA GIPJSEMA GRBMSEMA GTBMSEMA J17MSEMA J171SEMA J172SEMA J173SEMA J17OSEMA J17CSEMA J17DSEMA WATMSEMA TOOLSEMA SU_MSEMA GTINSEMA GTIMSEMA GTIDSEMA SRSBSEMA SRSNSEMA SRSMSEMA SRSISEMA SRSTSEMA IVANSEMA IVAMSEMA MIXMSEMA MIX_SEMA SCH_SEMA SCHNSEMA SCHMSEMA SCHRSEMA SCHASEMA SCHGSEMA SCHISEMA SCHPSEMA SCHTSEMA SCH1SEMA SCH2SEMA SCH3SEMA SCH4SEMA SCH5SEMA TSP1SEMA TSP5SEMA TSPMSEMA TSPRSEMA TSPTSEMA DSIMSEMA DSI_SEMA TLNSEMA  TLNMSEMA IVAWSEMA              ÿ                h      2 h²       l²               D0RBQ    D0TBQ    SENDQ                    lî   &amp;   (         PATMAP               TOOLMB   FLASHMB  ÿ      2             (((((                  H                                                                                                                                 ÿ&gt;¢ù?ÉÛ¾*ª¤&lt;&gt;¹O²&quot;6.[@IÛÿÿÿÿÿÿÿÿÿÿ@$      @Y      @Ã     A×    CAÃy7à F¸µµnM8Oé?ùõZwHù02õá   B@    &#x27;  è   d   
+       @$      @Y      @Ã     A×    CAÃy7à F¸µµnM8Oé?ùõZwHù02uOÝs¿=&lt;Infinity&gt; ÿ&lt;NaN&gt; ÿÿXDRG !ãX !ä    ÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿEODTÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿpMPBEGv2
+pMPENDv5
+pDGBEGv2
+pDGENDv4
+pDABEGv3
+pDAENDv3
+pDBBEGv4
+pDBENDv4
+pPRBEGv2
+pPRENDv2
+pFGBEGv5
+pFGENDv5
+pCODE_FSv5
+pDATBLvC
+pDBTBLvC
+pPRTBLvB
+pDIRRTv6
+</td></tr>
+</tbody></table>
+</section>
+<section id='LogicalSignBuild'><h2>LogicalSignBuild</h2>
+<p><strong>Rows:</strong> 4 • <strong>Columns:</strong> 5</p>
+<table>
+<thead><tr><th>LSignID</th><th>PSignID</th><th>PSignOriginX</th><th>PSignOriginY</th><th>PSignAddr</th></tr></thead>
+<tbody>
+<tr><td>1</td><td>247</td><td>1</td><td>1</td><td>1</td></tr>
+<tr><td>10</td><td>256</td><td>1</td><td>1</td><td>10</td></tr>
+<tr><td>11</td><td>257</td><td>1</td><td>1</td><td>11</td></tr>
+<tr><td>12</td><td>258</td><td>1</td><td>1</td><td>12</td></tr>
+</tbody></table>
+</section>
+<section id='LogicalSigns'><h2>LogicalSigns</h2>
+<p><strong>Rows:</strong> 4 • <strong>Columns:</strong> 5</p>
+<table>
+<thead><tr><th>LSignID</th><th>LSignName</th><th>LSignDescription</th><th>LSignDotHeight</th><th>LSignDotWidth</th></tr></thead>
+<tbody>
+<tr><td>1</td><td>ODK Console</td><td></td><td>14</td><td>100</td></tr>
+<tr><td>10</td><td>LF Side 8X96</td><td></td><td>8</td><td>96</td></tr>
+<tr><td>11</td><td>All Rear 16X48</td><td></td><td>16</td><td>48</td></tr>
+<tr><td>12</td><td>All Front 16x160</td><td></td><td>16</td><td>160</td></tr>
+</tbody></table>
+</section>
+<section id='MsgClass'><h2>MsgClass</h2>
+<p><strong>Rows:</strong> 5 • <strong>Columns:</strong> 3</p>
+<table>
+<thead><tr><th>MsgClassID</th><th>MsgClassName</th><th>MsgClassDescription</th></tr></thead>
+<tbody>
+<tr><td>1</td><td>A</td><td></td></tr>
+<tr><td>2</td><td>B</td><td></td></tr>
+<tr><td>3</td><td>C</td><td></td></tr>
+<tr><td>4</td><td>D</td><td></td></tr>
+<tr><td>5</td><td>E</td><td>New Message Class</td></tr>
+</tbody></table>
+</section>
+<section id='MsgListingElements'><h2>MsgListingElements</h2>
+<p><strong>Rows:</strong> 21 • <strong>Columns:</strong> 4</p>
+<table>
+<thead><tr><th>ColID</th><th>MsgClassID</th><th>ColName</th><th>ColWidth</th></tr></thead>
+<tbody>
+<tr><td>5</td><td>2</td><td>MsgCode</td><td>900</td></tr>
+<tr><td>6</td><td>2</td><td>Locked</td><td>700</td></tr>
+<tr><td>7</td><td>2</td><td>PRText</td><td>6000</td></tr>
+<tr><td>12</td><td>4</td><td>MsgCode</td><td>900</td></tr>
+<tr><td>13</td><td>4</td><td>Locked</td><td>700</td></tr>
+<tr><td>14</td><td>4</td><td>Announce</td><td>3000</td></tr>
+<tr><td>15</td><td>4</td><td>NextStop</td><td>3000</td></tr>
+<tr><td>28</td><td>5</td><td>MsgCode</td><td>900</td></tr>
+<tr><td>29</td><td>5</td><td>Locked</td><td>700</td></tr>
+<tr><td>30</td><td>5</td><td>ForbiddenWord</td><td>6000</td></tr>
+<tr><td>31</td><td>1</td><td>MsgCode</td><td>900</td></tr>
+<tr><td>32</td><td>1</td><td>Locked</td><td>700</td></tr>
+<tr><td>33</td><td>1</td><td>Title</td><td>3000</td></tr>
+<tr><td>34</td><td>1</td><td>Text</td><td>3000</td></tr>
+<tr><td>71</td><td>3</td><td>MsgCode</td><td>900</td></tr>
+<tr><td>72</td><td>3</td><td>Locked</td><td>700</td></tr>
+<tr><td>73</td><td>3</td><td>Route</td><td>2505</td></tr>
+<tr><td>74</td><td>3</td><td>Destination</td><td>6390</td></tr>
+<tr><td>75</td><td>3</td><td>DestLine2</td><td>1200</td></tr>
+<tr><td>76</td><td>3</td><td>SideRoute</td><td>1200</td></tr>
+<tr><td>77</td><td>3</td><td>SideDest</td><td>1200</td></tr>
+</tbody></table>
+</section>
+<section id='PhysicalSigns'><h2>PhysicalSigns</h2>
+<p><strong>Rows:</strong> 4 • <strong>Columns:</strong> 41</p>
+<table>
+<thead><tr><th>PSignID</th><th>PSignName</th><th>PSignDescription</th><th>PSignPartNumber</th><th>PSignType</th><th>PSignDotShape</th><th>PSignDotAspect</th><th>PSignDotHeight</th><th>PSignDotWidth</th><th>PSignCharWidth</th><th>PSignAllowMod</th><th>PSignDotColor</th><th>PSignCharLines</th><th>PSignNumChars</th><th>PSignCharHeight</th><th>PSignLineTime</th><th>PSignBlankTime</th><th>PSignBlankBeforePR</th><th>PSignBlankBeforeRPT</th><th>SuppressCentering</th><th>DefAttr1</th><th>DefAttr2</th><th>Def1Color</th><th>Def2Color</th><th>Reserve1</th><th>Reserve2</th><th>DefaultFont</th><th>Emergency</th><th>PSignDfltAddr</th><th>ScrollCapable</th><th>SparkleCapable</th><th>AlertCapable</th><th>FormatCapable</th><th>BlinkCapable</th><th>ScrollUpCapable</th><th>ScrollDownCapable</th><th>ScrollRightToLeftCapable</th><th>ScrollSpeed1Capable</th><th>ScrollSpeed2Capable</th><th>ScrollSpeed3Capable</th><th>WinScrollCapable</th></tr></thead>
+<tbody>
+<tr><td>247</td><td>ODK</td><td>ODK DECIMAL ENTRY</td><td>0100</td><td>Char</td><td>Round</td><td>1/1</td><td>14</td><td>100</td><td>5</td><td>0</td><td>16777088</td><td>2</td><td>20</td><td>7</td><td>16</td><td>3</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>16777088</td><td>0</td><td>  0</td><td>  0</td><td>5x7</td><td>0</td><td>1</td><td>0</td><td>0</td><td>1</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>256</td><td>SIDE</td><td>LED 8X96 MATRIX</td><td>08B4</td><td>Matrix</td><td>Round</td><td>1/1</td><td>8</td><td>96</td><td>0</td><td>0</td><td>4227327</td><td>0</td><td>0</td><td>0</td><td>16</td><td>3</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>4227327</td><td>0</td><td>  0</td><td>  0</td><td>8DVW</td><td>2</td><td>10</td><td>1</td><td>1</td><td>0</td><td>0</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td></tr>
+<tr><td>257</td><td>REAR</td><td>LED 16X48 MATRIX</td><td>08B5</td><td>Matrix</td><td>Round</td><td>1/1</td><td>16</td><td>48</td><td>0</td><td>0</td><td>4227327</td><td>0</td><td>0</td><td>0</td><td>16</td><td>3</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>4227327</td><td>0</td><td>  0</td><td>  0</td><td>L8vw</td><td>2</td><td>11</td><td>1</td><td>1</td><td>0</td><td>0</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td></tr>
+<tr><td>258</td><td>FRONT_93</td><td>LED, 16x160 MATRIX</td><td>08B1</td><td>Matrix</td><td>Round</td><td>1/1</td><td>16</td><td>160</td><td>0</td><td>0</td><td>33023</td><td>0</td><td>0</td><td>0</td><td>18</td><td>3</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>33023</td><td>0</td><td>0</td><td>0</td><td>16dvw</td><td>2</td><td>12</td><td>1</td><td>1</td><td>0</td><td>0</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td></tr>
+</tbody></table>
+</section>
+<section id='RenumberColorZone'><h2>RenumberColorZone</h2>
+<p><strong>Rows:</strong> 0 • <strong>Columns:</strong> 14</p>
+<table>
+<thead><tr><th>ID</th><th>MsgClassID</th><th>MsgCode</th><th>LSign</th><th>Frame</th><th>Phrase</th><th>ColorStr</th><th>GraphicID</th><th>Text</th><th>ColorNumber</th><th>XStart</th><th>YStart</th><th>XEnd</th><th>YEnd</th></tr></thead>
+<tbody>
+<tr><td colspan="14">(no rows)</td></tr>
+</tbody></table>
+</section>
+<section id='RenumberEffectZones'><h2>RenumberEffectZones</h2>
+<p><strong>Rows:</strong> 2 • <strong>Columns:</strong> 18</p>
+<table>
+<thead><tr><th>EffZoneID</th><th>MsgClassID</th><th>MsgCode</th><th>LSignID</th><th>Frame</th><th>OriginX</th><th>OriginY</th><th>Height</th><th>Width</th><th>Alert</th><th>ScrollIn</th><th>Scroll</th><th>Blink</th><th>Sparkle</th><th>Format</th><th>ScrollDirection</th><th>ScrollSpeed</th><th>AttrNumber</th></tr></thead>
+<tbody>
+<tr><td>858491</td><td>2</td><td>19</td><td>12</td><td>1</td><td>1</td><td>1</td><td>16</td><td>160</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>858490</td><td>2</td><td>19</td><td>1</td><td>1</td><td>1</td><td>1</td><td>14</td><td>100</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+</tbody></table>
+</section>
+<section id='RenumberMsgFrames'><h2>RenumberMsgFrames</h2>
+<p><strong>Rows:</strong> 6 • <strong>Columns:</strong> 32</p>
+<table>
+<thead><tr><th>MsgClassID</th><th>MsgFrameID</th><th>MsgCode</th><th>LSignID</th><th>Frame</th><th>Break</th><th>Phrase</th><th>GraphicID</th><th>FontID</th><th>LineTime</th><th>HJustify</th><th>VJustify</th><th>XPos</th><th>YPos</th><th>Alert</th><th>Scroll</th><th>Format</th><th>Blink</th><th>Up</th><th>Down</th><th>Scroll2</th><th>AttrBit0</th><th>AttrBit1</th><th>AttrBit2</th><th>AttrBit3</th><th>AttrBit4</th><th>AttrBit5</th><th>AttrBit6</th><th>AttrBit7</th><th>AttrBit9</th><th>Number</th><th>ElementID</th></tr></thead>
+<tbody>
+<tr><td>2</td><td>1420328</td><td>19</td><td>12</td><td>1</td><td>0</td><td>CONGRATS</td><td></td><td>24</td><td>10</td><td>0</td><td>0</td><td>3</td><td>2</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>3</td></tr>
+<tr><td>2</td><td>1420327</td><td>19</td><td>12</td><td>1</td><td>0</td><td>UTS GRAD</td><td></td><td>24</td><td>10</td><td>0</td><td>0</td><td>4</td><td>10</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>2</td><td>1420326</td><td>19</td><td>12</td><td>1</td><td>0</td><td>JESS!</td><td></td><td>42</td><td>10</td><td>1</td><td>0</td><td>99</td><td>2</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>2</td><td>1420325</td><td>19</td><td>12</td><td>1</td><td>0</td><td></td><td>143</td><td></td><td>10</td><td>0</td><td>0</td><td>54</td><td>2</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>2</td><td>1420324</td><td>19</td><td>1</td><td>1</td><td>0</td><td>P/R CODE 19</td><td></td><td>52</td><td>10</td><td>1</td><td>0</td><td>26</td><td>8</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>2</td><td>1420323</td><td>19</td><td>1</td><td>1</td><td>0</td><td>CONGRATS JESS!</td><td></td><td>52</td><td>10</td><td>1</td><td>0</td><td>16</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>3</td></tr>
+</tbody></table>
+</section>
+<section id='RenumberMsgs'><h2>RenumberMsgs</h2>
+<p><strong>Rows:</strong> 1 • <strong>Columns:</strong> 5</p>
+<table>
+<thead><tr><th>MsgCode</th><th>MsgClassID</th><th>Approved</th><th>PRText</th><th>IDPRText</th></tr></thead>
+<tbody>
+<tr><td>19</td><td>2</td><td>1</td><td>CONGRATSÃ·UTS GRAD JESS</td><td>3</td></tr>
+</tbody></table>
+</section>
+<section id='RenumberSignProperties'><h2>RenumberSignProperties</h2>
+<p><strong>Rows:</strong> 4 • <strong>Columns:</strong> 5</p>
+<table>
+<thead><tr><th>ID</th><th>MsgCode</th><th>MsgClassID</th><th>LSignID</th><th>Locked</th></tr></thead>
+<tbody>
+<tr><td>4332</td><td>19</td><td>2</td><td>12</td><td>0</td></tr>
+<tr><td>4331</td><td>19</td><td>2</td><td>11</td><td>0</td></tr>
+<tr><td>4330</td><td>19</td><td>2</td><td>10</td><td>0</td></tr>
+<tr><td>4321</td><td>19</td><td>2</td><td>1</td><td>0</td></tr>
+</tbody></table>
+</section>
+<section id='SignMsgCodeProperties'><h2>SignMsgCodeProperties</h2>
+<p><strong>Rows:</strong> 704 • <strong>Columns:</strong> 5</p>
+<table>
+<thead><tr><th>ID</th><th>MsgCode</th><th>MsgClassID</th><th>LSignID</th><th>Locked</th></tr></thead>
+<tbody>
+<tr><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td></tr>
+<tr><td>2</td><td>2</td><td>1</td><td>1</td><td>1</td></tr>
+<tr><td>3</td><td>3</td><td>1</td><td>1</td><td>1</td></tr>
+<tr><td>28</td><td>1</td><td>1</td><td>10</td><td>1</td></tr>
+<tr><td>29</td><td>2</td><td>1</td><td>10</td><td>1</td></tr>
+<tr><td>30</td><td>3</td><td>1</td><td>10</td><td>1</td></tr>
+<tr><td>31</td><td>1</td><td>1</td><td>11</td><td>1</td></tr>
+<tr><td>32</td><td>2</td><td>1</td><td>11</td><td>1</td></tr>
+<tr><td>33</td><td>3</td><td>1</td><td>11</td><td>1</td></tr>
+<tr><td>34</td><td>1</td><td>3</td><td>1</td><td>0</td></tr>
+<tr><td>35</td><td>2</td><td>3</td><td>1</td><td>0</td></tr>
+<tr><td>37</td><td>4</td><td>3</td><td>1</td><td>0</td></tr>
+<tr><td>38</td><td>5</td><td>3</td><td>1</td><td>0</td></tr>
+<tr><td>41</td><td>8</td><td>3</td><td>1</td><td>0</td></tr>
+<tr><td>43</td><td>10</td><td>3</td><td>1</td><td>0</td></tr>
+<tr><td>44</td><td>11</td><td>3</td><td>1</td><td>0</td></tr>
+<tr><td>47</td><td>15</td><td>3</td><td>1</td><td>0</td></tr>
+<tr><td>48</td><td>16</td><td>3</td><td>1</td><td>0</td></tr>
+<tr><td>49</td><td>17</td><td>3</td><td>1</td><td>0</td></tr>
+<tr><td>51</td><td>19</td><td>3</td><td>1</td><td>0</td></tr>
+<tr><td>52</td><td>20</td><td>3</td><td>1</td><td>0</td></tr>
+<tr><td>53</td><td>21</td><td>3</td><td>1</td><td>0</td></tr>
+<tr><td>54</td><td>22</td><td>3</td><td>1</td><td>0</td></tr>
+<tr><td>250</td><td>1</td><td>3</td><td>10</td><td>0</td></tr>
+<tr><td>251</td><td>2</td><td>3</td><td>10</td><td>0</td></tr>
+<tr><td>253</td><td>4</td><td>3</td><td>10</td><td>0</td></tr>
+<tr><td>254</td><td>5</td><td>3</td><td>10</td><td>0</td></tr>
+<tr><td>257</td><td>8</td><td>3</td><td>10</td><td>0</td></tr>
+<tr><td>259</td><td>10</td><td>3</td><td>10</td><td>0</td></tr>
+<tr><td>260</td><td>11</td><td>3</td><td>10</td><td>0</td></tr>
+<tr><td>263</td><td>15</td><td>3</td><td>10</td><td>0</td></tr>
+<tr><td>264</td><td>16</td><td>3</td><td>10</td><td>0</td></tr>
+<tr><td>265</td><td>17</td><td>3</td><td>10</td><td>0</td></tr>
+<tr><td>267</td><td>19</td><td>3</td><td>10</td><td>0</td></tr>
+<tr><td>268</td><td>20</td><td>3</td><td>10</td><td>0</td></tr>
+<tr><td>269</td><td>21</td><td>3</td><td>10</td><td>0</td></tr>
+<tr><td>270</td><td>22</td><td>3</td><td>10</td><td>0</td></tr>
+<tr><td>274</td><td>1</td><td>3</td><td>11</td><td>0</td></tr>
+<tr><td>275</td><td>2</td><td>3</td><td>11</td><td>0</td></tr>
+<tr><td>277</td><td>4</td><td>3</td><td>11</td><td>0</td></tr>
+<tr><td>278</td><td>5</td><td>3</td><td>11</td><td>0</td></tr>
+<tr><td>281</td><td>8</td><td>3</td><td>11</td><td>0</td></tr>
+<tr><td>283</td><td>10</td><td>3</td><td>11</td><td>0</td></tr>
+<tr><td>284</td><td>11</td><td>3</td><td>11</td><td>0</td></tr>
+<tr><td>287</td><td>15</td><td>3</td><td>11</td><td>0</td></tr>
+<tr><td>288</td><td>16</td><td>3</td><td>11</td><td>0</td></tr>
+<tr><td>289</td><td>17</td><td>3</td><td>11</td><td>0</td></tr>
+<tr><td>291</td><td>19</td><td>3</td><td>11</td><td>0</td></tr>
+<tr><td>292</td><td>20</td><td>3</td><td>11</td><td>0</td></tr>
+<tr><td>293</td><td>21</td><td>3</td><td>11</td><td>0</td></tr>
+</tbody></table>
+<p class="note">654 additional rows not shown.</p>
+</section>
+<section id='SignSetBuild'><h2>SignSetBuild</h2>
+<p><strong>Rows:</strong> 4 • <strong>Columns:</strong> 2</p>
+<table>
+<thead><tr><th>SignSetID</th><th>LSignID</th></tr></thead>
+<tbody>
+<tr><td>1</td><td>1</td></tr>
+<tr><td>1</td><td>10</td></tr>
+<tr><td>1</td><td>11</td></tr>
+<tr><td>1</td><td>12</td></tr>
+</tbody></table>
+</section>
+<section id='tblClipboardMsgs'><h2>tblClipboardMsgs</h2>
+<p><strong>Rows:</strong> 1 • <strong>Columns:</strong> 2</p>
+<table>
+<thead><tr><th>MsgClassID</th><th>MsgCode</th></tr></thead>
+<tbody>
+<tr><td>3</td><td>1105</td></tr>
+</tbody></table>
+</section>
+<section id='TemplateZones'><h2>TemplateZones</h2>
+<p><strong>Rows:</strong> 38 • <strong>Columns:</strong> 16</p>
+<table>
+<thead><tr><th>TemplateID</th><th>TZoneID</th><th>MsgClassID</th><th>ElementID</th><th>LSignID</th><th>OriginX</th><th>OriginY</th><th>SignSetID</th><th>GraphicID</th><th>FontID</th><th>TemplateText</th><th>Height</th><th>Width</th><th>FitStyle</th><th>HorzJustify</th><th>VertJustify</th></tr></thead>
+<tbody>
+<tr><td>1</td><td>2</td><td>3</td><td>7</td><td>10</td><td>1</td><td>1</td><td>1</td><td></td><td>59</td><td></td><td>8</td><td>96</td><td>1</td><td>1</td><td>2</td></tr>
+<tr><td>1</td><td>7</td><td>3</td><td>7</td><td>1</td><td>1</td><td>1</td><td>1</td><td></td><td>52</td><td></td><td>7</td><td>100</td><td>1</td><td>1</td><td>1</td></tr>
+<tr><td>2</td><td>12</td><td>3</td><td>6</td><td>1</td><td>1</td><td>1</td><td>1</td><td></td><td>52</td><td></td><td>7</td><td>15</td><td>1</td><td>0</td><td>1</td></tr>
+<tr><td>2</td><td>13</td><td>3</td><td>7</td><td>1</td><td>16</td><td>1</td><td>1</td><td></td><td>52</td><td></td><td>7</td><td>85</td><td>1</td><td>1</td><td>1</td></tr>
+<tr><td>2</td><td>23</td><td>3</td><td>6</td><td>10</td><td>1</td><td>1</td><td>1</td><td></td><td>81</td><td></td><td>8</td><td>18</td><td>1</td><td>0</td><td>2</td></tr>
+<tr><td>2</td><td>24</td><td>3</td><td>7</td><td>10</td><td>19</td><td>1</td><td>1</td><td></td><td>59</td><td></td><td>8</td><td>78</td><td>1</td><td>1</td><td>2</td></tr>
+<tr><td>2</td><td>27</td><td>3</td><td>6</td><td>11</td><td>1</td><td>1</td><td>1</td><td></td><td>46</td><td></td><td>16</td><td>48</td><td>1</td><td>1</td><td>2</td></tr>
+<tr><td>3</td><td>28</td><td>1</td><td>2</td><td>1</td><td>1</td><td>1</td><td>1</td><td></td><td>52</td><td></td><td>7</td><td>100</td><td>1</td><td>1</td><td>1</td></tr>
+<tr><td>3</td><td>31</td><td>1</td><td>1</td><td>11</td><td>1</td><td>1</td><td>1</td><td></td><td>26</td><td></td><td>16</td><td>48</td><td>1</td><td>1</td><td>1</td></tr>
+<tr><td>3</td><td>37</td><td>1</td><td>1</td><td>12</td><td>1</td><td>1</td><td>1</td><td></td><td>77</td><td></td><td>16</td><td>160</td><td>1</td><td>1</td><td>1</td></tr>
+<tr><td>3</td><td>38</td><td>1</td><td>1</td><td>10</td><td>1</td><td>1</td><td>1</td><td></td><td>81</td><td></td><td>8</td><td>96</td><td>1</td><td>1</td><td>1</td></tr>
+<tr><td>1</td><td>40</td><td>3</td><td>7</td><td>12</td><td>1</td><td>1</td><td>1</td><td></td><td>68</td><td></td><td>16</td><td>160</td><td>1</td><td>1</td><td>2</td></tr>
+<tr><td>2</td><td>41</td><td>3</td><td>6</td><td>12</td><td>1</td><td>1</td><td>1</td><td></td><td>46</td><td></td><td>16</td><td>23</td><td>1</td><td>0</td><td>1</td></tr>
+<tr><td>2</td><td>42</td><td>3</td><td>7</td><td>12</td><td>24</td><td>1</td><td>1</td><td></td><td>42</td><td></td><td>16</td><td>137</td><td>1</td><td>1</td><td>2</td></tr>
+<tr><td>4</td><td>43</td><td>3</td><td>6</td><td>1</td><td>1</td><td>1</td><td>1</td><td></td><td>52</td><td></td><td>7</td><td>100</td><td>1</td><td>1</td><td>1</td></tr>
+<tr><td>4</td><td>45</td><td>3</td><td>7</td><td>10</td><td>1</td><td>1</td><td>1</td><td></td><td>71</td><td></td><td>8</td><td>96</td><td>1</td><td>1</td><td>1</td></tr>
+<tr><td>4</td><td>46</td><td>3</td><td>7</td><td>12</td><td>1</td><td>1</td><td>1</td><td></td><td>71</td><td></td><td>16</td><td>160</td><td>1</td><td>1</td><td>1</td></tr>
+<tr><td>4</td><td>52</td><td>3</td><td>7</td><td>11</td><td>1</td><td>1</td><td>1</td><td></td><td>71</td><td></td><td>16</td><td>48</td><td>1</td><td>1</td><td>1</td></tr>
+<tr><td>5</td><td>55</td><td>2</td><td>3</td><td>12</td><td>1</td><td>1</td><td>1</td><td></td><td>46</td><td></td><td>16</td><td>160</td><td>1</td><td>1</td><td>2</td></tr>
+<tr><td>1</td><td>58</td><td>3</td><td>6</td><td>11</td><td>1</td><td>1</td><td>1</td><td></td><td>77</td><td></td><td>16</td><td>48</td><td>1</td><td>1</td><td>2</td></tr>
+<tr><td>5</td><td>61</td><td>2</td><td>3</td><td>1</td><td>1</td><td>1</td><td>1</td><td></td><td>52</td><td></td><td>14</td><td>100</td><td>1</td><td>1</td><td>1</td></tr>
+<tr><td>7</td><td>67</td><td>3</td><td>15</td><td>12</td><td>1</td><td>9</td><td>1</td><td></td><td>58</td><td></td><td>8</td><td>160</td><td>1</td><td>1</td><td>3</td></tr>
+<tr><td>7</td><td>68</td><td>3</td><td>7</td><td>12</td><td>1</td><td>1</td><td>1</td><td></td><td>60</td><td></td><td>8</td><td>160</td><td>1</td><td>1</td><td>1</td></tr>
+<tr><td>8</td><td>71</td><td>2</td><td>3</td><td>12</td><td>1</td><td>1</td><td>1</td><td></td><td>46</td><td></td><td>16</td><td>160</td><td>1</td><td>1</td><td>2</td></tr>
+<tr><td>8</td><td>72</td><td>2</td><td>3</td><td>10</td><td>1</td><td>1</td><td>1</td><td></td><td>59</td><td></td><td>8</td><td>96</td><td>1</td><td>1</td><td>2</td></tr>
+<tr><td>8</td><td>74</td><td>2</td><td>3</td><td>1</td><td>1</td><td>1</td><td>1</td><td></td><td>52</td><td></td><td>14</td><td>100</td><td>1</td><td>1</td><td>2</td></tr>
+<tr><td>9</td><td>82</td><td>3</td><td>6</td><td>12</td><td>1</td><td>1</td><td>1</td><td></td><td>46</td><td></td><td>16</td><td>24</td><td>1</td><td>0</td><td>2</td></tr>
+<tr><td>9</td><td>83</td><td>3</td><td>7</td><td>12</td><td>25</td><td>1</td><td>1</td><td></td><td>26</td><td></td><td>8</td><td>136</td><td>1</td><td>1</td><td>1</td></tr>
+<tr><td>9</td><td>84</td><td>3</td><td>15</td><td>12</td><td>25</td><td>9</td><td>1</td><td></td><td>26</td><td></td><td>8</td><td>135</td><td>1</td><td>1</td><td>1</td></tr>
+<tr><td>9</td><td>89</td><td>3</td><td>6</td><td>11</td><td>1</td><td>1</td><td>1</td><td></td><td>70</td><td></td><td>16</td><td>48</td><td>1</td><td>1</td><td>2</td></tr>
+<tr><td>9</td><td>90</td><td>3</td><td>6</td><td>1</td><td>1</td><td>1</td><td>1</td><td></td><td>52</td><td></td><td>7</td><td>20</td><td>1</td><td>0</td><td>2</td></tr>
+<tr><td>9</td><td>91</td><td>3</td><td>7</td><td>1</td><td>21</td><td>1</td><td>1</td><td></td><td>52</td><td></td><td>7</td><td>80</td><td>1</td><td>1</td><td>2</td></tr>
+<tr><td>9</td><td>92</td><td>3</td><td>15</td><td>1</td><td>21</td><td>8</td><td>1</td><td></td><td>52</td><td></td><td>7</td><td>80</td><td>1</td><td>1</td><td>2</td></tr>
+<tr><td>9</td><td>95</td><td>3</td><td>17</td><td>10</td><td>1</td><td>1</td><td>1</td><td></td><td>30</td><td></td><td>8</td><td>24</td><td>1</td><td>0</td><td>2</td></tr>
+<tr><td>9</td><td>96</td><td>3</td><td>18</td><td>10</td><td>25</td><td>1</td><td>1</td><td></td><td>29</td><td></td><td>8</td><td>72</td><td>1</td><td>1</td><td>2</td></tr>
+<tr><td>2</td><td>97</td><td>3</td><td>15</td><td>1</td><td>1</td><td>8</td><td>1</td><td></td><td>52</td><td></td><td>7</td><td>100</td><td>1</td><td>1</td><td>2</td></tr>
+<tr><td>10</td><td>100</td><td>2</td><td>3</td><td>11</td><td>1</td><td>1</td><td>1</td><td></td><td>60</td><td></td><td>16</td><td>48</td><td>1</td><td>1</td><td>2</td></tr>
+<tr><td>10</td><td>101</td><td>2</td><td>3</td><td>1</td><td>1</td><td>1</td><td>1</td><td></td><td>52</td><td></td><td>14</td><td>100</td><td>1</td><td>1</td><td>2</td></tr>
+</tbody></table>
+</section>
+<section id='VersionControl'><h2>VersionControl</h2>
+<p><strong>Rows:</strong> 10 • <strong>Columns:</strong> 5</p>
+<table>
+<thead><tr><th>ReleaseDate</th><th>DatabaseVersion</th><th>AppMajor</th><th>AppMinor</th><th>AppRevision</th></tr></thead>
+<tbody>
+<tr><td>10/05/00 00:00:00</td><td>2</td><td>3</td><td>0</td><td>1</td></tr>
+<tr><td>10/30/00 00:00:00</td><td>2</td><td>3</td><td>0</td><td>2</td></tr>
+<tr><td>01/15/01 00:00:00</td><td>3</td><td>3</td><td>1</td><td>0</td></tr>
+<tr><td>02/16/01 00:00:00</td><td>3</td><td>3</td><td>3</td><td>0</td></tr>
+<tr><td>03/29/01 00:00:00</td><td>4</td><td>3</td><td>3</td><td>0</td></tr>
+<tr><td>01/31/01 00:00:00</td><td>3</td><td>3</td><td>2</td><td>0</td></tr>
+<tr><td>08/06/01 00:00:00</td><td>5</td><td>3</td><td>4</td><td>0</td></tr>
+<tr><td>09/14/01 00:00:00</td><td>5</td><td>3</td><td>5</td><td>0</td></tr>
+<tr><td>04/29/02 00:00:00</td><td>6</td><td>3</td><td>6</td><td>0</td></tr>
+<tr><td>04/08/03 00:00:00</td><td>7</td><td>3</td><td>7</td><td>0</td></tr>
+</tbody></table>
+</section>
+<section id='ClassCMsgs'><h2>ClassCMsgs</h2>
+<p><strong>Rows:</strong> 144 • <strong>Columns:</strong> 13</p>
+<table>
+<thead><tr><th>MsgCode</th><th>MsgClassID</th><th>Approved</th><th>Route</th><th>IDRoute</th><th>Destination</th><th>IDDestination</th><th>DestLine2</th><th>IDDestLine2</th><th>SideRoute</th><th>IDSideRoute</th><th>SideDest</th><th>IDSideDest</th></tr></thead>
+<tbody>
+<tr><td>1</td><td>3</td><td>0</td><td>^</td><td>6</td><td>blank</td><td>7</td><td>BLANK</td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>2</td><td>3</td><td>0</td><td>GRN</td><td>6</td><td>GREEN LINE^HEREFORD^SCOTT STADIUM^EMMET ST. SOUTH^RUGBY RD.^MAD/PRESTON</td><td>7</td><td>STADIUM SERVICE</td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>3</td><td>3</td><td>1</td><td>GRN^GRN^GRN^GRN^GRN^GRN</td><td>6</td><td>GREEN LOOP^14TH ST.^JPA / HOSPITAL^CNTRL GRNDS^RUGBY RD.^MAD/PRESTON</td><td>7</td><td>McCORMICK RD SERVICE^McCORMICK RD SERVICE^McCORMICK RD SERVICE^McCORMICK RD SERVICE^McCORMICK RD SERVICE</td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>4</td><td>3</td><td>0</td><td>OR</td><td>6</td><td>ORANGE LINE^MAD/PRESTON^14TH ST.^JPA / HOSPITAL^SCOTT STADIUM</td><td>7</td><td>STADIUM SERVICE</td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>5</td><td>3</td><td>0</td><td>OR^OR^OR^OR^OR^OR</td><td>6</td><td>ORANGE LOOP^MAD/PRESTON^RUGBY RD.^CNTRL GRNDS^JPA / HOSPITAL^14TH ST.</td><td>7</td><td>McCORMICK RD SERVICE^McCORMICK RD SERVICE^McCORMICK RD SERVICE^McCORMICK RD SERVICE^McCORMICK RD SERVICE^McCORMICK RD SERVICE</td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>6</td><td>3</td><td>1</td><td>GOLD</td><td>6</td><td>GOLD LINE^BARRACKS^NORTH GRNDS^JPJ / EIG^EMMET ST. SOUTH^SCOTT STADIUM^HEREFORD</td><td>7</td><td>STADIUM SERVICE</td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>7</td><td>3</td><td>1</td><td>GOLD</td><td>6</td><td>GOLD LINE^BARRACKS^NORTH GRNDS^JPJ / EIG^CNTRL GRNDS^HEREFORD</td><td>7</td><td>McCORMICK RD SERVICE^McCORMICK RD SERVICE^McCORMICK RD SERVICE^McCORMICK RD SERVICE^McCORMICK RD SERVICE^McCORMICK RD SERVICE</td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>8</td><td>3</td><td>0</td><td>SLV^SLV^SLV^SLV^SLV</td><td>6</td><td>SILVER LINE^JPJ / EIG^EMMET ST. SOUTH^HOSPITAL^MADISON HALL</td><td>7</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>9</td><td>3</td><td>1</td><td>GRN^GRN^GRN^GRN^GRN</td><td>6</td><td>GREEN LINE^HEREFORD^CNTRL GRNDS^RUGBY RD.^MAD/PRESTON</td><td>7</td><td>McCORMICK RD SERVICE^McCORMICK RD SERVICE^McCORMICK RD SERVICE^McCORMICK RD SERVICE^McCORMICK RD SERVICE</td><td>15</td><td></td><td>17</td><td></td><td>18</td></tr>
+<tr><td>10</td><td>3</td><td>0</td><td>BLUE</td><td>6</td><td>BLUE LINE^EIG^HOSPITAL</td><td>7</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>11</td><td>3</td><td>0</td><td>RED</td><td>6</td><td>RED LINE^STADIUM^HOSPITAL</td><td>7</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>12</td><td>3</td><td>1</td><td>PRP</td><td>6</td><td>PURPLE LINE</td><td>7</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>13</td><td>3</td><td>1</td><td>PRP^PRP^PRP^PRP</td><td>6</td><td>PURPLE LINE^HOSPITAL^STADIUM^FONTAINE</td><td>7</td><td></td><td>15</td><td></td><td></td><td></td><td></td></tr>
+<tr><td>14</td><td>3</td><td>1</td><td>NP</td><td>6</td><td>NIGHT PILOT^CNTRL GRNDS^HEREFORD^JPA / HOSPITAL^MADISON HALL</td><td>7</td><td></td><td>15</td><td></td><td></td><td></td><td></td></tr>
+<tr><td>15</td><td>3</td><td>0</td><td>CHARTER^CHARTER^CHARTER</td><td>6</td><td>CHARTER</td><td>7</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>16</td><td>3</td><td>0</td><td>SPECIAL</td><td>6</td><td>SPECIAL</td><td>7</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>17</td><td>3</td><td>0</td><td></td><td>6</td><td>UTS BUS ROADEO</td><td>7</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>18</td><td>3</td><td>1</td><td>NOT INÃ·SERVICE</td><td>6</td><td>NOT IN SERVICE</td><td>7</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>19</td><td>3</td><td>0</td><td>TRAININGÃ·BUS^TRAININGÃ·BUS</td><td>6</td><td>TRAINING BUS^NO PASSENGERS</td><td>7</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>20</td><td>3</td><td>0</td><td>TEAMÃ·SHUTTLE</td><td>6</td><td>TEAM SHUTTLE</td><td>7</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>21</td><td>3</td><td>0</td><td>UVA</td><td>6</td><td>UNIVERSITY OF VIRGINIA</td><td>7</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>22</td><td>3</td><td>0</td><td>BUSÃ·FULL</td><td>6</td><td>BUS FULL</td><td>7</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>23</td><td>3</td><td>1</td><td></td><td>6</td><td>ACCESSIBILITY</td><td>7</td><td>SHUTTLE</td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>24</td><td>3</td><td>1</td><td></td><td>6</td><td>FOOTBALL SHUTTLE</td><td>7</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>25</td><td>3</td><td>1</td><td>STAFFÃ·SHUTTLE</td><td>6</td><td>STAFF SHUTTLE</td><td>7</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>26</td><td>3</td><td>1</td><td></td><td>6</td><td>BASKETBALL SHUTTLE</td><td>7</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>27</td><td>3</td><td>1</td><td>TEST BUS</td><td>6</td><td>TEST BUS^NO PASSENGERS</td><td>7</td><td></td><td>15</td><td></td><td>17</td><td></td><td>18</td></tr>
+<tr><td>29</td><td>3</td><td>1</td><td></td><td>6</td><td>SUMMER ORIENTATIONÃ·SHUTTLE</td><td>7</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>30</td><td>3</td><td>1</td><td>OCIR SHUTTLE, EJEST ONLY</td><td>6</td><td>RESERVED CODEÃ·PLEASE ENTER^RESERVED CODEÃ·NEW DESTINATION</td><td>7</td><td></td><td>15</td><td></td><td>17</td><td></td><td>18</td></tr>
+<tr><td>31</td><td>3</td><td>1</td><td>CONGRATSÃ·GRADS!</td><td>6</td><td>GRADUATION SHUTTLE</td><td>7</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>32</td><td>3</td><td>1</td><td>CLUB</td><td>6</td><td>CLUB LEADERS</td><td>7</td><td></td><td>15</td><td></td><td>17</td><td></td><td>18</td></tr>
+<tr><td>33</td><td>3</td><td>1</td><td></td><td>6</td><td>INAUGURATIONÃ·SHUTTLE</td><td>7</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>36</td><td>3</td><td>1</td><td></td><td>6</td><td>REUNION SHUTTLE</td><td>7</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>37</td><td>3</td><td>1</td><td></td><td>6</td><td>LAW SCHOOL REUNION</td><td>7</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>38</td><td>3</td><td>1</td><td>DAYS ONÃ·THE LAWN</td><td>6</td><td>DAYS ON THE LAWN</td><td>7</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>40</td><td>3</td><td>1</td><td>JEFFERSONÃ·SYMPOSIUM</td><td>6</td><td>JEFFERSON SYMPOSIUM</td><td>7</td><td></td><td>15</td><td></td><td></td><td></td><td></td></tr>
+<tr><td>41</td><td>3</td><td>1</td><td>RED</td><td>6</td><td>REDLINE^SPECIAL^STADIUM^HOSPITAL</td><td>7</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>42</td><td>3</td><td>1</td><td>WAHOOÃ·WALK</td><td>6</td><td>WAHOO WALK</td><td>7</td><td></td><td>15</td><td></td><td></td><td></td><td></td></tr>
+<tr><td>43</td><td>3</td><td>1</td><td>MEMORIAL SERVICE</td><td>6</td><td>MEMORIAL SERVICE SHUTTLE</td><td>7</td><td></td><td>15</td><td></td><td></td><td></td><td></td></tr>
+<tr><td>44</td><td>3</td><td>1</td><td>WINTERÃ·WANDER</td><td>6</td><td>WINTER WANDER</td><td>7</td><td></td><td>15</td><td></td><td></td><td></td><td></td></tr>
+<tr><td>45</td><td>3</td><td>1</td><td>HAPPY HOLIDAYS!</td><td>6</td><td>HAPPY HOLIDAYS!</td><td>7</td><td></td><td>15</td><td></td><td>17</td><td></td><td>18</td></tr>
+<tr><td>46</td><td>3</td><td>1</td><td></td><td>6</td><td>STAFF APPRECIATIONÃ·BREAKFAST</td><td>7</td><td></td><td>15</td><td></td><td>17</td><td></td><td>18</td></tr>
+<tr><td>47</td><td>3</td><td>1</td><td></td><td>6</td><td>STAFF APPRECIATION^PICNIC</td><td>7</td><td></td><td>15</td><td></td><td>17</td><td></td><td>18</td></tr>
+<tr><td>50</td><td>3</td><td>1</td><td></td><td>6</td><td>EMERGENCY^ON CAMPUS</td><td>7</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>51</td><td>3</td><td>1</td><td>UTS HIRINGÃ·EVENT</td><td>6</td><td>UTS HIRING EVENT</td><td>7</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>52</td><td>3</td><td>1</td><td>FANÃ·SHUTTLE</td><td>6</td><td>FAN SHUTTLE</td><td>7</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td>54</td><td>3</td><td>1</td><td>HEALTHÃ·AWARDS</td><td>6</td><td>UVA HEALTH AWARDS</td><td>7</td><td></td><td>15</td><td></td><td></td><td></td><td></td></tr>
+<tr><td>55</td><td>3</td><td>1</td><td>SERVICEÃ·AWARDS</td><td>6</td><td>UVA SERVICE AWARDS</td><td>7</td><td></td><td>15</td><td></td><td></td><td></td><td></td></tr>
+<tr><td>60</td><td>3</td><td>1</td><td>JPJ ARENA</td><td>6</td><td>JPJ ARENA </td><td>7</td><td>FAN SHUTTLE</td><td>15</td><td>JPJ FAN SHUTTLE</td><td>17</td><td>JPJ ARENA FAN SHUTTLE</td><td>18</td></tr>
+<tr><td>61</td><td>3</td><td>1</td><td>NORTH GROUNDS</td><td>6</td><td>NORTH GROUNDS</td><td>7</td><td>FAN SHUTTLE</td><td>15</td><td>NORTH GROUNDS^FAN SHUTTLE</td><td>17</td><td>NORTH GROUNDS^FAN SHUTTLE</td><td>18</td></tr>
+</tbody></table>
+<p class="note">94 additional rows not shown.</p>
+</section>
+<section id='ClassTemplates'><h2>ClassTemplates</h2>
+<p><strong>Rows:</strong> 9 • <strong>Columns:</strong> 5</p>
+<table>
+<thead><tr><th>TemplateID</th><th>MsgClassID</th><th>SignSetID</th><th>TemplateName</th><th>TemplateDescription</th></tr></thead>
+<tbody>
+<tr><td>1</td><td>3</td><td>1</td><td>Destination only</td><td></td></tr>
+<tr><td>2</td><td>3</td><td>1</td><td>RTw/Destination</td><td></td></tr>
+<tr><td>3</td><td>1</td><td>1</td><td>Back-Up Codes</td><td></td></tr>
+<tr><td>4</td><td>3</td><td>1</td><td>TEST PATTERN</td><td></td></tr>
+<tr><td>5</td><td>2</td><td>1</td><td>PR code</td><td></td></tr>
+<tr><td>7</td><td>3</td><td>1</td><td>Destination w/ 2 lin</td><td></td></tr>
+<tr><td>8</td><td>2</td><td>1</td><td>PR code - All Signs</td><td></td></tr>
+<tr><td>9</td><td>3</td><td>1</td><td>RT w/ 2 dest lines</td><td></td></tr>
+<tr><td>10</td><td>2</td><td>1</td><td>PR Code - Rear Only</td><td></td></tr>
+</tbody></table>
+</section>
+<section id='History'><h2>History</h2>
+<p><strong>Rows:</strong> 473 • <strong>Columns:</strong> 4</p>
+<table>
+<thead><tr><th>Timestamp</th><th>Event</th><th>User</th><th>Comments</th></tr></thead>
+<tbody>
+<tr><td>05/19/04 11:36:07</td><td>Close project</td><td>sk</td><td></td></tr>
+<tr><td>05/19/04 11:44:39</td><td>Close project</td><td>sk</td><td></td></tr>
+<tr><td>05/19/04 11:46:13</td><td>Close project</td><td>sk</td><td></td></tr>
+<tr><td>09/25/07 11:29:27</td><td>Close project</td><td>Theresa Halbrook</td><td></td></tr>
+<tr><td>09/25/07 16:35:50</td><td>Close project</td><td>Theresa Halbrook</td><td></td></tr>
+<tr><td>09/25/07 17:36:27</td><td>Close project</td><td>Theresa Halbrook</td><td></td></tr>
+<tr><td>09/26/07 10:55:54</td><td>Close project</td><td>ctorres</td><td></td></tr>
+<tr><td>04/04/08 13:26:49</td><td>Close project</td><td>ctorres</td><td></td></tr>
+<tr><td>08/11/08 08:46:52</td><td>Close project</td><td>Mike</td><td></td></tr>
+<tr><td>08/11/08 10:12:09</td><td>Close project</td><td>MIKE</td><td></td></tr>
+<tr><td>08/11/08 13:11:43</td><td>Close project</td><td>MIKE</td><td></td></tr>
+<tr><td>08/11/08 13:23:22</td><td>Close project</td><td>MIKE</td><td></td></tr>
+<tr><td>08/11/08 13:47:18</td><td>Close project</td><td>MIKE</td><td></td></tr>
+<tr><td>08/12/08 16:45:49</td><td>Close project</td><td>MIKE</td><td></td></tr>
+<tr><td>08/27/08 14:35:50</td><td>Close project</td><td>mike</td><td></td></tr>
+<tr><td>08/27/08 14:42:39</td><td>Close project</td><td>mike</td><td></td></tr>
+<tr><td>08/29/08 09:02:39</td><td>Close project</td><td>mike</td><td></td></tr>
+<tr><td>08/29/08 09:13:35</td><td>Close project</td><td>Mike</td><td></td></tr>
+<tr><td>08/29/08 10:07:53</td><td>Close project</td><td>Mike</td><td></td></tr>
+<tr><td>08/29/08 11:48:05</td><td>Close project</td><td>mike</td><td></td></tr>
+<tr><td>08/29/08 14:28:37</td><td>Close project</td><td>mike</td><td></td></tr>
+<tr><td>07/09/09 10:20:49</td><td>Close project</td><td>mike</td><td></td></tr>
+<tr><td>07/09/09 10:36:30</td><td>Close project</td><td>Alex</td><td></td></tr>
+<tr><td>07/09/09 16:38:10</td><td>Close project</td><td>alex</td><td></td></tr>
+<tr><td>07/09/09 16:38:33</td><td>Close project</td><td>alex</td><td></td></tr>
+<tr><td>07/09/09 16:59:39</td><td>Close project</td><td>alex</td><td></td></tr>
+<tr><td>07/09/09 19:33:52</td><td>Close project</td><td>alex</td><td></td></tr>
+<tr><td>07/16/09 16:17:32</td><td>Close project</td><td>alex</td><td></td></tr>
+<tr><td>07/17/09 10:36:26</td><td>Close project</td><td>alex</td><td></td></tr>
+<tr><td>07/19/09 21:18:46</td><td>Close project</td><td>Andrew</td><td>OMG</td></tr>
+<tr><td>07/21/09 09:32:37</td><td>Close project</td><td>alex</td><td></td></tr>
+<tr><td>07/21/09 13:59:21</td><td>Close project</td><td>alex</td><td></td></tr>
+<tr><td>07/21/09 14:07:08</td><td>Close project</td><td>alex</td><td></td></tr>
+<tr><td>07/21/09 15:15:13</td><td>Close project</td><td>alex</td><td></td></tr>
+<tr><td>07/21/09 15:26:13</td><td>Close project</td><td>alex</td><td>OMG!</td></tr>
+<tr><td>07/21/09 15:53:32</td><td>Close project</td><td>alex</td><td></td></tr>
+<tr><td>07/21/09 16:35:51</td><td>Close project</td><td>alex</td><td></td></tr>
+<tr><td>07/23/09 13:34:07</td><td>Close project</td><td>alex</td><td></td></tr>
+<tr><td>07/27/09 14:11:00</td><td>Close project</td><td>alex</td><td></td></tr>
+<tr><td>11/13/09 16:20:48</td><td>Close project</td><td>alex</td><td></td></tr>
+<tr><td>12/14/09 11:06:42</td><td>Close project</td><td>alex</td><td></td></tr>
+<tr><td>12/15/09 14:30:44</td><td>Close project</td><td>alex</td><td></td></tr>
+<tr><td>12/17/09 12:07:49</td><td>Close project</td><td>alex</td><td></td></tr>
+<tr><td>12/17/09 12:30:09</td><td>Close project</td><td>alex</td><td></td></tr>
+<tr><td>01/06/10 16:17:09</td><td>Close project</td><td>alex</td><td></td></tr>
+<tr><td>01/09/10 11:57:36</td><td>Close project</td><td>alex</td><td>
+</td></tr>
+<tr><td>01/21/10 10:15:22</td><td>Close project</td><td>alex</td><td></td></tr>
+<tr><td>01/29/10 15:27:03</td><td>Close project</td><td>alex</td><td></td></tr>
+<tr><td>02/24/10 16:30:12</td><td>Close project</td><td>alex</td><td></td></tr>
+<tr><td>04/20/10 14:37:32</td><td>Close project</td><td>alex</td><td></td></tr>
+</tbody></table>
+<p class="note">423 additional rows not shown.</p>
+</section>
+<section id='MessageFrames'><h2>MessageFrames</h2>
+<p><strong>Rows:</strong> 1561 • <strong>Columns:</strong> 32</p>
+<table>
+<thead><tr><th>MsgClassID</th><th>MsgFrameID</th><th>MsgCode</th><th>LSignID</th><th>Frame</th><th>Break</th><th>Phrase</th><th>GraphicID</th><th>FontID</th><th>LineTime</th><th>HJustify</th><th>VJustify</th><th>XPos</th><th>YPos</th><th>Alert</th><th>Scroll</th><th>Format</th><th>Blink</th><th>Up</th><th>Down</th><th>Scroll2</th><th>AttrBit0</th><th>AttrBit1</th><th>AttrBit2</th><th>AttrBit3</th><th>AttrBit4</th><th>AttrBit5</th><th>AttrBit6</th><th>AttrBit7</th><th>AttrBit9</th><th>Number</th><th>ElementID</th></tr></thead>
+<tbody>
+<tr><td>3</td><td>1356930</td><td>121</td><td>1</td><td>1</td><td>0</td><td>TRANSIT 121</td><td></td><td>52</td><td>16</td><td>0</td><td>0</td><td>26</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1356937</td><td>121</td><td>10</td><td>1</td><td>0</td><td>TRANSIT 121</td><td></td><td>59</td><td>16</td><td>0</td><td>0</td><td>21</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1356938</td><td>121</td><td>11</td><td>1</td><td>0</td><td>121</td><td></td><td>77</td><td>16</td><td>0</td><td>0</td><td>9</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>6</td></tr>
+<tr><td>3</td><td>1356939</td><td>121</td><td>12</td><td>1</td><td>0</td><td>TRANSIT 121</td><td></td><td>77</td><td>18</td><td>1</td><td>1</td><td>17</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1356974</td><td>123</td><td>1</td><td>1</td><td>0</td><td>TRANSIT 123</td><td></td><td>52</td><td>16</td><td>0</td><td>0</td><td>26</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1356981</td><td>123</td><td>10</td><td>1</td><td>0</td><td>TRANSIT 123</td><td></td><td>59</td><td>16</td><td>0</td><td>0</td><td>20</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1356982</td><td>123</td><td>11</td><td>1</td><td>0</td><td>123</td><td></td><td>77</td><td>16</td><td>0</td><td>0</td><td>8</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>6</td></tr>
+<tr><td>3</td><td>1356983</td><td>123</td><td>12</td><td>1</td><td>0</td><td>TRANSIT 123</td><td></td><td>77</td><td>18</td><td>1</td><td>1</td><td>16</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1356996</td><td>124</td><td>1</td><td>1</td><td>0</td><td>TRANSIT 124</td><td></td><td>52</td><td>16</td><td>0</td><td>0</td><td>26</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357003</td><td>124</td><td>10</td><td>1</td><td>0</td><td>TRANSIT 124</td><td></td><td>59</td><td>16</td><td>0</td><td>0</td><td>20</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357004</td><td>124</td><td>11</td><td>1</td><td>0</td><td>124</td><td></td><td>77</td><td>16</td><td>0</td><td>0</td><td>8</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>6</td></tr>
+<tr><td>3</td><td>1357005</td><td>124</td><td>12</td><td>1</td><td>0</td><td>TRANSIT 124</td><td></td><td>77</td><td>18</td><td>1</td><td>1</td><td>16</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357040</td><td>126</td><td>1</td><td>1</td><td>0</td><td>TRANSIT 126</td><td></td><td>52</td><td>16</td><td>0</td><td>0</td><td>26</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357047</td><td>126</td><td>10</td><td>1</td><td>0</td><td>TRANSIT 126</td><td></td><td>59</td><td>16</td><td>0</td><td>0</td><td>20</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357048</td><td>126</td><td>11</td><td>1</td><td>0</td><td>126</td><td></td><td>77</td><td>16</td><td>0</td><td>0</td><td>8</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>6</td></tr>
+<tr><td>3</td><td>1357049</td><td>126</td><td>12</td><td>1</td><td>0</td><td>TRANSIT 126</td><td></td><td>77</td><td>18</td><td>1</td><td>1</td><td>17</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357062</td><td>141</td><td>1</td><td>1</td><td>0</td><td>TRANSIT 141</td><td></td><td>52</td><td>16</td><td>0</td><td>0</td><td>26</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357069</td><td>141</td><td>10</td><td>1</td><td>0</td><td>TRANSIT 141</td><td></td><td>59</td><td>16</td><td>0</td><td>0</td><td>21</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357070</td><td>141</td><td>11</td><td>1</td><td>0</td><td>141</td><td></td><td>77</td><td>16</td><td>0</td><td>0</td><td>9</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>6</td></tr>
+<tr><td>3</td><td>1357071</td><td>141</td><td>12</td><td>1</td><td>0</td><td>TRANSIT 141</td><td></td><td>77</td><td>18</td><td>0</td><td>0</td><td>17</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357084</td><td>142</td><td>1</td><td>1</td><td>0</td><td>TRANSIT 142</td><td></td><td>52</td><td>16</td><td>0</td><td>0</td><td>26</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357091</td><td>142</td><td>10</td><td>1</td><td>0</td><td>TRANSIT 142</td><td></td><td>59</td><td>16</td><td>0</td><td>0</td><td>20</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357092</td><td>142</td><td>11</td><td>1</td><td>0</td><td>142</td><td></td><td>77</td><td>16</td><td>0</td><td>0</td><td>8</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>6</td></tr>
+<tr><td>3</td><td>1357093</td><td>142</td><td>12</td><td>1</td><td>0</td><td>TRANSIT 142</td><td></td><td>77</td><td>18</td><td>1</td><td>1</td><td>16</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357106</td><td>143</td><td>1</td><td>1</td><td>0</td><td>TRANSIT 143</td><td></td><td>52</td><td>16</td><td>0</td><td>0</td><td>26</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357113</td><td>143</td><td>10</td><td>1</td><td>0</td><td>TRANSIT 143</td><td></td><td>59</td><td>16</td><td>0</td><td>0</td><td>20</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357114</td><td>143</td><td>11</td><td>1</td><td>0</td><td>143</td><td></td><td>77</td><td>16</td><td>0</td><td>0</td><td>8</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>6</td></tr>
+<tr><td>3</td><td>1357115</td><td>143</td><td>12</td><td>1</td><td>0</td><td>TRANSIT 143</td><td></td><td>77</td><td>18</td><td>0</td><td>0</td><td>16</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357128</td><td>144</td><td>1</td><td>1</td><td>0</td><td>TRANSIT 144</td><td></td><td>52</td><td>16</td><td>0</td><td>0</td><td>26</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357135</td><td>144</td><td>10</td><td>1</td><td>0</td><td>TRANSIT 144</td><td></td><td>59</td><td>16</td><td>0</td><td>0</td><td>20</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357136</td><td>144</td><td>11</td><td>1</td><td>0</td><td>144</td><td></td><td>77</td><td>16</td><td>0</td><td>0</td><td>8</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>6</td></tr>
+<tr><td>3</td><td>1357137</td><td>144</td><td>12</td><td>1</td><td>0</td><td>TRANSIT 144</td><td></td><td>77</td><td>18</td><td>1</td><td>1</td><td>16</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357150</td><td>145</td><td>1</td><td>1</td><td>0</td><td>TRANSIT 145</td><td></td><td>52</td><td>16</td><td>0</td><td>0</td><td>26</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357157</td><td>145</td><td>10</td><td>1</td><td>0</td><td>TRANSIT 145</td><td></td><td>59</td><td>16</td><td>0</td><td>0</td><td>20</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357158</td><td>145</td><td>11</td><td>1</td><td>0</td><td>145</td><td></td><td>77</td><td>16</td><td>0</td><td>0</td><td>8</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>6</td></tr>
+<tr><td>3</td><td>1357159</td><td>145</td><td>12</td><td>1</td><td>0</td><td>TRANSIT 145</td><td></td><td>77</td><td>18</td><td>1</td><td>1</td><td>16</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357172</td><td>171</td><td>1</td><td>1</td><td>0</td><td>TRANSIT 171</td><td></td><td>52</td><td>16</td><td>0</td><td>0</td><td>26</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357179</td><td>171</td><td>10</td><td>1</td><td>0</td><td>TRANSIT 171</td><td></td><td>59</td><td>16</td><td>0</td><td>0</td><td>21</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357180</td><td>171</td><td>11</td><td>1</td><td>0</td><td>171</td><td></td><td>77</td><td>16</td><td>0</td><td>0</td><td>9</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>6</td></tr>
+<tr><td>3</td><td>1357181</td><td>171</td><td>12</td><td>1</td><td>0</td><td>TRANSIT 171</td><td></td><td>77</td><td>18</td><td>1</td><td>1</td><td>17</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357194</td><td>172</td><td>1</td><td>1</td><td>0</td><td>TRANSIT 172</td><td></td><td>52</td><td>16</td><td>0</td><td>0</td><td>26</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357201</td><td>172</td><td>10</td><td>1</td><td>0</td><td>TRANSIT 172</td><td></td><td>59</td><td>16</td><td>0</td><td>0</td><td>20</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357202</td><td>172</td><td>11</td><td>1</td><td>0</td><td>172</td><td></td><td>77</td><td>16</td><td>0</td><td>0</td><td>8</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>6</td></tr>
+<tr><td>3</td><td>1357203</td><td>172</td><td>12</td><td>1</td><td>0</td><td>TRANSIT 172</td><td></td><td>77</td><td>18</td><td>1</td><td>1</td><td>16</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357216</td><td>173</td><td>1</td><td>1</td><td>0</td><td>TRANSIT 173</td><td></td><td>52</td><td>16</td><td>0</td><td>0</td><td>26</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357223</td><td>173</td><td>10</td><td>1</td><td>0</td><td>TRANSIT 173</td><td></td><td>59</td><td>16</td><td>0</td><td>0</td><td>20</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357224</td><td>173</td><td>11</td><td>1</td><td>0</td><td>173</td><td></td><td>77</td><td>16</td><td>0</td><td>0</td><td>8</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>6</td></tr>
+<tr><td>3</td><td>1357225</td><td>173</td><td>12</td><td>1</td><td>0</td><td>TRANSIT 173</td><td></td><td>77</td><td>18</td><td>1</td><td>1</td><td>16</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357238</td><td>174</td><td>1</td><td>1</td><td>0</td><td>TRANSIT 174</td><td></td><td>52</td><td>16</td><td>0</td><td>0</td><td>26</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+<tr><td>3</td><td>1357245</td><td>174</td><td>10</td><td>1</td><td>0</td><td>TRANSIT 174</td><td></td><td>59</td><td>16</td><td>0</td><td>0</td><td>20</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>7</td></tr>
+</tbody></table>
+<p class="note">1511 additional rows not shown.</p>
+</section>
+<section id='MsgClassElements'><h2>MsgClassElements</h2>
+<p><strong>Rows:</strong> 11 • <strong>Columns:</strong> 4</p>
+<table>
+<thead><tr><th>ElementID</th><th>MsgClassID</th><th>ElementName</th><th>ElementDescription</th></tr></thead>
+<tbody>
+<tr><td>1</td><td>1</td><td>Title</td><td>Standard title</td></tr>
+<tr><td>2</td><td>1</td><td>Text</td><td>Message text</td></tr>
+<tr><td>3</td><td>2</td><td>PRText</td><td>Message text</td></tr>
+<tr><td>6</td><td>3</td><td>Route</td><td>Route number</td></tr>
+<tr><td>7</td><td>3</td><td>Destination</td><td>Destination</td></tr>
+<tr><td>10</td><td>4</td><td>Announce</td><td></td></tr>
+<tr><td>11</td><td>4</td><td>NextStop</td><td></td></tr>
+<tr><td>13</td><td>5</td><td>ForbiddenWord</td><td>text</td></tr>
+<tr><td>15</td><td>3</td><td>DestLine2</td><td>Second line of front destination</td></tr>
+<tr><td>17</td><td>3</td><td>SideRoute</td><td>Side sign route for 2 lines on LF units</td></tr>
+<tr><td>18</td><td>3</td><td>SideDest</td><td>Side sign dest for 2 lines on LF units</td></tr>
+</tbody></table>
+</section>
+<section id='NumericProperties'><h2>NumericProperties</h2>
+<p><strong>Rows:</strong> 2 • <strong>Columns:</strong> 4</p>
+<table>
+<thead><tr><th>ID</th><th>PropName</th><th>LSignID</th><th>PropValue</th></tr></thead>
+<tbody>
+<tr><td>1</td><td>HexMode</td><td></td><td>0</td></tr>
+<tr><td>2</td><td>CapsLock</td><td></td><td>0</td></tr>
+</tbody></table>
+</section>
+<section id='SignSets'><h2>SignSets</h2>
+<p><strong>Rows:</strong> 1 • <strong>Columns:</strong> 9</p>
+<table>
+<thead><tr><th>LoadModID</th><th>SignSetID</th><th>SignSetName</th><th>SignSetDescription</th><th>SignSetOutputDate</th><th>SignSetOutput</th><th>Timing620</th><th>Retention620</th><th>SignSetOutputVersion</th></tr></thead>
+<tbody>
+<tr><td>2</td><td>1</td><td>BUS</td><td></td><td>10/03/25 21:07:04</td><td> P  Òo@      Q 	
+
+ !&quot;#$%&amp;&#x27;()*+,-./0123456789:;&lt;=&gt;?@ABCDEFGHIJKLMNOP        0       1       1       0                                                
+ÉÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍ»
+º                                      º
+º            P/N 412014-002            º
+º            Copyright 1990            º
+º        Gulton Industries, Inc.       º
+º                                      º
+ÈÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍ¼
+
+
+ÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ ÿÿ` ^` ` ¦` &amp;` &quot;` `  ` ` ` ` 
+` ` ` þ` ú` ö` ò` î` ê` æ` â` Þ` * ` Ö` Ò` Î` *~` Æ` +` +¢` +ª` +Ü` ,¼` +ª` ª` ¦` ¢` ÿÿÿÿ |   N`Fü Aù  ¸#È  ¨#È  ¬Aù  ¸#È  °#È  ´Aù  ¸#È    ü )è ü Ø ü î ü ð#È  ¤¹    vü    9    vgS¹  xfa 29    gS¹  ¬fa &lt; y   ±ù  ¤gÆ&quot;X±ü  ¸l#È   `
+#ü  ¸   N`¦Fü&#x27; (y  ¤(Ë¹ü  ¸l#Ì  ¤`
+#ü  ¸  ¤NsFü&#x27; (y  ¬(Ë¹ü  ¸l#Ì  ¬`
+#ü  ¸  ¬NsFü&#x27; (y  ´(Ë¹ü  ¸l#Ì  ´`
+#ü  ¸  ´Nsü    |ü    +¹    7ü   3ü   øü 
+  ×ü   ü   ü   ü    ü    ü    ü    ü   ü    ü    3ü    ºNupÀ  	#À  aZ o&lt; Å  pÀ  	ü    ü    #À  a*a  æ9   oü   9   oü   Nuz t 49  ö&amp;y  úa 7    g  ¢ y  ü    ü    t 49  öü a /n ga /&amp;  þfÐ`hm
+  `föR`ò  ügº  þlN  òmà  óo&gt;  úg(  õf.9   	f9   ga&quot;À  `¬À  ` T`X`Nu9    f
+Û9  z `Û9  z Nu&amp;y  a ¹   ¹    |   3ü    $9   Ögü    |p (k , 	fjt 49   9   ÖfJ9   Öfa 62   g:`p#À  a 6^   g&amp;ù   t 49   a 5¼y    $n$p`p`
+pü    |#À  t 49   a 6&#x27;y   &#x27;y   |   |  «  
+y   $f«  
+p &quot;k +  
+g
++  
+f`+  
+g+  
+fp`Ð) Ð) Ðy  $3À  &amp;aNu3ü    &amp;y  p + °y  &amp;n è+ þ f  &quot;k +  
+g+  
+f &#x27;y  
+ `L+  
+g&#x27;k  |   `6+  
+g«  
+&#x27;y  
+ )   f F`&amp;ë  
+&#x27;k  |   `+  
+g
+)   f &quot;k é   #0) 
+g   0) g  ²) g  a .Ê  g ÿJCù  29  Eñ &amp;y  « #ë   Aù  Eù  #Ê  ,k %hÿþÿü&#x27;H t 49   ü ÂHB  gÐ`ü    &quot;a &#x27;Þ&#x27;y   `4ü    &quot;a &#x27; `&amp;0) f) gü    &quot;a -ü`ü    #`    g þCù  #É  rGù NJ| 9  #SFoNKSFnú&amp;y  +  Gù àNKNu|   Aù  ,k k ÿün ÿý1n 
+ÿþ9  &quot;r t 9  #Äü  RA²Bmö`t 9  #Äù  &amp;3Â  (Gù \NJGù NKNu&amp;y  a ¬3ü    $9   Ögü    |p (k , 	f6t 49  a 2ú   gt 49  a 2 y    $n p`
+pü    |#À  t 49  a 2þ«  
+&#x27;y   &#x27;y  
+ aRp &quot;k +  
+g
++  
+f`+  
+fÐ) Ð) Ðy  $3À  f
+ü    Nuü   ) a@Nu+  
+g&#x27;k  «  
++  
+g| þ `&#x27;k  ë  
+|   |  Nu&amp;y  p + °y  oS f
+ü    Nua+ þ fd&quot;k +  
+g+  
+f  &#x27;k  `&lt;+  
+g&#x27;k  `,+  
+g«  
+&#x27;k  )   f  b`ë  
+&#x27;k  )   f  Ja /  g ÿ  g ÿCù  #É  ¤Gù ÊNJSEoNLSEnú&amp;y  +  Gù 
+*NLNu|   09  °+ n f+  Gù 
+*NJ` p ) @ +  Gù PNJGù 
+*NLNuü   NuEù   49   Åü  02 3À   Áü  Cò  3é   #É  )   
+fGù `Gù NJNuGù NJGù NKNu0&lt;5S@füGù ´NJNuNDNuEù  bAù  #È  rvCù  9  ×aFvCù  a&lt;vCù  &quot;a2Gù NJRy  (rNKRy  (R oðGù \NKGù NKNur 0ù  ÃÀt ò  RAA mòü ÿRAA môNu&amp;y  a X¹   |   p
+9   Ð9  #À  3ü    $t 49   a /à   g
+y    $f9 	  o¼` :&#x27;y   |   |  «  
+3ü    Eù  bAù  #È  r9   f
+Cù  `  ² f
+Cù  `  ¢ f
+Cù  &quot;`   f
+Cù  2`   fCù  :`F f` f` 	f  9  ×r 0ù  ÃÀü ÿRAA môGù NJRy  (`DGù pa þNJRy  (pa þNKRy  (R   oì`9  ×a þtGù NJRy  (p &amp;y  +  
+f(Ðy  $3À  &amp;Gù 
+NK`t Gù \NJGù NKNu&amp;y  p + °y  &amp;n 0+ þ g &amp;&quot;k é   #0) 
+g  0) g  ®) g~a ((  gÊCù  29  Eñ &amp;y  « #ë   Aù  Eù  #Ê  ,k %hÿþÿü&#x27;H t 49   ü ÂHB  gÐ`ü    &quot;a !&gt;&#x27;y   `4ü    &quot;a ! `&amp;0) f) gü    &quot;a &#x27;\`ü    #`  R  g ÿCù  #É  rGù NJRy  (| 9  #SFoNKRy  (SFnô&amp;y  +  Gù 
+NKNuGù ^NJNu3ü    (29  Cù P i $y  0g
+°AgÐü `òª   
+3ü    #È  rGù NJRy  (@ mg@g@ÿoGù \NKGù NKNuGù ÌNKNuü   ù    Gù ^NKNuAù P$h &amp;h Iù   &quot;Px |ÿ~ÿ&lt;|  r 01 g ,t :2  g &quot;°Ef2 @ gB `æKò  )@v z 30  ÿgÊü ²Ef3  0gC `Þ@ f  Ü`Kó0 )@z Å  Å Å Å Å Å @
+¼  @¼ @@ ÿoJ@ÿo&amp;@ÿod@0f8ü   ´ @
+9@3Î  `z3Î  ö3À  øAô@ #È  úò   ×´ @
+9@Fÿÿg9``3Î  þ3Î   &lt;`69   f,ô @
+9@Gÿÿg9p`3Î  *3Î  .&gt;`ô @
+D  RN¼ü n
+2Âü ` þ´Aù   9   f09  Áü  Cð  #É  Gù )¼NJy  ømGù bNJFÿÿg1¹  þ`Gù ZNJGÿÿg21¹  *p09  .3À  ,Áü  Cð  #É  2ù    7Gù ,NJNu9   g&lt;9   g2Aù  ¼Eù  ¼ tNGAù à NqAù  ¼Eù  ¼ tNGNuGù  R9  Ö f4   y   øg
+y  øfp`pa &lt;Cù  2` \ f  Ú¹     fü    Cù  Ø`t  fCù  à`f  fCù  è`X  fCù  ð`J  f 2Cù  øaX9   fD Å  p(Gù  Øa °Cù  :v a RCC (mô`  Ða9   fGù ¸`Gù ¨NJNuR9  °9  gù   p ³    R@@ mòNu°9  ×f    fÅ  `  n 
+f  `  \ fCù   `: fCù       ` fDCù  &quot;Å     v a  ²RCC môv Å  ÖGù  ÖCù  a  Gù ¸`Gù NJAù   09  ,3À  .Áü  Cð  #É  2p p0 f&quot;p )   
+g6ù   `,0 
+ gÅ  Å Å Å Å Å  
+¼  @  @ào¬ü    |Nutr 10 Iù  bAó0 Eô °g,NG°g$Aù  R gÀ   Eñ0 NGEÐAù   NG`¸NuAù  ²&quot;y   hf&lt;( 
+ f4&lt; ³ ( ³ ( ³ °( f( 6 n( 0 mGù ÆNJ`| 4 `î| 3 `æNu y  ( R   
+oa 8Nu@ ` y  |   ü    Aù  Eù   ü  ²0ü  0ü  Ê0ü  0ü ü hü Sü 
+ü Ia òNu y  ( R   oa ÌNu@ &amp;y  ¨`&gt;&amp;y  ¤ y   Df EÓ¼ 0 #Ë  ¤p
+~a  D a õX`z|   #Ë  ¨ü   Aù  Eù   ü  ²0ü  0ü  Ê0ü  0ü ü hü P$Û#Ë  ¤ü 
+Eù  p ³ ³ ³ ³ ³ ³ ³ 
+  a  Nut v x z | a ~ f¶@lÈÀÊÀØHDÚD8&lt;  HD´mÜHD8HD`x NuNVÿ2&lt;  C÷ 2&lt; ÈE÷ I×r(K÷ Å  Ör 3  am
+ zn   RA²@mâr x z 1 ¼  P(A  gv ´50 g8RC¶EmôP R5P(PP@ RD6RC¶@l10 ´5P fð@ RDR5P(`äRERA²@mªSEr 650 8RC¶En´50 mô`ì¸Ag&amp;µ @  5@(µ(@((5@PµP@PPRA²EmºAù P h $a  ªF  m  r 4¸5  g0mæ64¸5  g$nÚt 4AB mÎü ÔA¸5  g
+n6`â2`Þx ~ 5 P5 (4@ t RB´Fn(2  RA²@l  g1   gì¶1 gÜSGo ÿ~RD`Ìr ¼   RA²@oôù   ÖNqNq9  ÖN^Nu|ÿ ûfT`ô òfX`ê þgä ýg   íft  ndÄü ÐÂ`  mV nPRk&quot;RF¼@l6ah é` kaX Õ2` `Ú ûo. üg&gt; ýg6 þg2` üg( þg&quot;4 a P0` ÿ\ òm  óoT`X`|ÿNqNu /o 9o @o Fo
+Æ &lt;  `  NuHçàø0&lt;  Cù   a 
+îLßNsHçÿþ0&lt; Cù   a 
+ÖLßÿNsv (*,.&amp;CIù   Kù  L$T4, 6l ´Kn(2  RB :fð´KnaL ÿo  n
+Xã\¸KoÆ `.SGka*`ø    fz v - Çü  Gù   ­ 0­ 0NuaéaØP REÜNu2  RB /o 9o @o Fo
+Æ &lt;  `  NuNqNqNqNsNqNqNqNu0&lt;  Aù   y    f,(y  ¨¹ù  ¬g&amp;\¹ü  ¸l#Ì  ¨`
+#ü  ¸  ¨NJNu(y  °¹ù  ´g &amp;\¹ü  ¸l#Ì  °`
+#ü  ¸  °NJ`ü    Nup t ~Eù  b9  ×  
+g
+  ga ðêCù  a6#Ä  Cù  2  Ã  Ö  fCù  `Cù  &quot;a#Ä  Nur v x z | 1 a þÔ f¶@lÈÀÊÀØHDÚD8&lt;  HDRA²mÖHD8HD`x Nur 49  (vEù  #Ê  3ü    3ü 
+  a Za tNux `xÿv`&amp;vxÿ` x¡`x¢`x£`x¤`x¥`
+x¦`x§`x¨vAù   Eù  v ü  ¶0ü  0ü @ Ê0ü  0ü 49   &quot;y  Ãra  êa Nu&quot;y  é   
+Gù °NJNu&quot;y  )  f$)   g)  f)  lR) Gù Z`é   
+Gù °NJNu&quot;y  |   )  
+fGù Z`Gù  NJNu&quot;y  |   Gù ZNJNu0&lt;  2&lt; 49  v Aù   &quot;y  rEù  #Ê  3ü    3ü -  a#É  rÔA3Â  a &quot;Nuü :z &lt;a2&lt;à^a,a(a$A  g
+8aSDfø
+EÿÿREa
+ü 
+ü 
+NuÚFè  0 9o Ç  0 9o ÇNuy   gaV`¹    vGù ZNJNua l y  9 ð  g| 4 `Cù   i   g| 4 `| 2 Gù ÆNJNuy   fa î y  Cù @r  g g. n  l6&lt; `0(  ¨n ¡m `&lt; `(   g&lt; `&lt; Âü xÒÁr 9    vfJ f  &gt; f  6  f  .9  °9  Nf  (  g&amp; g&lt; n  lJ&lt; `D&lt; ¹    v`6(  n  m ` &lt; `(  n m z`&lt; Âü ÒÁ&amp;QNJNu y  Cù p r 9  Àü ( A 0ÐA@  m ìØ@  n ìÐÀü ÒÀ&amp;QNJNqNu  X : X X X   X ¦ X X X  ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° °  ü ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° °  ü ° ° ° ° ° ° ° T ¤ Oþ P ¨ z ° Oþ ¶ ° ¨ P PZ PZ ° PD ° ° ° ° °   È È È È È È È È È È È È È È È È È È È È È È È È È È È È È ü È È È È È È È È È È È È È È È È È È È È È È È È È È È È È ü È È È È È È È È È È È È È È È È È È È È È È È È È È È È È ü ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° °  ü ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° X PZ ü ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ¨ ° ° ° ° P ü ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ¨ ° ° ° ° P ü 6 Oþ ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ¨ ü ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° °  ° ° ° ¬ ü ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° Z ° ° ° Z ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° °  ° ´ ü 6 Oþ ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ¨ ü È È È È È È È È È È È È È È È È È È È È È È È È È È È È È ü ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ¶ ° ° ° ° ° ° PD ° ° ° ° ° ° ZAù   0 
+Â9  t gF$Q4) ü   °   2 
+  gRB´i g3B Nu3|   a Gù jNJGù ®NJNu gl0   f0 Nu9  $i 4) °   RB´i g3B Nu3|   a  y  9 ð  g| 4 9  Nq`j  Gù ÆNJNu  g0$i 4) ´i g²   RB3B Nu3|   a ~Gù DNJNu g($i 4) ´i l²   RB3B Nu3|   a ôNu fNuAð  9   g*(  fJR9  9 
+  mB¹   ¹   `((  g R9  9   mù   ù   ü    9   g*(  gJR9  9 
+  mB¹   ¹   `((  f R9  9   mù   ù   ü    9    g,ü    9   gGù 	
+(y  °¹ù  ´gNL`NJ9    g(&amp;y  +   gSB `ü    Gù NJ(  BZ  ( NuNq0&lt;  Aù   ¼  9  t   
+Á  t0 NuAù   0&lt;  ¼   ¼   ¼ 0 ¼ 0 ¼  ¼  ¼   ¼   ¼  ¼  ¼ Z ¼   ¼ ° (  g¼ Ì `¼ » ¼ f ¼ @ ¼   ¼ À ¼ 0 ¼   
+ü    tNu9  t ý 
+¼   ¼  Á  t¹    vNu9  t þ 
+0  gø¼ 0 ¼ P   Á  t 
+¼  Nu9  t ï 
+Á  tNuNq0&lt;  Aù   9  t ý 
+¼   ¼ P   Á  t 
+ù    vv &amp;y  (k , Æüü#Ã  x¼  Nu9  t ï   Á  t 
+¼  #ü  X   ¬ü   ü    NuNq&amp;&lt;   SjüAù   0&lt;  9  t ß 
+¼   ¼     Á  t 
+¼  NuAù   0&lt;  9  t ß 
+¼ &quot; ¼ @ Á  tü    NuAù à p ¼ @| ÿ | ÿ  |   | T &quot;|   &amp;|   (| ð *| °  è    ¨  | P 
+|  |  Ð ü    +NuHçàÀAù à  ü   +LßNs49  *2Âü  2
+À À À À À 
+¼ ´y  ,g42`Ê3Â  .Åü  Cò  #É  2NuHç Gù à «    Gú NqNJLß NsAù à Eù   9   +g
+ü   +`9    +g(  gÐ ü    +a ÿP49  .Åü  02 3À  .Áü  Cò  #É  2)  
+g|  ) S o@ 49  .´y  ,m¼`L3é   0ü   Lü   iü   p(i ,   Vm  [n@ &quot;|   &amp;|   (| ð *`¨  | T &quot;|   &amp;| b (|   *| °  è    NuHç øGù ?`&quot;Hç øGù Cò`Hç øGù Fp`
+Hç øGù A|Aù à ¨    ¨  ¨  NJLß NsHçøøAù à 9  h9  ig(  g  ²  g$  g(  g,  g@  gD`lü   i`bü   i`Xü   i`Bü   i69  ,9  h `4ü   i`ü    iü   L| T &quot;¨  `| õ *  3`|  *|   (|   &amp;C | °  è    `¨    Gù HîNJLßNsHçøøAù à 9  o9  pg  g  d  g  g`0ü   p`&amp;ü   p`ü    pü   L| T &quot;¨  |  *|  (|   &amp;C | °  è    `¨    Gù KNJLßNsEù  &amp;y  k ÿü#Ê  ,k n ÿý5n 
+ÿþ&amp;y  *k ¹    Vr 2- ^Aü A mA or3Á  JÂí 
+p ÀSAnú0. a  k $y  t 49   ü a   ga Ø&#x27;H @ NuCù  
+|   a ®z v x p j  ðl  ÈCù  
+|   ¶m là¸y  NlØºm 
+lÒ  `fa °y  TnÀy  Rk¸Àü r 44  24 Cô  Bù  L09  Lt S@oá`öE  lÔù  J`C  gmçº`èº09  JS@oà`öRESAn¼09  PS@k
+REÔù  J`ò9   Hf ÿ&lt;09   a ` ÿ.g   ñg R  óg&lt;  ôg  v  õg  Ú  ög  Ü  ÷g  ä  øg  ê  ùg  ê  úg  ò` 9    Vga XáX@ g: $y  Àù  JÔÀáX@ g6 x C` þ 9    Vga Cù  
+p   ÿg   fé   : $y  Àù  JÔÀ`é    ÿg  mé  6 x C`é  a Þ` þ4áX` þ*áXa bp ` þ(áXa b` þ` þ&quot;y  Xÿý` ýô&quot;y  XÿþXÿÿCù  
+|   a |` ýÒ9    VgaJ.   f  Ú0- 
+Eo4ù    V3Å  X3À  \#Ê  ^Eù  Öz Cù  ÖÀù  JÅS@nú` ý|¹    V$y  ^E  gH| &lt;9  \ºFl&quot;2Âù  JERFü ÚFÚy  XÌù  JÔÆ`
+:2Âù  JCù  ÖSAnøNu:9  XNu9    Vg
+E  ga ÿv 6- my  Nkü `v x C` üäa  9    Vga ÿX|&#x27;H @ Eù  Nu&quot;zÌNqü   H`&quot;z¸Nqü    H3À   Àü (q  r 1 3Á  N^Aü A mA or3Á  Lr 1 3Á  P1 3Á  R1 3Á  TNujü  ül2  òm  óoT`æX`â  ífÜp @ nÀü ÐÀ`Ê   `ÆNuvj&quot;  íg  üo  :`  6C oU`  (   m    n  °f  
+HBf
+HBSfÚ| NuHBSgÆü ÐÃ|Nu2+ AmAÿn
+9    f6Hç p ) n ) °) n Q0  Aù  b0  R) `S) p Lß Nu2+ AmAÿn9    f Hç 8|   |   p 9   f9  Iù  2`TIù  :9     g.)   g)  g)  g`  ¦+  gØÀ9  `9  À  ü    @ &quot;r &amp;y  +ÿÿ gft Eù  b) °) l4  2   fR R`èS @ ) S °) o4  2   fS R`è@ +  ÿÿg+ ÿÿgRü B Lß NuEù  `*Eù  &lt;&amp;y  2Cù  .¹    Z¹    W`Eù  &amp;y  Cù   k ÿü#Ê  ,k n ÿý5n 
+ÿþ*k ¹    Vr - p - 	ÂÀ3Á  &lt;  ÀSnú k $y  t 4ü a ý ga ýP&#x27;H @ NuCù  |   a þ&amp;z v p j  ðlDCù  |   º- lâ¶- 	lÜ  `fa ý¢@ ßnÌ@  mÆ  lR`  mÀR`°g ¾  ñg   óg8  ôg&gt;  õg@  ög  ¤  ÷g  ¤  øg  ¤  ùg  ¤  úg  ¬` ê` ÿ\` ÿT9    Vga Cù  p   ÿg   fé   : `é    ÿg  mé  6 `é  - $y  ÔÅÀÃÔÀa ý` þê` þî` þÚ` þÒ(y  Xÿý` þÂ(y  XÿþXÿÿCù  |   a üÄ` þ 9    VgaR+  
+gù    WÅ  Zù    V3Å  Xp - Elp 3À  \#Ê  ^Eù  Öz .   f  ¼` þB¹    V$y  ^E  g4| &lt;9  \ºFl2ERFü ÔÆÚFÚy  X`:2Iù  ÖÜSAnúNu:9  XNu9    Vg
+E  g(a ÿv - 	gSCü p - $y  ÔÅÀÃÔÀ` ýºv - 	gSCü p - (y  Øù  XÀÃØÀ#Ì  ^` ýa  n  õg ý9    Vga ÿ2|&#x27;H @ 4. $zæNqÄü 2   f2 r  0Eð   Vf&quot; Ff Of Nf Tf
+&amp;y  a èNujü  ülN  òm  õg,  óoT`àX`Ü  ífÖp @ nÀü ÐÀ`Ä   `Àp   ÿg²°Cg®W&lt; õNuEù  &amp;y  k ÿü,k n ÿý5n 
+ÿþ*k rPp0ÀSAnú k Eù  t 49  ü a ùæ ga ù&#x27;H @ Nuz (&lt;0000ü    °v p j  ðl  ` nì  ,g:  0mà  9o  Dg  dfÎRCC nü   °`¼RCC ná `®S9   °fá&lt; Dà$ÄR`g     ñg    óg&lt;  ôg  B  õg  B  ög  B  ÷g  B  øg  B  ùg  B  úg  F`  Z` ÿ&lt;` ÿ4` ÿ,` ÿ$` ÿ` ÿØ  ` ÿØ  Ø  ` þø` þô` þð9   °fá&lt; Dà$ÄR|&#x27;H @ Eù  Nu 9  ë  
+    g2Cú~Nq i a  À   g#È  
+ü   |9    *g«  
+Nu 9  ë  
+    g*Cú6Nq i a  x   g#È  9    *g«  
+Nu 9  ë  
+    g*CúöNq i a8   g#È  9    *g «  
+`CúÌNq i #È  ü    |Nurx &quot;H ûgV ògZ ýg   íg\ þg4  m nvRjü ûoP üg^ ýg` þfZ²gnn\R`¨²lTR` r á`ááá`v  n$Æü ÐÃ`¦ òm  óoT`X`` ÿtRRDD dmAúþNq&quot;h p  INu Iü ü    *a öÐ  üo  gÝy  $ü   *a öt  þfØp INu:9  E  g,2 KpIú ìNq´g
+S@fø$H6`$ Jf PRSAfØNupIú ÂNq´gS@føRSAfè:&gt;A`&quot; Lf `
+ Jf P&gt;AR&amp;HSA:2 JpIú Nq´g&amp;S@føSAfêpIú ~Nq2 J´gSAføS@fî` ÿTASA,HG  g J 0m
+ Zn PRSGfèA  g ÿ&amp; N 0m
+ Zn RSAfè` ÿ !%&#x27;+,-./1:;IJLT_MNVWXYZRKBDPGSAQOUCHEF3245697809    Lg` n9  H9  JR9  6y    4y À  4n9  6gÞ` Ô3ü    4 y  @&quot;y  DSy  2y    2m8 !9   6frÿ`±gÚ#È  @#É  DÀ  HÁ  Jü    6`3ü   2 y  8&quot;y  &lt;ØRy  P09  R°y  Po  Zy  0y   0nhp r 9   6g² gÂ#È  8#É  &lt;$y  @°y  Fny  Dlp Àü 42  Aò ²y  Fny  Dlr Âü 42 Cò ` ÿ&amp;3ü    0y   .y   .n` ÿ|3ü    03ü    .3ü    P`  Xa 
+3ü    43ü   23ü    03ü    P3ü    .09  .2 Ãü 3Á  ,Aù  &lt;Eù  ¸Áü Cò  ` ÿ
+3ü    ,ü    6Aù à | T &quot;|   &amp;|   (| ð *| °  è    ¨  Nu g0&lt;@ `0&lt;  Ðy  ,Ðy  .Ðy  0Ðy  2Ðy  4ü    LAù à  |   &amp;|   (| ú *| °  è  è    Nu9    Lg` n9  H9  JR9  6y    4y    4m9  6gÞ` Ô3ü À  4 y  @&quot;y  DRy  2y   2n8 !9   6frÿ`±gÚ#È  @#É  DÀ  HÁ  Jü    6`3ü    2 y  8&quot;y  &lt;ØRy  P09  R°y  Po  [y  0y    0mhp r 9   6g² gÂ#È  8#É  &lt;$y  @°y  Fny  Dlp Àü 42  Aò ²y  Fny  Dlr Âü 42 Cò ` ÿ&amp;3ü   0y   .y    .m` ÿ|3ü   03ü   .3ü    P`  Xa 
+¤3ü À  43ü    23ü   03ü    P3ü   .09  .2 Ãü 3Á  ,Aù  &lt;Eù  ¸Áü Cò  ` ÿ
+3ü    ,ü    6Aù à | T &quot;|   &amp;|   (| ð *| °  è    ¨  Nu g0&lt;@ `0&lt;  Ðy  ,Ðy  .Ðy  0Ðy  2Ðy  4ü    LAù à  |   &amp;|   (| ú *| °  è  è    Nu9    Lg` v09  H29  JR9  6y   4y p  4n9  6gÞ` Ü3ü    4 y  @&quot;y  DRy  2y   2n8029   6frÿ`±AgÚ#È  @#É  D3À  H3Á  Jü    6`3ü    2 y  8&quot;y  &lt;ØRy  P09  R°y  Po  ¨y   0y  0nhp r 9   6g² gÀ#È  8#É  &lt;$y  @°y  Fny  Dlp Àü 42  Aò  ²y  Fny  Dlr Âü 42 Cò  ` ÿ$3ü    03ü    Py   .y   .nAù  &lt;` ÿn3ü    03ü    .`  Xa &amp;3ü    43ü    23ü    03ü    P3ü    .09  .2 Ãü 3Á  ,Aù  &lt;Eù  ¸Áü Cò  ` ÿ3ü   ,ü    6Aù à | T &quot;|   &amp;|   (| ð *| °  è    ¨  Nu g0&lt;@ `0&lt;  Ðy  ,Ðy  .Ðy  0Ðy  2Ðy  4ü    LAù à  |   &amp;|   (| ú *| °  è  è    Nu9    Lg` v09  H29  JR9  6y   4y    4m9  6gÞ` Ü3ü h  4 y  @&quot;y  DSy  2y    2m8029   6frÿ`±AgÚ#È  @#É  D3À  H3Á  Jü    6`3ü   2 y  8&quot;y  &lt;ØRy  P09  R°y  Po  ¨y   0y    0mhp r 9   6g² gÀ#È  8#É  &lt;$y  @°y  Fny  Dlp Àü 42  Aò  ²y  Fny  Dlr Âü 42 Cò  ` ÿ$3ü  03ü    Py   .y   .nAù  &lt;` ÿn3ü  03ü    .`  Xa ¨3ü h  43ü   23ü  03ü    P3ü    .09  .2 Ãü 3Á  ,Aù  &lt;Eù  ¸Áü Cò  ` ÿ3ü   ,ü    6Aù à | T &quot;|   &amp;|   (| ð *| °  è    ¨  Nu g0&lt;@ `0&lt;  Ðy  ,Ðy  .Ðy  0Ðy  2Ðy  4ü    LAù à  |   &amp;|   (| ú *| °  è  è    Nu9    Lf R9  h  3Aù à C ü    L|   &amp;|   (| õ *| °  è    r v ü    i9   jf
+Ã Ã  `Ã Ã 9  T9  U49  V&quot;y  XR o&gt;r 49  VRB´y  \mt R   fp `  opÀ  T3Â  Va ¨#É  XÁ  U1 fÃ r 9  ^9  _49  `&quot;y  bR   fp `B  o&lt;pR o,r 49  `RB´y  fm
+t ü   i3Â  `a 6#É  bÁ  _À  ^1 fÃ Ã  hNua Pv z Kù  :m nºy  .gü   j`Aù à | T &quot;`  ¨ü    j y  2p (h , 3À  \3À  fr Á  Ut 3Â  Va   #É  XpÀ  T1 fÃ pÀ  ^r Á  _t 3Â  `a  l#É  b1 fÃ Ã  hËü E@ 3Å  ,E Aù à  è  ü   iü    L|   &amp;|   (|  *| °  è    NuKù  &lt;x 5  ¸y  Fny  Dlx Èü $y  @&lt;2@ Cò` Nu9    Lf  Ò9  oÃ    Aù à C ü    L|   &amp;|  (|  *| °  è    r ü    p  9  k9  l9  m9  nS k  g`,p`(RAA m
+r ü   pa JÁ  lÂ  mÄ  nÀ  kf `Ã  ff `Ã Ã  oNu&amp;y  2+   
+g«   
+ù   +a ¹   +v z Aù à Kù  :m2 n,ºy  .g4 9    Wg9    ZgÃ `Ã `ü   p| T &quot;``Ã r Á  la  zÂ  mÄ  npÀ  kgÃ  fgÃ Ã  oC Ëü E@  è  ü   pü    L|   &amp;|  (|  *| °  è    NuKù  &lt;5  `m  `ô 0ftO²9  Zmx `Nu&amp;y  2p (k , 3À  R(k 0, &quot;zÖNqÀü #ñ    @r 1 3Á  D1 3Á  F+  
+g  ü9   +f ²«  
+a Ì¾¹   |   3ü    $9   Ögü    |p (k , 	fjt 49  .9   ÖfJ9   Öfa íê   g:`p#À  a î   g&amp;ù   t 49  .a íty    $n$p`p`
+pü    |#À  t 49  .a íÎ&#x27;y   &#x27;y   |   |  ü   6y   $f«  
+9    +f  ¸+ þ f  &quot;k +  
+g+  
+f  À&#x27;y  
+ `V+  
+g&#x27;k  |  |   `:+  
+g«  
+&#x27;y  
+ )   fd`,ë  
+&#x27;k  |  |   `
++  
+g  
+)   f6a æÌ&amp;y  2  g ÿ^9  9@ +  `Tü   Zù    W`ü    Z¹    W|   Aù  &lt;,k 1n 
+ÿþ. @ÿý@ r ¼   RAA mòNu y  |   Gù  NJNu y  (   l
+R Gù  `p è   
+Gù °@ NJNu y  |   Gù NJNu y  (   l
+R Gù `p è   
+Gù °@ NJNu PÊ QÊ R\ ¿b å| å¾ æú ò( 5 5 5 5 5 5 5  5¢                   ´µ±                                                                                                                                                                                                                                      @         
+(         @
+    (´  ` 0     ´@       ` Iµ  0 0     µ@       0 I±    (     ±@            ST i U ` Vâ ` X¶ ~ [ ` \ð	 ` `B
+ ` cò ` g°
+ ` kv ` o ` sº ` xL i z ~ |¤ i ~` ` . `   ~ h ~ Â ` ¢	 ` ô
+ ~ F } þ
+ } Ö } £* } ©Þ } °â } ¹ ~ »D ~ ½ `     £ ¨ ­ ² ³ µ · ¼ Á Ã Æ È Í Ñ Ô Ø Ü á å é í ñ õ ö ø û ÿ	&quot;&amp;*-159&gt;CGKPTX]afkpuz£§«¯³·¼   
+
+
+	
+
+
+
+
+
+
+
+
+
+
+
+	
+
+
+	
+	
+
+                                            ¢ ¥ ¨ « ° ¶ ¹ ¼ ¾ Ã É Í Ó Ù ß ä ê ð ö ü þ	
+$*05:@FJOUZahntz ¦¬²·¼ÁÆÊÑ   //???????$*?*363%*(!!&gt;&gt;&gt; 8000?!!?&quot;?? 2;)-&#x27;&amp;3!%?
+	??7%=?%%=19
+?%%?/))? ;6&quot;&quot;6)-?!)-/&lt;&gt;&gt;&lt;??%%??!!3??!!???%%!???!):????!??!0 ???3!??   ?????????!!???		?!1.??	?&amp;7%-;???  ?0????#66#&lt;&lt;!19-&#x27;#??!!!0!!!??````?!!!!!?ÿ        ¢ ¥ ¨ « ° ¶ ¹ ¼ ¾ Ä Ê Î Ô Ú à å ë ñ ÷ ý ÿ
+%+16;AGKPV[biou{¡§­³¸¾ÃÈÌÓ   __$**3fc6IV P&gt;AA&gt;&gt;&gt;&gt;@p0```0&gt;AA&gt;B@BcqYOF&quot;cII6/oIy1&gt;IIy2qy
+6II6&amp;OII&gt;66@v66cc6QY&gt;AYU_|~~|II6&gt;AAc&quot;AA&gt;IIA		&gt;AI;zAA `@?6cA@@@&gt;AA&gt;		&gt;A1^9oF&amp;oII{2?@@?0`000c66cxxaqYMGCAAA0`AAA@@@@AAAAAÿ À Ã Ä É Î Ó Ù Þ à ã æ ë ð ò ö ø ý
+#(-.048&lt;AFKPUZ^bglosx|¤©®³¸½ÃÈÍÒ×Ûàäèìðôøü 	
+#&#x27;*.38=AEJOTY   ¿ÿÿÿÿÿDJÿR&quot;Ã#ÄÃv` &lt;BB&lt;&quot;&quot;&gt;`ÀÀ ~~ÿÂ¡BvÿOp~rñ	vvN~$d(DD(¹~¹¥¿üüÿv~Bÿ~ÿÿ		~rÿÿÿ@ÿ$Bÿÿÿÿÿ~~ÿ			~¡A¾ÿ)IFrÿ?@@?ÿ`8`ÿÃ$$ÃðÁ¡ÿÿ ÿÿÿÿdøÿpxpÿxþ	¤¤|ÿðú@zÿ Pÿøððøðxxü$$$$üød~xx8@@8xpxP P  |È¨ÿ ÿ ÿUUUUU ÿ ÿ ªªªªªÿ        ¥ ¨ « ® ´ º ½ Â Ä Ê Ð Ô Ú à æ ì ò ø þ	&quot;(.4:?DJPTY_dkrx~£ª±·½ÂÈÍÔØß   ßßÿÿÿÿÿ$ÿ$ÿ$DJÿÿR&quot;Ãã0ÇÃ`ö®@ &lt;~~&lt;&quot;&quot;~~à`ÀÀ`0~ÿÿ~ÿÿÂã±BÃÿvÿÿOÏùp~ÿùráñvÿÿvNÿ~66æf8lÆÆl8ÑÙ~ÿ¹¥¾üþþüÿÿÿv~ÿÃBÿÿÿ~ÿÿÿÿ		~ÿsòÿÿÿÿÿÿ@Àÿÿÿ6ãÁÿÿÿÿÿÿÿÿ0ÿÿ~ÿÿ~ÿÿ		~ÿ¡¾ÿÿ9ïÆFÏûrÿÿÿÿ?`À`?ÿ00ÿÃç&lt;&lt;çÃøøÁá±ÿÿ0`ÿÿÿÿÿ     ¤ ° ¼ È Î Ö Þ ê ö ü
+&quot;*6BNZfr~ ¬¸ÄÔàìø&amp;2:DPZhv¦²¾ÊØæô &quot;,:DR      ÿÿÿÿÿÿ Dÿ Dÿ D  ÿÿ  b Ã ã 0  Æï9o Æ@    | þ þ | D ( þ þ ( D   ~ ~   À À      À ` 0    þÿÿ þÿÿ Ãa1 ÿ î 0 ( $þÿ   ñ à þÿó â  áù   îÿÿ î ÿ þ Ì Ì Ì Ì  8 l Æ $ $ $ $ $ $ Æ l 8   ±¹   þÿ»«¿ &gt;üþ # #þüÿÿÿ î þÿ ÿÿÿ þÿÿÿÿ    þÿ óò  ÿÿ  ÿÿÿÿ  ÿ ÿÿÿ 8 lÇÿÿ   ÿþ   þÿÿÿ  8 àÿÿ þÿÿ þÿÿ     þÿA ÿ~ÿÿ 1 qß ó â  ÿÿ   ÿÿ  ÿ ÿ ?  À À  ?ÿ ÿ ` 0 ` ÿÿÇ l 8 lÇ  ðð  Áqÿÿ    0 ` Àÿÿ ` 0    0 `ÿÿ     ¬ ¼ Ê Ø Þ æ î þ&quot;0&gt;FTbp~¨¶ºÀÌØäð *8DP^ltª¸ÆÔâðþ
+(8HXfp~ °      ??ÿÿÿÿÿÿÿ Ìÿÿ Ì Ìÿÿ Ì &gt;2ÿÿ2ò àÃ ` 0 Æï9oÆ    üþþ ü Ì xÿÿ x Ì 0 0 0þþ 0 0 0  0 0 0 0 0   À ` 0    üþþ üÿÿ Ãc333ÿÎ p x l fÿÿ `¿¿333óàþÿ333çÆ  ã ;  Îÿ333ÿÎ333ÿþ Ì Ì    p Ø Ì Ì Ì Ì Ì Ì Ø p    cs  þÿ3{K &gt;øü f c füøÿÿ333ÿÎþÿÿÿÿþÿÿ333ÿÿ 3 3 3 þÿ33óòÿÿ 0 0 0ÿÿÿÿ  ÿÿÿÿ 8 l Æÿÿ    ÿÿ  8 8 ÿÿÿÿ  8 àÿÿþÿÿþÿÿ 3 3 3 ? þÿCÿþÿÿ s ó³?¿333çÆ  ÿÿ  ÿÿ   ÿÿ  ? à à ? ÿÿ À p p Àÿÿ Ì x x Ì   ðð   Ãs;ÿÿ    0 ` Àÿÿ ` 0    0 `     ÿÿ     ® ¾ Ì Ü â ê ò&quot;&amp;4BN\jx¢°¾ÂÈÖâðþ*8FR^lz¨¸ÆÔâðþ&amp;6FVft~¤®¾      ÿÿÿÿÿÿÿÿÿÿþþþþ&lt;~fÿÿfæÆÀ ð &lt;Îqß
+      ðüü ð ðþþ ð ` ` `üü ` ` `    ` ` ` ` `    À ð &lt;  üþþüÿÿ  
+ãccÿ p x l fÿÿ `??333óàþÿcccçÆ  Ã ó ? ¿ócó¿&gt;cccÿþ  @ à°° à @  
+
+Ã c ? þÿó
+û
+
+ÿ þøü Æ Ã Æüøÿÿcccÿþÿÿÿÿþÿÿcccÿÿ c c c þÿccçæÿÿ ` ` `ÿÿÿÿ    ÿÿÿÿ à ð¼ÿÿ    ÿþ  p p þÿÿÿ &lt; ðÀÿÿþÿÿþÿÿ c c c  &gt;þÿ
+ÿþÿÿ ããc&gt;&gt;cccçÆ  ÿÿ  ÿÿ   ÿÿ ? ÿ   ÿ ?ÿÿÀÀÿÿ ð ð   ðð   Ãó?ÿÿ   &lt; ðÀ  ÿÿ À ` 0  0 ` À     ÿÿ     ¬ ¼ Ê Ú à è ð  $2@LZhx¢°¾ÂÈØäô .&lt;JVbp~ ¬¼ÊØæô*:JZjx¬¶Æ      ÿÿÿÿÿÿÿÿÿþþþþ&lt;~fÿÿfæÆÀ ð &lt;Îó     ðüüð ðþþ ð ` ` `üü ` ` `    ` ` ` ` `    À ð &lt;  þÿÿþÿÿ  ãccÿ à ð Ø Ì Æÿÿ À??333óàþÿcccçÆ  ã  ÿcccÿ~ÿÃÃÃÿþ  @ à°° à @  Ã c ? üþãó7þüøü Æ Ã Æüøÿÿcccÿþÿÿÿÿþÿÿcccÿÿ c c c þÿÃÃÇÆÿÿ ` ` `ÿÿÿÿ    ÿÿÿÿ àð¼ÿÿ    ÿþ  p p þÿÿÿ &lt; ðÀÿÿþÿÿþÿÿ c c c  &gt;þÿÿþÿÿ cãã&gt;&gt;cccçÆ  ÿÿ  ÿÿ   ÿÿ ÿ  ÿ ÿÿ  ÿÿ¸ðð¸   &lt;ðð &lt;  Ãó?ÿÿ   &lt; ðÀ  ÿÿ À ` 0 ` À     ÿÿ     ® ¾ Î Þ ä ì ô*.&gt;NZjzªºÊÚÞäô  0@P`p~¬¸ÆÖäö&amp;6FVbp¢²ÂÌÜæô       3ÿ3ÿ?ÿ?ÿ?ÿ?ÿ?ÿ?ÿ?ÿ?ÿ0üü00üü0|þÆ?ÿ?ÿÆÆ0&lt; À ð &lt;00 9ß q!¿6 ,    ðü&lt;00&lt;üð0àüüà0 À À Àøø À À À  &gt;   À À À À À À À À0 0 0 &lt;  À ð &lt;  üþ8008þü00?ÿ?ÿ0 0 08&lt;631ç0~0800Ã8Çþ&lt; à ð Ø Ì Æ?ÿ?ÿ À80c0c0c0cÃüþ90Ã0Ã8Ã  &gt;?ã {  ¾9ç0Ã0Ã9ç¾&lt;~0Ç0Ã0Ã8gþü  &gt; À`00 000000 00`À    33Ã g ~ &lt;üþ81ã3ó373þü?ø?ü?ü?ø?ÿ?ÿ0Ã0Ã0Ã9çþ&lt;üþ8008?ÿ?ÿ0008þü?ÿ?ÿ0Ã0Ã0Ã0Ã0?ÿ?ÿ Ã Ã Ã Ã üþ8011??ÿ?ÿ À À À À?ÿ?ÿ00?ÿ?ÿ00  0 0 0 ÿÿ?ÿ?ÿ À Àð&lt;&lt;0?ÿ?ÿ0 0 0 0 0 ?ÿ?ÿ &lt; ðà ð &lt;?ÿ?ÿ?ÿ?ÿ 8 ðÀ ?ÿ?ÿüþ8008þü?ÿ?ÿ Ã Ã Ã ç ~ &lt;üþ826&lt;þ7ü?ÿ?ÿ ÃÃÃç&lt;~0&lt;&lt;~8ç0Ã0Ã9Ç  ?ÿ?ÿ  ÿÿ8 0 8 ÿÿ ÿÿ &lt; &lt;  ÿ ÿ?ÿ?ÿ ÀàÀ ?ÿ?ÿ0&lt;&lt;ðð&lt;&lt;0  ? ð?À?À ð ? 8&lt;?3Ã0ó0?00?ÿ?ÿ000   &lt; ðÀ &lt; 0 000?ÿ?ÿ À ` 0 ` À0 0 0 0 0 0 ?ÿ       ?ÿ      ° À Ð à æ î ö,0@P\l|¬¼ÌÜàæø&amp;6FVfv¢²¾ÌÜêþ 0@P`p¤¸ÌÜæö 2        gÿgÿÿÿÿÿÿÿÿÿ0?þ?þ00?þ?þ00|0þ0Æÿÿ0Æ?Æ0&lt; À ð &lt;00 ?qß`qa¿6 ,    ðüx``xüð0àüüà0 À À Àøø À À À@ | &lt;  À À À À À À À À` ` 0 &lt;  À ð &lt;  ü?þp``p?þü``ÿÿ` ` `pxngaç`~`8p``ÃpÇ?þ&lt; à ð Ø Ì Æÿÿ Àÿ0ÿ`Ã`Ã`ÃpÃ? ü?þq`Ã`ÃpÃ?  ~ã {  ?¾qç`Ã`Ãqç?¾|0þaaapÇ?þü00@ |0&lt;0 À`00`@000000@`00`À    ggÃ g ~ &lt;ü?þpcãgóf7gþüøüüøÿÿ`Ã`Ã`Ãqç?þ&lt;ü?þp``p8ÿÿ```p?þüÿÿ`Ã`Ã`Ã`Ã`ÿÿ Ã Ã Ã Ã ü?þp`aa?ÿÿ À À À Àÿÿ``ÿÿ`` 8 p ` p ?ÿÿÿÿ ÀÀð&lt;x`ÿÿ` ` ` ` ` ÿÿ &lt; ðÀÀ ð &lt;ÿÿÿÿ  xà ÿÿü?þp``p?þüÿÿ Ã Ã Ã ç ~ &lt;ü?þpdlx?þoüÿÿ ÃÃÃçx~`&lt;&lt;0~pç`Ã`ÃqÇ?   ÿÿ   ÿ?ÿp ` ` p ?ÿÿÿÿ x x  ÿÿÿÿ àà ÿÿ`x&lt;pÀÀp&lt;x`   &lt; ðÀÀ ð &lt;  p|ocÃ`ó`?``ÿÿ```   &lt; ðÀ &lt; 0 ```ÿÿ  À ` 0 ` À ` ` ` ` ` ` ÿ@@@@@@@@ÿ      ° Ä Ö è î ö þ&amp;,&lt;@Rdp¦¸ÊÜî 
+,&gt;P`r¨¸ÈÚìø*&gt;PbtªºÌàô.&lt;N\n~        ÏÿÏÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ0?þ?þ00?þ?þ0 x`üaÎaÿÿÿÿas? Àð&lt; À ðà&lt;àà&gt;  áÀÿÁáÇ?Üp Ð    ð?üðÀÀð?üð0`À?ü?üÀ`0øøÀ ü &lt;  À À À À À À À ÀÀ À À ð &lt;  À ð &lt;  ?üþàÀÀÀàþ?üÀÀÿÿÿÿÀ À àðØÌÆÃÁçÀ~À0pàÀÁÁáþ&gt;|Àà°ÿÿÿÿ ÿ`ÿÀÃÀÃÀÃÀÃáÃ? ?üþãÁÁÁá&gt;   þÿã {  &gt;&lt;~ãÇÁÁÁãÇ~&gt;&lt; |`þÁÁÁÁàÇþ?ü00À ü0&lt;0 À`00`@````````@`00`À     ÏÏÃ ç ~ &lt;?üþàÇÃÏãÌgÏþüÿðÿøÿøÿðÿÿÿÿÁÁÁÁãÇþ&gt;|?üþàÀÀÀàp0ÿÿÿÿÀÀÀÀàþ?üÿÿÿÿÁÁÁÁÁÀÿÿÿÿ ?üþàÀÃÃÃÿÿÿÿÿÿÿÿÿÀÀÿÿÿÿÀÀ0 p à À À à ÿ?ÿÿÿÿÿÀð&lt;&lt;ðÀÿÿÿÿÀ À À À À À ÿÿÿÿ &lt; ðÀÀ ð &lt;ÿÿÿÿÿÿÿÿ &lt; ðÀ &lt; ÿÿÿÿ?üþàÀÀÀàþ?üÿÿÿÿÇ þ |?üþàÀÈØðþßüÿÿÿÿ=ÇðþÀ| |`þáÇÁÁÁã&gt;   ÿÿÿÿ   ?ÿÿà À À À à ÿ?ÿ ÿÿ &lt; ð ð &lt;  ÿ ÿÿÿÿÿ&gt;  ÀÀ &gt; ÿÿÿÿÀð&lt;&lt;pÀÀp&lt;&lt;ðÀ   &lt; ðÿÀÿÀ ð &lt;  àðüÏÃÃÀóÀ?ÀÀÿÿÿÿÀÀÀÀÀ   &lt; ðÀ &lt; ð À ÀÀÀÀÀÿÿÿÿ   À ` À  À À À À À À À À ÿÿÿÿ     £ ¨ ­ ² ³ µ · ¼ Á Ã Æ È Í Ñ Ô Ø Ü á å é í ñ õ ö ø û ÿ	&quot;&amp;*-159&gt;CGKPTX]afkpuz£§«¯³·¼   /????
+
+
+$*?*&quot;&quot;&#x27;+(!!*&gt;*&gt; 00 !!&quot;? &quot;1)&amp;!%%
+?&#x27;%%%%9%%)) &quot;
+
+
+
+&quot;-!-/&lt;
+	
+&lt;?%%!!&quot;?!!?%%!?!)9??!?!  ?
+1?   ????!!?		!).?	&amp;&quot;%%?   ??1
+
+181)%#!??!!! !!!??    ?!!!?                                     À Å Ê Ï Ô Ù Þ ã è í ò ÷ ü$).38=BGLQV[`ejoty~¡¦«°µº¿ÄÉÎÓØÝâçìñöû 
+#(-27&lt;AFKPUZ_dinsx}       _  $**#db6IV P      &quot;AA&quot;  &gt;&gt; @0     ``   &gt;AAA&gt; B@ BaQIF AIM3&#x27;EEE9&lt;JII0q	6III6II)     @4  &quot;A  A&quot;Y&gt;A]YN||III6&gt;AAA&quot;AAA&gt;IIIA			&gt;AAQq AA  @@@?&quot;A@@@@&gt;AAA&gt;			&gt;AQ!^	)F&amp;III2?@@@? @   ccxaQIECAAA AAA@@@@@AAA xx HH0 8DDH 0HH 8TTX ~	 8DT0 p  ú    @@&gt; (D    |xx |x 8DD8 | | | HTT$ ?D  &lt;@@&lt; @ &lt;@8@&lt;D((Dp DdTL  UUUUU   *****ÿ     £ ¨ ­ ² ³ µ · ¼ Á Ã Æ È Í Ñ Ô Ø Ü á å é í ñ õ ö ø û ÿ	&quot;&amp;*-159&gt;CGKPTX]afkpuz£§«¯³·¼   
+
+
+	
+
+
+
+
+
+
+
+
+
+
+
+	
+
+
+	
+	
+
+                                            £ ¥ ¨ « ° ¶ ¹ ¼ ¾ Ä Ê Î Ó Ø Þ ã é î ô ú ü ÿ!&#x27;-27=CGLRW^ekqw}¢¨®³¹¾ÃÇÎ   
+
+
+	
+
+	
+
+
+
+
+
+
+
+
+
+
+	
+	        ¢ ¥ ¨ « ° ¶ ¹ ¼ ¾ Ã É Í Ó Ù ß ä ê ð ö ü þ	
+$*05:@FJOUZahntz ¦¬²·¼ÁÆÊÑ   //???????$*?*363%*(!!&gt;&gt;&gt; 8000?!!?&quot;?? 2;)-&#x27;&amp;3!%?
+	??7%=?%%=19
+?%%?/))? ;6&quot;&quot;6)-?!)-/&lt;&gt;&gt;&lt;??%%??!!3??!!???%%!???!):????!??!0 ???3!??   ?????????!!???		?!1.??	?&amp;7%-;???  ?0????#66#&lt;&lt;!19-&#x27;#??!!!0!!!??````?!!!!!?ÿ À Ã Å Ê Ï Ô Ù Þ à ã æ ë ð ò õ ÷ ü
+#(-/159=BGLQV[`ejosx}¤©­²·¾ÄÊÐÕÚßäèíñõùý	
+ $(,047;@EJOSX]bg   __$**3fc6IV P&gt;AA&gt;&gt;&gt;p0```0&gt;A&gt;B@bsYOF&quot;cI6/oIy1&gt;Iy2qy6I6&amp;OI&gt;66v66cc6QY&gt;AYU_|~~|I6&gt;Ac&quot;A&gt;IIA		&gt;ASrAA `@?6c@@@&gt;A&gt;	&gt;A1^f&amp;oI{2?`??`?00c66cxxaqYMGCAAA0AAA@@@@AAA$TTxDD88DDD8DD8TTX~	HTT&lt;x} @@=(D|xx|x8DD8|||HTT$?D&lt;@@&lt; @ &lt;@8@&lt;D((DpDdTL  UUUUU   *****ÿ À Ã Ä É Î Ó Ù Þ à ã æ ë ð ò ö ø ý
+#(-.048&lt;AFKPUZ^bglosx|¤©®³¸½ÃÈÍÒ×Ûàäèìðôøü 	
+#&#x27;*.38=AEJOTY   ¿ÿÿÿÿÿDJÿR&quot;Ã#ÄÃv` &lt;BB&lt;&quot;&quot;&gt;`ÀÀ ~~ÿÂ¡BvÿOp~rñ	vvN~$d(DD(¹~¹¥¿üüÿv~Bÿ~ÿÿ		~rÿÿÿ@ÿ$Bÿÿÿÿÿ~~ÿ			~¡A¾ÿ)IFrÿ?@@?ÿ`8`ÿÃ$$ÃðÁ¡ÿÿ ÿÿÿÿH¨¨ðÿpppÿp¨¨°þ	¨¨xÿðú@zÿ Pÿøððøðppø((((øø¨¨Hþxx8@@8xpxP P  xÈ¨ÿ ÿ ÿUUUUU ÿ ÿ ªªªªªÿ        ¥ ¨ « ® ´ º ½ Â Ä Ê Ð Ô Ú à æ ì ò ø þ	&quot;(.4:?DJPTY_dkrx~£ª±·½ÂÈÍÔØß   ßßÿÿÿÿÿ$ÿ$ÿ$DJÿÿR&quot;Ãã0ÇÃ`ö®@ &lt;~~&lt;&quot;&quot;~~à`ÀÀ`0~ÿÿ~ÿÿÂã±BÃÿvÿÿOÏùp~ÿùráñvÿÿvNÿ~66æf8lÆÆl8ÑÙ~ÿ¹¥¾üþþüÿÿÿv~ÿÃBÿÿÿ~ÿÿÿÿ		~ÿsòÿÿÿÿÿÿ@Àÿÿÿ6ãÁÿÿÿÿÿÿÿÿ0ÿÿ~ÿÿ~ÿÿ		~ÿ¡¾ÿÿ9ïÆFÏûrÿÿÿÿ?`À`?ÿ00ÿÃç&lt;&lt;çÃøøÁá±ÿÿ0`ÿÿÿÿÿ     ¤ ° ¼ È Î Ö Þ ê ö ü
+&quot;*6BNZfr~ ¬¸ÄÔàìø&amp;2:DPZhv¦²¾ÊØæô &quot;,:DR      ÿÿÿÿÿÿ Dÿ Dÿ D  ÿÿ  b Ã ã 0  Æï9o Æ@    | þ þ | D ( þ þ ( D   ~ ~   À À      À ` 0    þÿÿ þÿÿ Ãa1 ÿ î 0 ( $þÿ   ñ à þÿó â  áù   îÿÿ î ÿ þ Ì Ì Ì Ì  8 l Æ $ $ $ $ $ $ Æ l 8   ±¹   þÿ»«¿ &gt;üþ # #þüÿÿÿ î þÿ ÿÿÿ þÿÿÿÿ    þÿ óò  ÿÿ  ÿÿÿÿ  ÿ ÿÿÿ 8 lÇÿÿ   ÿþ   þÿÿÿ  8 àÿÿ þÿÿ þÿÿ     þÿA ÿ~ÿÿ 1 qß ó â  ÿÿ   ÿÿ  ÿ ÿ ?  À À  ?ÿ ÿ ` 0 ` ÿÿÇ l 8 lÇ  ðð  Áqÿÿ    0 ` Àÿÿ ` 0    0 `ÿÿ À Æ Ê Ø è ø&quot;*:JPZ^lz¬ºÈÖäòöü ,&lt;JXft¨´ÀÎÚêø&quot;0&gt;JXhx¦°¾ÈÖàðþ
+&quot;.&lt;HTXdptª¶ÂÎÚæò&amp;26BR      ??ÿÿÿÿÿÿÿ Ìÿÿ Ì Ìÿÿ Ì &gt;2ÿÿ2ò àÃ ` 0 Æï9oÆ    üþþ ü Ì xÿÿ x Ì 0 0 0þþ 0 0 0  0 0 0 0 0   À ` 0    üþc3þ üÿÿ Ãc333ÿÎ p x l fÿÿ `¿¿333óãþÿ333çÆ  ãó   Îÿ333ÿÎ333ÿþ Ì Ì    p Ø Ì Ì Ì Ì Ì Ì Ø p    cs  þÿ3{K &gt;øü f c füøÿÿ333ÿÎþÿÿÿÿþÿÿ333ÿÿ 3 3 3 þÿ33óòÿÿ 0 0 0ÿÿÿÿ  ÿÿÿÿ x Ìÿÿ    ÿÿ  8 8 ÿÿÿÿ  8 àÿÿþÿÿþÿÿ 3 3 3 ? þÿCÿþÿÿ s ó³?¿333çÆ  ÿÿ  ÿÿ   ÿÿ  ? à à ? ÿÿ À p p Àÿÿ Ì x x Ì   ðð   Ãc3ÿÿ    0 ` Àÿÿ ` 0    0 `     ÿÿÐPPPðàÿÿ00ðààð0 àð00ÿÿàðPPp` 0 0þÿ 3 7 6 pPPððÿÿ 0 0ðàöö  ööÿÿ ` ðÿÿðð ` 0 à 0ààðð   0 0ðààððàðð   ð ` ` ð  ðððà 0 0 0  `ðÐÐÐ 0 0þþ 0 0ðð  ðð ðð  ð ððð ÀÀ ðð0àà00p@@ðð0°°pp0 0þÿßßÿþ 0 8 &lt;   0 0   ¾ Ä È Ø è ø$,&lt;LR\`n|¤²ÀÎÜêøü*8HVdrª¸ÄÒàîþ(6DRbp °¾ÈÖàîø(8HXhx¬°ÄÔäô$4DTdt¤¨¸      ÿÿÿÿÿÿÿÿÿÿþþþþ&lt;~fÿÿfæÆÀ ð &lt;ßósß 	    ðüü ð ðþþ ð ` ` `üü ` ` `    ` ` ` ` `    À ð &lt;  üþÇc7þüÿÿ  
+Ãc?ccÿ p x l fÿÿ `??333óãþÿcccçÆ  Ãã 3  ¿ócó¿&gt;cccÿþ  @ à°° à @  
+
+Ã c ? þÿó
+û
+
+ÿ þøü Æ Ã Æüøÿÿcccÿþÿÿÿÿþÿÿcccÿÿ c c c  þÿccçæÿÿ ` ` `ÿÿÿÿ     ÿÿÿÿ ðÿÿ     ÿþ  p p þÿÿÿ &lt; ðÀÿÿþÿÿþÿÿ c c c  &gt;þÿ
+ÿþÿÿãcw&gt;&gt;cccçÆ   ÿÿ   ÿÿ   ÿÿ ? ÿ   ÿ ?ÿÿÀÀÿÿ ð ð   ðð   Ãó?ÿÿ   &lt; ðÀ  ÿÿ À ` 0  0 ` À     ÿÿ °°°°°ðàÿÿ000pàÀàð0000p`Ààp000ÿÿàð
+0
+0
+0
+0
+ðà 0 0 0þÿ 3 3 6`ðððÿÿ ` 0 0 0ðàöö      ööÿÿ Àà0ÿÿðà 0 0ðà 0 0ðàðà p 0 0 0ðààð0000ðàðð°°°°ð à àð°°°°ðððà p 0 0 0 0 `à
+ð
+°
+°
+°
+°°  0 0 0ÿÿ 0 0 0ðð    ðððð    ðððð  ðð0`ÀÀ`0ð
+ð
+
+
+
+ðð00
+0
+0°°pp `þÿ¿¿ÿþ ` ¾ Ä È Ö æ ö$,&lt;LR\`n|¤´ÂÐÞìúþ 0&gt;N\jx¢°¾ÊØèô .&lt;LZjx¨¸ÊÖäðþ(8HXhx¬¼ÀØêú
+*:JZj~ ´ÄÈØ      ÿÿÿÿÿÿÿÿÿþþþþ&lt;~fÿÿfæÆÀ ð &lt;ßsó@À   ðüüð ðþþ ð ` ` `üü ` ` `    ` ` ` ` `    À ð &lt;  üþÃgþüÿÿ  Ãc?ccÿ à ð Ø Ì Æÿÿ ÀcccãÃþÿcccçÆ  Ã c ? ÿcccÿ~ÿÃÃÃÿþ  @ à°° à @  Ã c ? üþãó7þüøü Æ Ã Æüøÿÿcccÿþÿÿÿÿþÿÿcccÿÿ c c c  þÿÃÃÇÆÿÿ ` ` `ÿÿÿÿ     ÿÿÿÿ à°ÿÿ    ÿþ  p p þÿÿÿ &lt; ðÀÿÿþÿÿþÿÿ c c c  &gt;þÿÿþÿÿãccw&gt;&gt;cccçÆ   ÿÿ   ÿÿ   ÿÿ ÿ  ÿ ÿÿ  ÿÿ¸ðð¸   &lt;ðð &lt;  Ãc3ÿÿ   &lt; ðÀ  ÿÿ À ` 0 ` À     ÿÿ@`````àÀÿÿ```àÀÀà````àÀÀà```ÿÿÀà````à
+À ` ` `þÿ c g f
+Àà````ààÿÿ À ` ` `àÀìì      ììÿÿÀ`0ÿÿàÀ ` ` `ÀÀ ` ` `àÀàÀ à ` ` ` `àÀÀà````àÀàà````àÀÀà````àààÀ à ` ` ` à À	Àà`````@ ` ` `þþ ` ` `àà    àààà    àààà    àà `ÀÀ` àà    àà``````ààà` `þÿ¿¿ÿþ ` ¾ Ä È Ø è ø (0@PVfjz¦¶ÆÖæö 0&lt;L\l|¬¼ÌÜìø*&lt;L\l|®ÀÐâò,6DPbtª¼Îàòö6L^p¦¶ÈÚò,&gt;BT      3ÿ3ÿ?ÿ?ÿ?ÿ?ÿ?ÿ?ÿ?ÿ?ÿ0üü00üü0|þÆ?ÿ?ÿÆÆ0&lt; À ð &lt;009ó0ó3?6?&#x27;    ðü&lt;00&lt;üð0àüüà0 À À Àøø À À À  &gt;   À À À À À À À À0 0 0 &lt;  À ð &lt;  üþ;10Ã8gþü00?ÿ?ÿ0 0 &lt;&gt;310Ã0g0&gt;0800Ã8Çþ&lt; à ð Ø Ì Æ?ÿ?ÿ À80c0c0c0cÃüþ90Ã0Ã8Ã   ?Ã?ã 3  ¾9ç0Ã0Ã9ç¾&lt;~0Ç0Ã0Ã8gþü  &gt; À`00 000000 00`À    33Ã g ~ &lt;üþ81ã3ó373þü?ø?ü?ü?ø?ÿ?ÿ0Ã0Ã0Ã9çþ&lt;üþ8008?ÿ?ÿ0008þü?ÿ?ÿ0Ã0Ã0Ã0Ã00?ÿ?ÿ Ã Ã Ã Ã  üþ8011??ÿ?ÿ À À À À?ÿ?ÿ00?ÿ?ÿ00  0 0 0 0 ÿÿ?ÿ?ÿ Àà00?ÿ?ÿ0 0 0 0 0 0 ?ÿ?ÿ &lt; ðà ð &lt;?ÿ?ÿ?ÿ?ÿ 8 ðÀ ?ÿ?ÿüþ8008þü?ÿ?ÿ Ã Ã Ã ç ~ &lt;üþ826&lt;þ7ü?ÿ?ÿÃÃÃÃç0~ &lt;&lt;~8ç0Ã0Ã9Ç   ?ÿ?ÿ   ÿÿ8 0 0 0 8 ÿÿ ÿÿ &lt; &lt;  ÿ ÿ?ÿ?ÿ ÀàÀ ?ÿ?ÿ0&lt;&lt;ðð&lt;&lt;0  ? ð?À?À ð ? 8&lt;?3Ã0ó0?00?ÿ?ÿ000   &lt; ðÀ &lt; 0 000?ÿ?ÿ À ` 0 ` À0 0 0 0 0 0 ?ÿ       ?ÿ@?`3`3`3`3`3`à?À?ÿ?ÿ0`0`0`0`8àÀÀ?à0`0`0`0`0`8àÀÀ8à0`0`0`0`?ÿ?ÿÀ?à3`3`3`3`3`;àÀ À À À?þ?ÿ Ã Ã Ç ÆÀ;à3`3`3`3`3`?àà?ÿ?ÿ À ` ` ` à?À??ì?ì &gt; 0 0 0 0 0 ?ìì?ÿ?ÿÀ`00 ?ÿ?ÿ?à?À à ` `ÀÀ à ` `?à?À?à?À à ` ` ` ` ` à?À?À?à0`0`0`0`0`?àÀ?à?à`````àÀÀà`````?à?à?à?À à ` ` ` ` à ÀÀ;à2`2`2`2`2`&gt;àÀ ` ` `?þ?þ ` ` `à?à0 0 0 0 0 ?àààà  0   àààà0 0 0   0 0 0 àà  0`À
+  
+À0`  à;à3 2 2 2 3 ?àà8`8`&lt;`4`6`2`3`1à1à0à À Àþ?ÿ0000????0000?ÿþ À À ¾ Æ Ê Ú ê ú
+&quot;*2BRXhl| ²ÄÖèú04:LXjz®ÀÒäö*&lt;Pbv¬¾Òäø
+0DXjt ¬ÀÒäö,&gt;PTfx|¦¸ÊÜî &amp;8Pdv¢´        gÿgÿÿÿÿÿÿÿÿÿ0?þ?þ00?þ?þ00|0þ0Æÿÿ0Æ?Æ0&lt; À ð &lt;00?qó`sa¿fNxÀ?o    ðüx``xüð0àüüà0 À À Àøø À À À@ | &lt;  À À À À À À À À` ` 0 &lt;  À ð &lt;  ü?þsa`Ã`cp7?þü` ```ÿÿ` ` ` x|fca`Ã`g`&gt;`8p``Ã`Ãqç?&gt;àðÿÿÿ8ÿpÃ`Ã`Ã`ÃqÃ?ü?þq`Ã`Ã`ÃqÇ?   Ã c 3  ?¾qç`Ã`Ã`Ãqç?¾|8þqÇaaapÇ?þü00@ |0&lt;0 À`00`@000000@`00`À    ggÃ g ~ &lt;ü?þpcãgóf7gþüðøøðÿÿ`Ã`Ã`Ã`Ãsç?~&lt;ü?þp```p8ÿÿ````0üøÿÿ`Ã`Ã`Ã`Ã`Ã``ÿÿ Ã Ã Ã Ã Ã  ü?þp``aa?ÿÿ À À À À Àÿÿ```ÿÿ``` &gt; p ` ` ` p ?ÿÿÿÿÀ`00`@ÿÿ` ` ` ` ` ` ` ÿÿ &lt; ðÀÀ ð &lt;ÿÿÿÿ  xà ÿÿü?þp```p?þüÿÿ Ã Ã Ã Ã ç ~ &lt;ü?þpdlx0þ_üÿÿÃÃÃÃÃ0ç`~@&lt;&lt;0~pç`Ã`Ã`ÃqÇ?    ÿÿ    ÿ?ÿp ` ` ` p ?ÿÿÿÿ x p x  ÿÿÿÿ àà ÿÿ`x&lt;pÀÀp&lt;x`   &lt; ðÀÀ ð &lt;  p|ocÃ`ó`?```ÿÿ```   &lt; ðÀ &lt; 0 ```ÿÿ  À ` 0 ` À ` ` ` ` ` ` ÿ@@@@@@@@ÿ&lt;À~àf`f`f`f`f`?àÀÿÿ````````0À ?Àpà````````0À 0À````````ÿÿ?Ààf`f`f`f`f`wà3À ` ` `þÿ c c g f3Àwàf`f`f`f`f`à?àÿÿ À ` ` ` àÀìì &gt; p ` ` ` p ?ììÿÿ  
+À0``0@ÿÿàÀ ` ` `ÀÀ ` ` `ÀàÀ à ` ` ` àÀ?Àpà``````pà?Ààà`````àÀÀà`````àààÀ à ` ` ` ` à À3Àwàf`f`f`f`f`~à&lt;À ` ` ` `þþ ` ` ` `à?àp ` ` ` p ?àààà 0 ` 0  ààà?àp ` ` ? ? ` ` p ?àà@``À1    1`À@`3àwàf f f f f à?àp`p`x`l`d`f`b`c`aà`à`à Àü?þp```  ```p?þü À ¾ Æ Ê Ú ê þ$*2:Nbhx| ¬¾Ðâô*&lt;@FXhz®ÀÒäö,@Rfx°ÂÔèú 4H\p¢°ÂÒæú&quot;6J^r²¶Îâö
+2FZn°ÄØìð        ÏÿÏÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ0?þ?þ00?þ?þ0 x`üaÎaÿÿÿÿas? Àð&lt; À ðà&lt;àà&gt;?áãÀãÁÿÇ| 1ß Î    ð?üðÀÀð?üð0`À?ü?üÀ`0øøÀ ü &lt;  À À À À À À À ÀÀ À À ð &lt;  À ð &lt;  ?üþæÃÁÀÃàgþ?üÀÀÿÿÿÿÀ À ðøÌÆÃÁÀÇÀ~À&lt;0pàÀÁÁáþ&gt;|Àà°ÿÿÿÿ ÿ`ÿÀÃÀÃÀÃÀÃáÃ??üþãÁÁÁá&gt;   ÿÿÃ c 3  &gt;&lt;~ãÇÁÁÁãÇ~&gt;&lt; |`þÁÁÁÁàÇþ?ü00À ü0&lt;0 À`00`@````````@`00`À     ÏÏÃ ç ~ &lt;?üþàÇÃÏãÌgÏþüÿðÿøÿøÿðÿÿÿÿÁÁÁÁãÇþ&gt;|?üþàÀÀÀàp0ÿÿÿÿÀÀÀÀàþ?üÿÿÿÿÁÁÁÁÁÀÀÿÿÿÿ  ?üþàÀÃÃÃÿÿÿÿÿÿÿÿÿÀÀÀÀÿÿÿÿÀÀÀÀ8 x à À À À à ÿ?ÿÿÿÿÿÀ`00`ÀÿÿÿÿÀ À À À À À À ÿÿÿÿ &lt; ðÀÀ ð &lt;ÿÿÿÿÿÿÿÿ &lt; ðÀ &lt; ÿÿÿÿ?üþàÀÀÀàþ?üÿÿÿÿÇ þ |?üþàÀÈØðþßüÿÿÿÿ
+1aÇÀþ| |`þáÇÁÁÁã&gt;    ÿÿÿÿ    ?ÿÿà À À À à ÿ?ÿ ÿÿ &lt; ð ð &lt;  ÿ ÿÿÿÿÿ&gt;  ÀÀ &gt; ÿÿÿÿÀð&lt;&lt;pÀÀp&lt;&lt;ðÀ   &lt; ðÿÀÿÀ ð &lt;  àðüÏÃÃÀóÀ?ÀÀÿÿÿÿÀÀÀÀÀ   &lt; ðÀ &lt; ð À ÀÀÀÀÀÿÿÿÿ   À ` À  À À À À À À À À ÿÿÿÿyýÀÌÀÌÀÌÀÌÀÌÀÌÀÀÿÿÿÿÿÀÀÀÀÀÀÀÀÀÀáÀ? ? áÀÀÀÀÀÀÀÀÀÀÀa! ? áÀÀÀÀÀÀÀÀÀÀÀÿÿÿÿ? íÀÌÀÌÀÌÀÌÀÍÀo/  À À À Àÿþÿÿ Ã Ã Ï Î&#x27;oÀÌÀÌÀÌÀÌÀÌÀìÀÀ?Àÿÿÿÿ À À À ÀÀÿÿ ÿÌÿÌ&gt; ~ à À À À À à Ì?Ìÿÿÿÿ  
+À0``0ÀÿÿÿÿÿÀÿ À À À?? À ÀÀÿÿ ÿÀÿÀ À À À ÀÀÿÿ ? áÀÀÀÀÀÀÀÀÀáÀ? ÿÀÿÀÀÀÀÀÀÀÀÀÀÀÀÀÀÀÿÀÿÀÿÀÿÀ À À À À À gïÀÌÀÌÀÌÀÌÀÌÀÌÀýÀy À À À Àÿþÿþ À À À À?ÀÀà À À À À à À?ÀÀÀ0 ` À À ` 0 ÀÀ?ÀÀà À à ~ ~ à À à À?À@ÀÀa3    3 aÀÀ@#ÀgÀÎ Ì Ì Ì Ì Æ À?ÀàÀàÀðÀØÀÈÀÄÀÆÀÃÀÁÀÁÀ?üþàÀÀÀÀ@ þþ @ÀÀÀÀàþ?ü ¾ È Î æ þ0HRdv ª¼ÂÚî ,BXl²¸Ðäö
+&quot;:Pd|¨¼Ôêü$8Rj®ÂÖì4Nd|¢´ÈÜð,@Tfz¨¼Âàø&quot;6J^pºÎâö
+$          çÿçÿçÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ88ÿÿÿ88ÿÿÿ889ø{ü{þssÿÿÿÿÿÿss?Î àp8 ?¿ÿÿáãÃÿÇ?þü páÿ  0 8   ø?üþðàààÀÀàààðþ?üørvþü ø p p øüþvrÀÀÀøøøÀÀÀà ð ~ ~  ÀÀÀÀÀÀÀÀÀà à à À à p 8    À à p 8øþþðààðþþøàààÿÿÿÿÿÿà à à ðøüîçãáÇàïà~à~à80ppàáÇáÇáÇóïþ~&gt;&lt;àðøÿÿÿÿÿÿ1ÿqÿqÿáÇáÇáÇáÇóÇÿ??üþþóãããw&gt;    ÿÿÇÿç w ?  &gt;&lt;~ÿÿóïáÇáÇáÇáÇóïÿÿ~&gt;&lt;8|xþyþñïáÇáÇáÇáÇñÇþþ?üqÀqÀqÀð ð þà&gt;àà              Ààp88pàÀàààààààààÀàp88pàÀ &lt; &gt; ?  îîïÿ þ |?øüàÏÇßçßçÜçÜçÜçßîüøÿüÿþÿþÿþÿþÿüÿÿÿÿÿÿáÇáÇáÇóïþ~&gt;&lt;?üþþðààààðxx8ÿÿÿÿÿÿààààðxþ?üðÿÿÿÿÿÿáÇáÇáÇáÇàààÿÿÿÿÿÿÇÇÇÇÇ  ?üþþðààããó?ÿÿÿÿÿÿÀÀÀÀÀÿÿÿÿÿÿàààÿÿÿÿÿÿààà&gt; ~ ~ ð à à ð ÿÿ?ÿÿÿÿÿÿÿàp88pàÀÿÿÿÿÿÿà à à à à à à ÿÿÿÿÿÿ  8 p à p 8 ÿÿÿÿÿÿÿÿÿÿÿÿ øàÀ &gt; ÿÿÿÿÿÿ?üþþðààààðþþ?üÿÿÿÿÿÿÏþþ ü?üþþðàäìøpÿþÿþßüÿÿÿÿÿÿ9ÏpþàþÀ|8&lt;x~pþàïáÇáÇó&gt;    ÿÿÿÿÿÿ    ?ÿÿÿð à à à ð ÿÿ?ÿÿÿÿ8 p à p 8 ÿÿÿÿÿÿÿÿ      ÿÿÿÿÿàp88pàÀàp88pà ?  ÿÀÿÿ ÿÀ ÿ  ?ðøüîçãáÇàçàwà?ààÿÿÿÿÿÿàààààà    8 p àÀ  ààààààÿÿÿÿÿÿ          à à à à à à à à à à ÿÿÿÿyýÀýÀìÀÄÀÄÀìÀÀÿÀÿÿÿÿÿÿÿsáÀáÀóÀ?  óÀáÀáÀáÀss3 ? óÀáÀáÀsÿÿÿÿÿÿ? íÀÌÀÌÀíÀoo&#x27; ÀÀÿüÿþÿÿÇÇÏÎ&#x27; ooÍÀÌÀÌÀÍÀ? ÿÿÿÿÿÿÀÀÀÿÀÿÿ ÿÎÿÎÿÎ &lt; | ð à à ð Î?ÎÎÿÿÿÿÿÿ À8àppà8ÀÿÿÿÿÿÿÿÀÿÀÿÀÀÀÀÀÀÀÿÀÿÿ ÿÀÿÀÿÀÀÀÀÀÀÿÀÿÿ  óÀáÀáÀáÀóÀ ÿÀÿÀÿÀÀÀÀÀÀ  ÀÀÀÀÀÿÀÿÀÿÀÿÀÿÀÿÀÀ À ÀÀ # gïÀÌÀÌÀÌÀÌÀýÀy1 ÀÀÀÿüÿüÿüÀÀÀÀ?ÀÀð à à à ð À?ÀÀÀÀ?Àp à À à p ?ÀÀÀÀ?ÀÀð à ð ~ &gt; ~ ð à ð À?ÀÀÀÀáÀs?   ? sáÀÀÀ#ÀgÀïÀÎ Ì Î ç ÿÀÀ?ÀñÀñÀùÀéÀíÀåÀçÀãÀãÀáÀÀÀþÿÿÿÿðàà` þþþ `ààðÿÿÿÿþ À Ã Ä É Î Ó Ø Ý Þ á ä é î ð ó õ ú þ	
+!&quot;$(,05:&gt;BFJNRVZ]aeinsw{¢§¬±¶»¿ÄÈÌÐÔØÜàäåéíîó÷ûÿ!&amp;*/49&gt;   _$**#db6IV P&quot;AA&quot;&gt;&gt;@0`` &gt;AA&gt;B@rIIFAIM2
+&#x27;EE9&gt;II0y6II6II&gt;@4&quot;AA&quot;Y&gt;AYU^~		~II6&gt;AA&quot;AA&gt;III		&gt;AQ2AA @@?&quot;A@@@&gt;AA&gt;		&gt;Q!^)F&amp;II2?@@? @   ccxaQIECAAA AAA@@@@AAAxxHH08DDH0HH8TTX~	8DT0pz @@&gt;(D|xx|x8DD8|||HTT$?D&lt;@@&lt; @ &lt;@8@&lt;D((DpDdTL  UUUUU   ***** À Ã Ä É Î Ó Ø Ý Þ á ä é î ð ó õ ú þ	
+!&quot;$(,05:&gt;BFJNRVZ]aeinsw{¢§¬±¶»¿ÄÈÌÐÔØÜàäåéíîó÷ûÿ!&amp;*/49&gt;   _$**#db6IV P&quot;AA&quot;&gt;&gt;@0`` &gt;AA&gt;B@rIIFAIM2
+&#x27;EE9&gt;II0y6II6II&gt;@4&quot;A&quot;AY&gt;AYU^~		~II6&gt;AA&quot;AA&gt;III		&gt;AQ2AA @@?&quot;A@@@&gt;AA&gt;		&gt;Q!^)F&amp;II2?@@? @   ccxaQIECAAA AAA@@@@AAA$TTxDD88DDH8DD8TTX~	HTT&lt;x} @@=(D|xx|x8DD8|||HTT$?D&lt;@@&lt; @ &lt;@8@&lt;D((DpDdTL  UUUUU   *****        ¥ ¨ « ® ´ º ½ Â Ä Ê Ð Ô Ú à æ ì ò ø þ	&quot;(.4:?DJPTY_dkrx~£ª±·½ÂÈÍÔØß   ßßÿÿÿÿÿ$ÿ$ÿ$DJÿÿR&quot;Ãã0ÇÃ`ö®@ &lt;~~&lt;&quot;&quot;~~à`ÀÀ`0~ÿÿ~ÿÿÂã±BÃÿvÿÿOÏùp~ÿùráñvÿÿvNÿ~66æf8lÆÆl8ÑÙ~ÿ¹¥¾üþþüÿÿÿv~ÿÃBÿÿÿ~ÿÿÿÿ		~ÿsòÿÿÿÿÿÿ@Àÿÿÿ6ãÁÿÿÿÿÿÿÿÿ0ÿÿ~ÿÿ~ÿÿ		~ÿ¡¾ÿÿ9ïÆFÏûrÿÿÿÿ?`À`?ÿ00ÿÃç&lt;&lt;çÃøøÁá±ÿÿ0`ÿÿÿÿÿ ÃÊ   Ä   ÅN   Æ   ÆÒ   Ç   Ç¼    Çä    È    È4   È\   È|   È   È¼   ÈÜ   Èü   É(   ÉT   É   É¬   ÉØ   Éü    Ê     ÊD    Êh   Ê   Ê¨   ÊÄ   Êà   Êü   Ë   Ë:   Ë\   Ë~   Ë    ËÂ   ËÒ    ËØ    ËÞ    Ëä   Ëô
+   Ì
+    Ì
+    Ì0
+    ÌD
+   ÌX   Ì    Ì¨    ÌÐ    Ìø   Í    ÍH    Íp    Í    ÍÀ   Íè   Î&lt;    Î    Îä    Ï8   Ï   ÏÌ    Ð    ÐL    Ð   ÐÌ   Ñ     Ñt    ÑÈ    Ò   Òp   Òª    Òä    Ó    ÓX   Ó
+   Ó¸
+    ÓÞ
+    Ô
+    Ô*
+   ÔP   Ô¤    Ôø    ÕL    Õ    Õô   Ö(    Ö\    Ö    ÖÄ   Öø   ×    ×    ×&quot;    ×0   ×&gt;   ×n    ×    ×Î    ×þ   Ø.   ØR    Øv    Ø    Ø¾   Øâ   Ù6    Ù    ÙÞ    Ú2   Ú   Û    Û~    Ûú    Üv   Üò   Ý    Ý    Ý.    ÝB   ÝV   ÝÒ    ÞN    ÞÊ    ßF   ßÂ   à4    à¦    á    á   áü   â     ãD    ãè    ä   å0   å&gt;    åL    åZ    åh   åv     Âü ü ü ü ü øù þ þ ü@øÿ ÿ þ ü þ ù ùøÿÿþÿàÿ ø þ ú û ù û ú ú ü þ ú ú ú ü ü ü þ ÿüÿüÿüÿüÿüÿüÿüÿÿ þ ÿ þÿÿÿðþþÿÀÿÀÿþÿøÿøÿúÿþÿîÿúÿèÿøÿèÿðÿÀÿÿ ÿÿÀÿÀþ ÿÿÿþ@þ þ þ þ þ þ þ þ þ þ þ &gt;      Âü ü ü ü ü øù þ þ ü@øÿ ÿ þ ü þ ù ùøÿÿþÿàÿ ø þ ú û ù û ú ú ü þ ú ú ú ü ü ü þ ÿüÿüÿüÿüÿüÿüÿüÿÿ þ ÿ þÿÿÿðþþÿÀÿÀÿþÿøÿøÿúÿþÿîÿúÿèÿøÿèÿðÿÀÿÿ ÿÿÀÿÀþ ÿÿÿþ@þ þ þ þ þ þ þ þ þ þ þ &gt;      Âü ü ü ü ü øù þ þ ü@øÿ ÿ þ ü þ ù ùøÿÿþÿàÿ ø þ ú û ù û ú ú ü þ ú ú ú ü ü ü þ ÿüÿüÿüÿüÿüÿüÿüÿÿ þ ÿ þÿÿÿðþþÿÀÿÀÿþÿøÿøÿúÿþÿîÿúÿèÿøÿèÿðÿÀÿÿ ÿÿÀÿÀþ ÿÿÿþ@þ þ þ þ þ þ þ þ þ þ þ &gt;      Â                                                                                                                                                                                                Â                                                                                                                                                                                                (ü÷ôôÿôô÷ü  (ü÷ôôÿôô÷ü  (ü÷ôôÿôô÷ü  (                                      (                                         H$ .R&quot;  xÔ *É â      H$ .R&quot;  xÔ *É â      H$ .R&quot;  xÔ *É â                                                                 ,ø  À`0ÄIBe ¦0B#QÁ y   ,ø  À`0ÄIBe ¦0B#QÁ y   ,ø  À`0ÄIBe ¦0B#QÁ y   ,                                          ,                                          $àð$L333L3$ðà  $àð$L333L3$ðà  $àð$LL$ðà  $           0 0     0 0            $                                  @0N@Q! À @?À  @0N@Q! À @?À  @0N@Q! À @?À                                                      &quot; ?cþÇÿÆÏÆÆÆÀÆ f &gt;   0 ` 0   &quot; ?cþÇÿÆÏÆÆÆÀÆ f &gt;   0 ` 0   &quot; ?cþÇÿÆÏÆÆÆÀÆ f &gt;   0 ` 0   &quot;                                &quot;                                ..   ÿ   ÿ   ÿ                ¸ðð¸  ¸ðð¸  ¸ðð¸                                      (      ÀH` ££ @@        (      ÀH` ££ @@        (      ÀH` ££ @@        (                                      (                                      (  ÿðÿøü?þ?ÿ?ÿ?ÿÿÿ?&gt;?üøÿð        (  ÿðÿøü?þ?ÿ?ÿ?ÿÿÿ?&gt;?üøÿð        (  ÿðÿøü?þ?ÿ?ÿ?ÿÿÿ?&gt;?üøÿð        (                                      (                                      T»ß©UéZ  û!Uû  ûÞùÀø ø   ø    ø ¨  À°0HGâÿÿGâH0°À  T»ß©UéZ  û!Uû  ûÞùÀø ø   ø    ø ¨  À°0HGâÿÿGâH0°À  T»ß©UéZ  û!Uû  ûÞùÀø ø   ø    ø ¨  À°0HGâÿÿGâH0°À  T                                                                                  T                                                                                  @       @   &quot; f¤|
+81Ï`Ï81|
+¤f&quot;     @          @       @   &quot; f¤|
+81Ï`Ï81|
+¤f&quot;     @          @       @   &quot; f¤|
+81Ï`Ï81|
+¤f&quot;     @          @                                                              @                                                              T    À À À À À À À Á Á áHðù&quot;ñDøü°þ@ÿ?þ@ü°øñDá&quot;ðùHñ á À À À À À À À À À         T    À À À À À À À Á Á áHðù&quot;ñDøü°þ@ÿ?þ@ü°øñDá&quot;ðùHñ á À À À À À À À À À         T    À À À À À À À Á Á áHðù&quot;ñDøü°þ@ÿ?þ@ü°øñDá&quot;ðùHñ á À À À À À À À À À         T                                                                                  T                                                                                  :                    Àð  4@2Í³í·àí·Í³L, ðÀ  :                    Àð  4@2Í³í·àí·Í³L, ðÀ  :                    Àð  4@2Í³í·àí·Í³L, ðÀ  :                                                        :                                                        &amp;     8 | þþþüüøüüþþ þ | 8  &amp;     8 | þþþüüøüüþþ þ | 8  &amp;     8 | þþþüüøüüþþ þ | 8  &amp;                                    &amp;                                    T                 à  P P&gt;!!!&quot;&quot;$&quot;&quot;!!!&gt; P P                          T                 à  P P&gt;!!!&quot;&quot;$&quot;&quot;!!!&gt; P P                          T                 à  P P&gt;!!!&quot;&quot;$&quot;&quot;!!!&gt; P P                          T                                                                                  T                                                                                  4         Ô !Âÿ!Â Ô             4         Ô !Âÿ!Â Ô             4         Ô !Âÿ!Â Ô             4                                                  4                                                  
+`»h @@ ÿ  
+`»h @@ ÿ  
+`»h @@ ÿ  
+         ÿ  
+         ÿ  0 à  P P&gt;!!!&quot;&quot;$&quot;&quot;!!!&gt; P P      0 à  P P&gt;!!!&quot;&quot;$&quot;&quot;!!!&gt; P P      0 à  P P&gt;!!!&quot;&quot;$&quot;&quot;!!!&gt; P P      0                                              0                                              $þ@    ÿÿÿÿ~þþ?ü?üø            $þ@    ÿÿÿÿ~þþ?ü?üø            $þ@    ÿÿÿÿ~þþ?ü?üø            $                                  $                                  T                  #0#011003 6`f`f@F@F@F`F`F C c0c011ÄÀÀ ð &lt;     T                  #0#011003 6`f`f@F@F@F`F`F C c0c011ÄÀÀ ð &lt;     T                  #0#011003 6`f`f@F@F@F`F`F C c0c011ÄÀÀ ð &lt;     T                                                                                  T                                                                                  | @ F0&quot;3			003 3 # &#x27;`f`f@F@F@F@Ì@ÌÀÀÌÆÀFÀF@f@c@#`#`3 3 0°		
+À À À À à p 0   | @ F0&quot;3			003 3 # &#x27;`f`f@F@F@F@Ì@ÌÀÀÌÆÀFÀF@f@c@#`#`3 3 0°		
+À À À À à p 0   | @ F0&quot;3			003 3 # &#x27;`f`f@F@F@F@Ì@ÌÀÀÌÆÀFÀF@f@c@#`#`3 3 0°		
+À À À À à p 0   |                                                                                                                          |                                                                                                                          ÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ  ÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ  ÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ                                      |    üüüø 0?ÿ?ÿ    &lt;&lt;&lt;&lt;ü?ÿ?ÿ?ü?ü    ?ü?ü?ÿ?ÿ0 øüüø 0?ÿ?ÿ0   ÿÿÿ  0 ?ÿ?ÿ    ?&lt;&gt;&lt;&lt;&lt;1Ã?ÿ?ÿ?ÿ?ÿ?ÿ?ÿ  |    üüüø 0?ÿ?ÿ    &lt;&lt;&lt;&lt;ü?ÿ?ÿ?ü?ü    ?ü?ü?ÿ?ÿ0 øüüø 0?ÿ?ÿ0   ÿÿÿ  0 ?ÿ?ÿ    ?&lt;&gt;&lt;&lt;&lt;1Ã?ÿ?ÿ?ÿ?ÿ?ÿ?ÿ  |    üüüø 0?ÿ?ÿ    &lt;&lt;&lt;&lt;ü?ÿ?ÿ?ü?ü    ?ü?ü?ÿ?ÿ0 øüüø 0?ÿ?ÿ0   ÿÿÿ  0 ?ÿ?ÿ    ?&lt;&gt;&lt;&lt;&lt;1Ã?ÿ?ÿ?ÿ?ÿ?ÿ?ÿ  |                                                                                                                          |                                                                                                                          r  &gt;y&gt;|&gt;|&gt;y  ?ÿ?ÿ0 øüüø#ñ3ó?ÿ?ÿ?ü?ü    ?ü?ü?ÿ?ÿüü    üü?ÿ?ÿ? &lt; 0ÿÿÿ0ÿ&lt; ? ?ÿ?ÿ    &lt;&lt;&lt;&lt;ü?ÿ?ÿ  r  &gt;y&gt;|&gt;|&gt;y  ?ÿ?ÿ0 øüüø#ñ3ó?ÿ?ÿ?ü?ü    ?ü?ü?ÿ?ÿüü    üü?ÿ?ÿ? &lt; 0ÿÿÿ0ÿ&lt; ? ?ÿ?ÿ    &lt;&lt;&lt;&lt;ü?ÿ?ÿ  r  &gt;y&gt;|&gt;|&gt;y  ?ÿ?ÿ0 øüüø#ñ3ó?ÿ?ÿ?ü?ü    ?ü?ü?ÿ?ÿüü    üü?ÿ?ÿ? &lt; 0ÿÿÿ0ÿ&lt; ? ?ÿ?ÿ    &lt;&lt;&lt;&lt;ü?ÿ?ÿ  r                                                                                                                r                                                                                                                ¤  ¤  ¤  ¤                                                                                                                                                                  ¤                                                                                                                                                                  ÿÿÿÿÿÿÿÿÿÿ  ÿÿÿÿÿÿÿÿÿÿ  ÿÿÿÿÿÿÿÿÿÿ                          ÿ  
+      §   
+       ¦          ¦          J   ÿÿ ú ñEXCEEDED RANGEõPLEASE ENTERüñ     ü÷ ñ     ü÷ ôM      ü ú ñEXCEEDED RANGEõNEW DESTINATIONþ ñPLEASE CALLõ	911üñPLEASE CALLü÷ ñCALLü÷ ô 911÷ ô+PLEASE CALL POLICEüñPOLICEü÷ ñ911þ õ THIS SIGN IS NOTõ SELECTED..CHECK FILEüñCHECK FILEü÷ ô CHECK÷ ô
+	FILEü÷ ô CHECK FILEþý #HOOS GOT YOUR BACK!õP/R CODE 1üú  ù ÷ ô#HOOS GOT YOUR BACK!þ ñWELCOME BACK HOOS!õP/R CODE 2ü÷ ôWELCOME BACK HOOS!þ ñGO HOOS!õP/R CODE 3üö &lt;÷ 	ô.GO HOOS!ô ö &lt;þ NOW HIRING STUDENTS!õP/R CODE 4üù ÷ ôNOW HIRING STUDENTS!þ ñHAPPY HOLIDAYS!õP/R CODE 5üú  ù óÿÿ  ö U÷ ô!HAPPY HOLIDAYS!ô ö Uþ ñGO VOTE ON NOV. 5!õP/R CODE 6üú  ù ÷ 	ô	GO VOTE ON NOV. 5!þ ñACTIVE DETOURõP/R CODE 7ü÷ ñACTIVE DETOURüù ö ô ö sô ö sô ö sôö }ôN ö ôSö xô ö sô ö sôö sô ö þ ñHAPPY EARTH WEEK!õP/R CODE 8ü÷ 	ôHAPPY EARTH WEEK!þ ù ñDOWNLOAD TRANSLOCõP/R CODE 9üù ÷ ô	 DOWNLOAD THE TRANSLOCô
+APP FOR REAL-TIME INFOþ ñCLEAN COMMUTE MONTHõP/R CODE 10 PART 1üù ÷ ôCLEAN COMMUTE MONTHü ñ#CLEANCOMMUTECVILLEõP/R CODE 10 PART 2üù ÷ ô#CLEANCOMMUTECVILLEþ ñHAPPY NURSES WEEK!õP/R CODE 11ü÷ ôHAPPY NURSES WEEK!þ ñFOLLOW THE BUSõP/R CODE 12 PART 1ü÷ 	ôFOLLOW THE BUS!ü TWITTER AND INSTAGRAõP/R CODE 12 PART 2ü÷ ô TWITTER: @UVAUTSô	INSTAGRAM: @UVA.UTSþ  ñTEXT ALERTSõP/R CODE 13õ P/R CODE 13üù ÷ ñTEXT &#x27;&#x27;HEALTH&#x27;&#x27; TOô+434.939.4307üù ÷ ô FOR PARKING &amp; TRANSITô=ALERTSþ GOOD LUCK WITH EXAMSõP/R CODE 14ü÷ ôGOOD LUCK WITH EXAMS!þ  õ  HIRNG FULL TME DRVRSõP/R CODE 15üù #óÿÿ  ö &lt;÷ ô0 NOW HIRINGô ö &lt;ô	FULL TIME DRIVERS!þ ñELECTRIC BUSõP/R CODE 16ü÷ ô)BATTERY÷ ô\BUS÷ ô(ELECTRICþ ù 
+ñCONGRATS CASEY!õP/R CODE 17 PT 1üù 
+÷ ôCONGRATSô6 ö P÷ 	ô`CASEY!÷ ô	UTS GRADü ù 
+ñCONGRATS LIAM!õP/R CODE 17 PT 2üù 
+÷ ôCONGRATSô6 ö P÷ 	ôeLIAM!÷ ô	UTS GRADþ ù 
+ñCONGRATS JONAH!õP/R CODE 18 PT 1üù 
+÷ ôCONGRATSô6 ö P÷ 	ô`JONAH!÷ ô	UTS GRADü ù 
+ñCONGRATS BERNARD!õP/R CODE 18 PT 2üù ÷ ôCONGRATSô6 ö P÷ 	ôYBERNARD!÷ ô	UTS GRADü ù 
+ñCONGRATS BRIAN!õP/R CODE 18 PT 3üù ÷ ôCONGRATSô6 ö P÷ 	ôbBRIAN!÷ ô	UTS GRADþ ñELECTRIC BUSõP/R CODE 19ü÷ ô) BATTERY÷ 
+ô\ BUS÷ ô(ELECTRICþ IN LOVING MEMORY OF KELVINü÷ ô4 IN LOVINGô	MEMORY OF KELVINþ õ HAPPYõ RETIREMENTõBECCA WHITEü÷ ôHAPPY÷ ôGBECCA WHITE÷ ôRETIREMENTþ TRANSIT EMP. APPREC.õP/R CODE 22üù ô ö ÷ ôTRANSIT EMPLOYEEô ö ô	APPRECIATION DAYþ ù 
+ñREMEMBER DEVINõP/R CODE 17 PART 1üù 
+÷ 	ôREMEMBER DEVINü ù 
+ñREMEMBER D&#x27;SEANõP/R CODE 17 PART 2üù 
+÷ 	ôREMEMBER D&#x27;SEANü ù 
+ñREMEMBER LAVELõP/R CODE 17 PART 3üù 
+÷ 	ôREMEMBER LAVELü ù 
+ñUVA STRONGõP/R CODE 17 PART 4üù 
+ö &lt;÷ 	ô&quot;UVA STRONGô ö &lt;þû&lt; RAIL REPLACEMENT BUSõ DON&#x27;T USE THIS CODEüù ÷ ôRAIL REPLACEMENT BUSþûB ñHAPPY PRIDE MONTHõP/R CODE 22ü÷ ôHAPPY PRIDE MONTHþû PIPELINES &amp; PATHWAYSüù ÷ ôPIPELINES &amp;ôN ö nô ö dô	PATHWAYSþþ ñON DETOURõP/R CODE 407ü÷ ô# ON DETOURþûX ñGAME DELAYõP/R CODE 600ü÷ ñGAME DELAYü÷ ô GAME DELAYþûQ ú! ñTHANKS!õREAR P/R CODE 849ü÷ ôTHANKS!üú ô ö ô ö &lt;þýÿ õblanküüþ GRNñGREEN LINEõSTADIUM SERVICEüGRN÷ ñGREEN LINEü÷ ô	 GRNüù ÷ GRN÷ 	ô4GREEN LINEü GRNñHEREFORDõSTADIUM SERVICEüGRN÷ ô$ HEREFORDüù ÷ GRN÷ 	ô:HEREFORDü GRNñSCOTT STADIUMõSTADIUM SERVICEüGRN÷ ô SCOTT STADIUMüù ÷ GRN÷ 	ô&amp;SCOTT STADIUMü GRNñEMMET ST. SOUTHõSTADIUM SERVICEüGRN÷ ô EMMET ST. SOUTHüù ÷ GRN÷ 	ô#EMMET ST. SOUTHü GRNñRUGBY RD.õSTADIUM SERVICEüGRN÷ ô&quot; RUGBY RD.üù ÷ GRN÷ 	ô9RUGBY RD.ü GRNñMAD/PRESTONõSTADIUM SERVICEüGRN÷ ñMAD/PRESTONüù ÷ GRN÷ 	ô*MAD/PRESTONþ GRNñGREEN LOOPõ McCORMICK RD SERVICEüGRN÷ ô GREEN LOOPü÷ ô	 GRNü÷ GRN÷ 	ô2GREEN LOOPü GRNñ14TH ST.õ McCORMICK RD SERVICEüGRN÷ ô&amp; 14TH ST.ü÷ GRN÷ 	ôA14TH ST.ü GRNñJPA / HOSPITALõ McCORMICK RD SERVICEüGRN÷ ñJPA/HOSPITALü÷ GRN÷ 	ô#JPA / HOSPITALü GRNñCNTRL GRNDSõ McCORMICK RD SERVICEüGRN÷ ô CNTRL GRNDSü÷ GRN÷ 	ô-CNTRL GRNDSü GRNñRUGBY RD.õ McCORMICK RD SERVICEüGRN÷ ô&quot; RUGBY RD.ü÷ GRN÷ 	ô9RUGBY RD.üí GRN÷ ô õ MAD/PRESTONü÷ GRN÷ 	ô*MAD/PRESTONþ ORñORANGE LINEõSTADIUM SERVICEüOR÷ ô ORANGE LINEü÷ ô ORüù ÷ OR÷ 	ô)ORANGE LINEü ORñMAD/PRESTONõSTADIUM SERVICEüOR÷ ô MAD/PRESTONüù ÷ OR÷ 	ô%MAD/PRESTONü ORõ 14TH ST.õSTADIUM SERVICEüOR÷ ô&quot; 14TH ST.üù ÷ OR÷ 	ô;14TH ST.ü ORõ JPA / HOSPITALõSTADIUM SERVICEüOR÷ ñJPA / HOSPITALüù ÷ OR÷ 	ôJPA / HOSPITALü ORñSCOTT STADIUMõSTADIUM SERVICEüOR÷ ñSCOTT STADIUMüù ÷ OR÷ 	ô SCOTT STADIUMþ ORñORANGE LOOPõ McCORMICK RD SERVICEüOR÷ ñORANGE LOOPü÷ ô ORü÷ OR÷ 	ô&#x27;ORANGE LOOPü ORñMAD/PRESTONõ McCORMICK RD SERVICEüOR÷ ô MAD/PRESTONü÷ OR÷ 	ô%MAD/PRESTONü ORñRUGBY RD.õ McCORMICK RD SERVICEüOR÷ ô RUGBY RD.ü÷ OR÷ 	ô4RUGBY RD.ü ORñCNTRL GRNDSõ McCORMICK RD SERVICEüOR÷ ô CNTRL GRNDSü÷ OR÷ 	ô(CNTRL GRNDSü ORõ JPA / HOSPITALõ McCORMICK RD SERVICEüOR÷ ô JPA / HOSPITALü÷ OR÷ 	ôJPA / HOSPITALü ORõ 14TH ST.õ McCORMICK RD SERVICEüOR÷ ô% 14TH ST.ü÷ OR÷ 	ô;14TH ST.þ GOLDõ GOLD LINEõSTADIUM SERVICEüGOLD÷ ñGOLD LINEü÷ ô GOLDüù ÷ GOLD÷ 	ô=GOLD LINEü GOLDñBARRACKSõSTADIUM SERVICEüGOLD÷ ô% BARRACKSüù ÷ GOLD÷ 	ô=BARRACKSü GOLDõ NORTH GRNDSõSTADIUM SERVICEüGOLD÷ ñNORTH GRNDSüù ÷ GOLD÷ 	ô2NORTH GRNDSü GOLDõ JPJ / EIGõSTADIUM SERVICEüGOLD÷ ñJPJ / EIGüù ÷ GOLD÷ 	ô@JPJ / EIGü GOLDõ EMMET SOUTHõSTADIUM SERVICEüGOLD÷ ô EMMETô9 ST.ôF SOUTHüù ÷ GOLD÷ ô/EMMETô]STôl.ñSOUTHü GOLDñSCOTT STADIUMõSTADIUM SERVICEüGOLD÷ ñSCOTT STADIUMüù ÷ GOLD÷ 	ô0SCOTTô`STADIUMü GOLDñHEREFORDõSTADIUM SERVICEüGOLD÷ ñHEREFORDüù ÷ GOLD÷ 	ô?HEREFORDþ GOLDõ GOLD LINEõ McCORMICK RD SERVICEüGOLD÷ ñGOLD LINEü÷ ô GOLDüù ÷ GOLD÷ 	ô=GOLD LINEü GOLDñBARRACKSõ McCORMICK RD SERVICEüGOLD÷ ô% BARRACKSüù ÷ GOLD÷ 	ô=BARRACKSü GOLDõ NORTH GRNDSõ McCORMICK RD SERVICEüGOLD÷ ô NORTH GRNDSüù ÷ GOLD÷ 	ô4NORTH GRNDSü GOLDõ JPJ / EIGõ McCORMICK RD SERVICEüGOLD÷ ñJPJ / EIGüù ÷ GOLD÷ 	ô@JPJ / EIGü GOLDõ CNTRL GRNDSõ McCORMICK RD SERVICEüGOLD÷ ñCNTRL GRNDSüù ÷ GOLD÷ 	ô4CNTRL GRNDSü GOLDñHEREFORDõ McCORMICK RD SERVICEüGOLD÷ ñHEREFORDüù ÷ GOLD÷ 	ô?HEREFORDþí SLV÷ ô õ SILVER LINEü÷ ô	 SLVü÷ SLV÷ 	ô0SILVER LINEüí SLV÷ ñJPJ / EIGü÷ SLV÷ 	ô;JPJ / EIGüí SLV÷ ñEMMET ST. SOUTHü÷ SLV÷ ô&amp;EMMET ST. SOUTHüí SLV÷ ñHOSPITALü÷ SLV÷ 	ô;HOSPITALüí SLV÷ ô õ MADISON HALLü÷ SLV÷ 	ô(MADISON HALLþ GRN LINEñGREEN LINEõ McCORMICK RD SERVICEüGRN÷ ñGREEN LINEü÷ ô	 GRNü÷ GRN÷ 	ô4GREEN LINEü GRN LINEñHEREFORDõ McCORMICK RD SERVICEüGRN÷ ô$ HEREFORDü÷ ô	 GRNü÷ GRN÷ 	ô:HEREFORDü GRN LINEñCNTRL GRNDSõ McCORMICK RD SERVICEüGRN÷ ô CNTRL GRNDSü÷ ô	 GRNü÷ GRN÷ 	ô-CNTRL GRNDSü GRN LINEñRUGBY RD.õ McCORMICK RD SERVICEüGRN÷ ô&quot; RUGBY RD.ü÷ ô	 GRNü÷ GRN÷ 	ô9RUGBY RD.ü GRN LINEñMAD/PRESTONõ McCORMICK RD SERVICEüGRN÷ ô MAD/PRESTONü÷ ô	 GRNü÷ GRN÷ 	ô*MAD/PRESTONþí BLUE÷ ô( õ BLUE LINEü÷ ô BLUEüù ÷ BLUE÷ 	ô&gt;BLUE LINEüí BLUE÷ ô5 õ EIGüù ÷ BLUE÷ 	ôWEIGüí BLUE÷ ô&amp; õ HOSPITALüù ÷ BLUE÷ 	ô?HOSPITALþí RED÷ ô% õ RED LINEü÷ ô	 REDüù ÷ RED÷ 	ô=RED LINEüí RED÷ ñSTADIUMüù ÷ RED÷ 	ô?STADIUMüí RED÷ ô# õ HOSPITALüù ÷ RED÷ 	ô:HOSPITALþí PRP÷ ô õ PURPLE LINEü÷ ô	 PRPü÷ PRP÷ 	ô/PURPLE LINEþ PRPñPURPLE LINEõTO STD &amp; FONTüPRP÷ ô PURPLE LINEü÷ ô	 PRPü÷ PRP÷ 	ô/PURPLE LINEüí PRP÷ ñHOSPITALü÷ ô	 PRPü÷ PRP÷ 	ô;HOSPITALüí PRP÷ ô&amp; õ STADIUMü÷ ô	 PRPü÷ PRP÷ 	ô?STADIUMüí PRP÷ ô$ õ FONTAINEü÷ ô	 PRPü÷ PRP÷ 	ô;FONTAINEþí NP÷ ñNIGHT PILOTü÷ ô NPüù ÷ NP÷ 	ô+NIGHT PILOTüí NP÷ ñCNTRL GRNDSüù ÷ NP÷ 	ô(CNTRL GRNDSüí NP÷ ñHEREFORDüù ÷ NP÷ 	ô4HEREFORDüí NP÷ ñJPA / HOSPITALüù ÷ NP÷ 	ôJPA / HOSPITALüí NP÷ ô õ MADISON HALLüù ÷ NP÷ 	ô#MADISON HALLþí ÷ ñCHARTERüù ÷ ôCHARTERô
+ö #üù ÷ ô-CHARTERüù ÷ ôCHARTERô
+ö #üù ÷ ôCHARTERô#
+ö #þí ÷ ô õ SPECIALü÷ ôSPECIALü÷ ô/SPECIALþí ÷ ñUTS BUS ROADEOüñö &lt;ü÷ 	ôUTS BUS ROADEOþí ÷ ô õ NOT IN SERVICEü÷ ñNOT INôSERVICEü÷ ô	NOT IN SERVICEü÷ ô&quot; SORRYþ ñTRAINING BUSõNO PASSENGERSü÷ ô TRAINING BUSü÷ ñTRAININGôBUSü÷ ôTRAINING BUSü ñTRAINING BUSõNO PASSENGERSü÷ ô NO PASSENGERSü÷ ñTRAINING÷ ôBUSü÷ ôNO PASSENGERSü÷ ñTRAININGôBUSþí ÷ ñTEAM SHUTTLEü÷ ô TEAMôSHUTTLEü÷ ôTEAM SHUTTLEþ ñUNIVERSITY OFõVIRGINIAü÷ ô UNIVERSITY OFü÷ ô
+UVAüö &lt;÷ ô+ UNIVERSITY OFô ö &lt;÷ ô6VIRGINIAü÷ ô VIRGINIAüù ö &lt;÷ ô+ UNIVERSITY OFô ö &lt;÷ ô6VIRGINIAþí ÷ ñBUS FULLü÷ ñBUSôFULLü÷ ô+BUS FULLþ ñACCESSIBILITYõSHUTTLEüö Z÷ ñACCESSIBILITYüô ö üù ö ÷ ô&#x27; ACCESSIBILITY÷ ô9
+SHUTTLEþí ÷ ñFOOTBALL SHUTTLEüñö ü÷ ôFOOTBALL SHUTTLEþí ÷ ô
+ õ STAFF SHUTTLEü÷ ô
+ STAFFôSHUTTLEü÷ ôSTAFF SHUTTLEþí ÷ ô õ BASKETBALL SHUTTLEüñö 7ü÷ ôBASKETBALL SHUTTLEü ñBASKETBALL SHUTTLEþí ÷ ñTEST BUSü÷ ô TESTôBUSü÷ ô+TEST BUSüí ÷ ô õ NO PASSENGERSü÷ ôNO PASSENGERSþþ ñSUMMERõORIENTATION SHUTTLEü÷ ñSUMMERüñö ü÷ ñSUMMER ORIENTATION÷ ô9
+SHUTTLEüí ÷ ñORIENTATIONüí ÷ ô õ SHUTTLEþ ñEXCEEDED RANGEõPLEASE ENTERü÷ ô
+  ü÷ ô ü ñEXCEEDED RANGEõNEW DESTINATIONü÷ ô
+  ü÷ ô þí ÷ ôõ GRADUATION SHUTTLEü÷ ô GRADUATIONü÷ ô CONGRATSôGRADS!ü÷ ô SHUTTLEþí ÷ ô õ CLUB LEADERSü÷ ô
+ CLUBôLEADERSü÷ ôCLUB LEADERSþí ÷ ô õ INAUGURATIONüñö ü÷ ô INAUGURATION÷ ô:SHUTTLEüí ÷ ô õ SHUTTLEþþþí ÷ ñREUNION SHUTTLEüô ö ô ö ü÷ ôREUNION SHUTTLEþí ÷ ôõ LAW SCHOOL REUNIONü÷ ô LAW SCHOOLüô ö ü÷ ñREUNIONþí ÷ ô õ DAYS ON THE LAWNü÷ ô DAYS ONôTHE LAWNü÷ ôDAYS ON THE LAWNþþí ÷ ô õ JEFFERSON SYMPOSIUMü÷ óÿÞÿ÷JEF÷ ô JEFFERSONôSYMPOSIUMü÷ ôJEFFERSON SYMPOSIUMþí RED÷ ô% õ RED LINEü÷ ô	 REDü÷ RED÷ 	ô=RED LINEüí RED÷ ñSPECIALü÷ RED÷ 	ô?SPECIALüí RED÷ ñSTADIUMü÷ RED÷ 	ô?STADIUMüí RED÷ ô# õ HOSPITALü÷ RED÷ 	ô:HOSPITALþí ÷ ñWAHOO WALKü÷ ô WAHOOôWALKü÷ ô WAHOO WALKþí ÷ ô õ MEMORIAL SERVICE÷ ô9
+õSHUTTLEü÷ ô MEMORIAL SERVICEü÷ ñMEMORIALô	SERVICEþí ÷ ô
+ õ WINTER WANDERü÷ ô
+ WINTERô	WANDERüù óÿÿ  ö U÷ ôWINTER WANDERô ö Uþí ÷ ñHAPPY HOLIDAYS!ü÷ óÿå  HAPPY÷ ñHAPPYôHOLIDAYSüù óÿÿ  ö U÷ ô!HAPPY HOLIDAYS!ô ö Uþí ÷ ñSTAFF APPRECIATIONô6õBREAKFASTü÷ ôSTAFF APPRECIATIONüñö ü÷ ôBREAKFASTþ ñSTAFF APPRECIATIONõPICNICü÷ ô STAFF APPRECIATIONüñö ü÷ ôSTAFF APPRECIATIONü ñSTAFF APPRECIATIONõPICNICü÷ ñPICNICü÷ ô7PICNICþþþ ù ñEMERGENCYõON CAMPUSüù ÷ ô EMERGENCYüôö (üù ÷ ô EMERGENCYü ù ñEMERGENCYõON CAMPUSüù ÷ ô ON CAMPUSüù ÷ ô ON CAMPUSþí ÷ ô õ UTS HIRING EVENTü÷ ñUTS HIRINGô	EVENTü÷ ôUTS HIRING EVENTþí ÷ ñFAN SHUTTLEü÷ ñFAN÷ ô	SHUTTLEü÷ ôFAN SHUTTLEþþí ÷ ô õ UVA HEALTH AWARDSü÷ ñHEALTHô	AWARDSü÷ ôUVA HEALTH AWARDSþí ÷ ôõ UVA SERVICE AWARDSü÷ ñSERVICEôAWARDSü÷ ôUVA SERVICE AWARDSþû &lt; ñJPJ ARENAõFAN SHUTTLEü÷ ñJPJ ARENA SHUTTLEü÷ ñJPJ ARENAôSHUTTLEü÷ ô2 JPJ ARENA ÷ ô-
+FAN SHUTTLEþí ÷ ñNORTH GROUNDS÷ ô-
+õFAN SHUTTLEü÷ ô NORTH GROUNDSü÷ ñNORTHôGROUNDSü÷ ñFAN SHUTTLEü÷ ô FANôSHUTTLEþ ñFONTAINE RSRCH PARKõFAN SHUTTLEü÷ ñFONTAINE RSRCH PARKü÷ ô FONTAINEôSHUTTLEü÷ ô	 FONTAINE RESEARCH PARK÷ ô-
+FAN SHUTTLEþí ÷ ñMEDIA SHUTTLEü÷ ñMEDIAôSHUTTLEü÷ ôMEDIA SHUTTLEþí ÷ ñWAHOO WALKü÷ ô WAHOOôWALKü÷ ô WAHOO WALKþí ÷ ñFOOTBALL SHUTTLEüñö ü÷ ôFOOTBALL SHUTTLEþ NORTH GRNDS POSTGAMEõSHUTTLEü÷ ô JPJ-D3-PARK-DARDENüñö ü÷ ôJPJ-D3-THE PARK-DARDENþû dí ÷ ôUTS IS 100% STAFFED!ü÷ ñ100%÷ ô STAFFED!ü÷ ôUTS IS 100% STAFFED!þû yí ÷ ô õ TRANSIT 121ü÷ ô 121ü÷ ô TRANSIT 121þí ÷ ô õ TRANSIT 122ü÷ ô 122ü÷ ô TRANSIT 122þí ÷ ô õ TRANSIT 123ü÷ ô 123ü÷ ô TRANSIT 123þí ÷ ô õ TRANSIT 124ü÷ ô 124ü÷ ô TRANSIT 124þí ÷ ô õ TRANSIT 125ü÷ ô 125ü÷ ô TRANSIT 125þí ÷ ô õ TRANSIT 126ü÷ ô 126ü÷ ô TRANSIT 126þû í ÷ ô õ TRANSIT 141ü÷ ô 141ü÷ ô TRANSIT 141þí ÷ ô õ TRANSIT 142ü÷ ô 142ü÷ ô TRANSIT 142þí ÷ ô õ TRANSIT 143ü÷ ô 143ü÷ ô TRANSIT 143þí ÷ ô õ TRANSIT 144ü÷ ô 144ü÷ ô TRANSIT 144þí ÷ ô õ TRANSIT 145ü÷ ô 145ü÷ ô TRANSIT 145þû «í ÷ ô õ TRANSIT 171ü÷ ô 171ü÷ ô TRANSIT 171þí ÷ ô õ TRANSIT 172ü÷ ô 172ü÷ ô TRANSIT 172þí ÷ ô õ TRANSIT 173ü÷ ô 173ü÷ ô TRANSIT 173þí ÷ ô õ TRANSIT 174ü÷ ô 174ü÷ ô TRANSIT 174þí ÷ ô õ TRANSIT 175ü÷ ô 175ü÷ ô TRANSIT 175þí ÷ ô õ TRANSIT 176ü÷ ô 176ü÷ ô TRANSIT 176þí ÷ ô õ TRANSIT 177ü÷ ô 177ü÷ ô TRANSIT 177þþþí ÷ ñOUT OF SERVICEü÷ ô OUT OFôSERVICEü÷ ô	OUT OF SERVICEü÷ ô&quot; SORRYþí ÷ ô õ TRANSIT 181ü÷ ô 181ü÷ ô TRANSIT 181þí ÷ ô õ TRANSIT 182ü÷ ô 182ü÷ ô TRANSIT 182þí ÷ ô õ TRANSIT 183ü÷ ô 183ü÷ ô TRANSIT 183þí ÷ ô õ TRANSIT 184ü÷ ô 184ü÷ ô TRANSIT 184þí ÷ ô õ TRANSIT 185ü÷ ô 185ü÷ ô TRANSIT 185þí ÷ ô õ TRANSIT 186ü÷ ô 186ü÷ ô TRANSIT 186þí ÷ ô õ TRANSIT 187ü÷ ô 187ü÷ ô TRANSIT 187þí ÷ ô õ TRANSIT 188ü÷ ô 188ü÷ ô TRANSIT 188þþþí ÷ ô õ TRANSIT 191ü÷ ô 191ü÷ ô TRANSIT 191þí ÷ ô õ TRANSIT 192ü÷ ô 192ü÷ ô TRANSIT 192þí ÷ ô õ TRANSIT 193ü÷ ô 193ü÷ ô TRANSIT 193þí ÷ ô õ TRANSIT 194ü÷ ô 194ü÷ ô TRANSIT 194þí ÷ ô õ TRANSIT 195ü÷ ô 195ü÷ ô TRANSIT 195þû Éí ÷ ô õ TRANSIT 201ü÷ ô 201ü÷ ô TRANSIT 201þí ÷ ô õ TRANSIT 202ü÷ ô 202ü÷ ô TRANSIT 202þí ÷ ô õ TRANSIT 203ü÷ ô 203ü÷ ô TRANSIT 203þí ÷ ô õ TRANSIT 204ü÷ ô 204ü÷ ô TRANSIT 204þû-í ÷ ô
+ õ DRIVE FOR UTS!ü÷ ñDRIVEô
+4 UTS!ü÷ ôDRIVE FOR UTS!þí ÷ ñINTERNATIONAL÷ ôõFAMILIES RECEPTIONü÷ ô
+ INTERNATIONALüñö ü÷ ñFAMILIES RECEPTIONþí ÷ ô õ OPEN HOUSE TOURSü÷ ñOPENôHOUSEü÷ ôOPEN HOUSE TOURSþþ COMMUNITY BRIDGES 5Küú ÷ ñCOMMUNITY BRIDGESüô ö Aüú  ù #ô ö A÷ ô1 COMMUNITY÷ ôu 5K÷ ô3BRIDGESþ õ DANNY, WILL YOUõACCEPT THIS ROSE?üú ÷ DANNY, WILL YOU ACCüú ÷ óÿÿ  CEPT THIS ROSE?üô ö Füù ô ö F÷ ô5DANNY, WILL YOUô.	ACCEPT THIS ROSE?þ ñSEASON OF LOVEüú ô SEASON OF LOVEüôö Küù ôö K÷ ôSEASON OF LOVEôö Kþ ñCONGRATS, GRADS!üú ÷ ñCONGRATS, GRADS!üô
+ö Püù ÷ ôCONGRATS, GRADS!ô}ö Pþí ÷ ñGHOST-BUS-STERSüñö 2üù ÷ ô
+GHOST-BUS-TERSþþþí ÷ ô	 õ SPOOKY EXPRESSüô ö 2üù ô ö 2÷ ôSPOOKY EXPRESSô ö -üñö -üù ö -÷ ôSPOOKY EXPRESSô ö 2þ ñUNIVERSITYõTRANSIT SERVICEüú ÷ UNIVERSITY TRANSITüú ÷ óÿý  T SERVICEü÷ ô UTSüù ô ö &lt;÷ ô3 UNIVERSITYô ö &lt;÷ ôTRANSIT SERVICEþþþ ñPOLAR EXPRESSõNORTH POLEü÷ ñPOLAR EXPRESSü÷ ô
+ POLARôEXPRESSüù ÷ ô POLAR÷ ôF NORTH POLE ÷ ô EXPRESS÷ ô&lt;	via EDBROOKE AVE÷ ô EXPRESSü÷ ñto NORTH POLEü÷ ô via EDBROOKE AVEþ ñCONGRATSõUTS GRAD JONAH!ü÷ ñCONGRATS JONAH!üô
+ö Püù ÷ ôCONGRATSô6 ö P÷ ô`JONAH!÷ ô	UTS GRADþ ñCONGRATSõUTS GRAD CASEY!ü÷ ñCONGRATS CASEY!üô
+ö Püù ÷ ôCONGRATSô6 ö P÷ ô_CASEY!÷ ô	UTS GRADþ ñCONGRATSõUTS GRAD BERNARD!ü÷ ñCONGRATS BERNARD!üô
+ö Pü÷ ôCONGRATSô4ö P÷ ôVBERNARD!÷ ô	UTS GRADþ ñCONGRATSõUTS GRAD BRIAN!ü÷ ô CONGRATS BRIAN!üô
+ö Pü÷ ôCONGRATSô4ö P÷ ô`BRIAN!÷ ô	UTS GRADþ ñCONGRATSõUTS GRAD LIAM!ü÷ ñCONGRATS LIAM!üô
+ö Püù ÷ ôCONGRATSô4ö P÷ ôcLIAM!÷ ô	UTS GRADþ ñCONGRATSõUTS GRAD CALLIE!ü÷ ñCONGRATS CALLIE!üô
+ö Pü÷ ôCONGRATSô4ö P÷ ô\CALLIE!÷ ô	UTS GRADþ IN LOVING MEMORY OF KELVINü÷ ô IN LOVING MEMORYüôö Kü÷ ô7 IN LOVINGô MEMORY OF KELVINü÷ ñOF KELVINþþí ÷ ñTIMECARDSü÷ ô TIMECARDSüí ÷ ô!õ PLEASEü÷ ô@PLEASEþû õ PIPELINES &amp; PATHWAYSü÷  ôPIPELINES&amp;PATHWAYSüóÿø  ö iö düù ÷ ôPIPELINES &amp;ôK ö nô ö dô	PATHWAYSþû BLUEñBLUE LINEõ	SPECIALüBLUE÷ ñBLUE SPECIALü÷ ô BLUEü÷ BLUE÷ ôI BLUE LINE÷ ôN	SPECIAL÷ 	ô SPECIALü BLUEñEIG/JPJ ARENAüBLUE÷ ô EIG/JPô; J ARENAü÷ ô BLUEü÷ BLUE÷ 	ô.EIG/JPôcJ ARENAüí BLUE÷ ô&amp; õ HOSPITALü÷ ô BLUEü÷ BLUE÷ 	ô?HOSPITALþí ÷ BLUE÷ ôI õ BLUE LINE÷ ôN	õ	SPECIALüBLUE÷ ñBLUE SPECIALü÷ ô BLUEüí BLUE÷ ô$ õ JPJ ARENAü÷ ô BLUEü÷ BLUE÷ 	ô&lt;JPJ ARENAüí BLUE÷ ô# õ HOSPITALü÷ ô BLUEü÷ BLUE÷ 	ô?HOSPITALþûôí ÷ ñBUS-BUS SLIDEü÷ ôBUS-BUS SLIDEþí ÷ ô
+ õ BLINK RIGHT &gt;&gt;&gt;ü÷ ôBLINK RIGHT &gt;&gt;&gt;þí ÷ ñ&lt;&lt;&lt; BLINK LEFTü÷ ô&lt;&lt;&lt; BLINK LEFTþí ÷ ñCRISS-CROSSü÷ ôCRISS-CROSSþí ÷ óÿö  BUS DANCE REAL SMOOTHüô ö ÷ ô6 BUS DANCEô ö ô0REAL SMOOTHþí ÷ ñCRUISE TO THE RIGHTü÷ óÿú CRUISE TO THE RIGHTþûM ñUNIVERSITYõTRANSIT SERVICEüú8 ö ô_ö üú üú ÷ UNIVERSITY TRANSITüú ÷ óÿý  T SERVICEü÷ ô UTSüù ö &lt;÷ ô3 UNIVERSITYô ö &lt;÷ ôTRANSIT SERVICEþûQí ÷ ô õ SPOOKLE EXPRESSüù ö -üù ô ö -÷ ô.SPOOKLEô ö -üù ô  ö -üù ô ö -÷ ô.SPOOKLEô ö -üù ö 2üù ô ö 2÷ ô.EXPRESSô ö 2üù ô ö 2üù ô ö 2÷ ô.EXPRESSô ö 2þûÁí ÷ ô
+HAPPY BIRTHDAY LAUREN!ü÷ ô HAPPY BDAY LAURENü÷ ô LOBOþûí ÷ ñstruggle busü÷ ñi&#x27;môstrugglingü÷ ôstruggle busþû5í ÷ FART÷ ô: õ FONTAINE AREAô:õRAPID TRANSITüFART÷ ô&#x27; FONTAINEü÷ ô FARTüí ÷ FART÷ 	ô@õ FONTAINEüFART÷ ô5 JPJü÷ ô FARTüí ÷ FART÷ 	ôWõ
+ JPJü÷ ô FARTþûðí ÷ ô õ SIC SEMPER TYRANNISü÷ SIC SEMPERôTYRANNISü÷ ôSIC SEMPER TYRANNISþû EXõ CTAV EXPOõ 33õVIA FREEWAYü33÷ ô CTAV EXPOü÷ ô 33ü÷ 33÷ ôCTAV EXPO÷ ôxVIAôj	FREEWAYü33÷ ô VIA FREEWAYþûm GRNñLAST STOP:õSHANNON LIBüGRN÷ ô  LAST STOP:ü÷ ô GRNü÷ GRN÷ ôA LAST STOP:ô-SHANNON LIBRARYüGRN÷ ô SHANNON LIBþí ÷ GRN÷ ôA õ LAST STOP:ô9õMAD/PRESTONüGRN÷ ô  LAST STOP:ü÷ ô GRNüGRN÷ ô MAD/PRESTONü÷ ô GRNþí ÷ GRN÷ ôA õ LAST STOP:ôLõ	CHAPELüGRN÷ ô  LAST STOP:ü÷ ô GRNüGRN÷ ñCHAPELþí ÷ GRN÷ ôA õ LAST STOP:ôEõHOSPITALüGRN÷ ô  LAST STOP:ü÷ ô GRNüGRN÷ ô$ HOSPITALþûøí ñBATTLESHIP!ü÷ ô BATTLEô
+SHIP!üù ö 
+ô&#x27; ö  üí ñBATTLESHIP!ü÷ ô BATTLEô
+SHIP!üù ÷ ô BATTLESHIP!þû
+ EXõ DOWNTOWN õ 33õVIA FREEWAYü33÷ ñDOWNTOWNü÷ ô 33ü÷ 33÷ ôDOWNTOWN÷ ôxVIAôj	FREEWAYü33÷ ô VIA FREEWAYþûUí ÷ OR÷ ô; õ LAST STOP:ô3õMAD/PRESTONüOR÷ ô LAST STOP:ü÷ ô ORüOR÷ ô MAD/PRESTONþí ÷ OR÷ ô; õ LAST STOP:ô/õSCOTT STADIUMüOR÷ ô LAST STOP:ü÷ ô ORüOR÷ ñSCOTT STADIUMþû=í ÷ OR÷ ô; õ LAST STOP:ô@õHOSPITALüOR÷ ô LAST STOP:ü÷ ô ORüOR÷ ô  HOSPITALþ ORñLAST STOP:õSHANNON LIBüOR÷ ô LAST STOP:ü÷ ô ORü÷ OR÷ ô; LAST STOP:ô&#x27;SHANNON LIBRARYüOR÷ ô SHANNON LIBþí ÷ OR÷ ô; õ LAST STOP:ô3õMAD/PRESTONüOR÷ ô LAST STOP:ü÷ ô ORüOR÷ ô MAD/PRESTONþû%í ÷ GOLD÷ ôF õ LAST STOP:ôIõBARRACKSüGOLD÷ ñLAST STOP:ü÷ ô GOLDüGOLD÷ ô% BARRACKSþû
+ GOLDñLAST STOP:õMCCORMICK DORMSüGOLD÷ ñLAST STOP:ü÷ ô GOLDü÷ GOLD÷ ôJ LAST STOP:ô7McCORMICK DORMSüGOLD÷ ñMcCORMICKüGOLD÷ ô. DORMSþí ÷ GOLD÷ ôF õ LAST STOP:ô9õGOOCH/DILLARDüGOLD÷ ñLAST STOP:ü÷ ô GOLDüí ÷ ô GOLDüGOLD÷ ôGOOCH/DILLARDþí ÷ GOLD÷ ôF õ LAST STOP:ôBõLILE-MAUPINüGOLD÷ ñLAST STOP:ü÷ ô GOLDüGOLD÷ ô  LILE-MAUPINþûõí ÷ SLV÷ ôA õ LAST STOP:ôVõ
+JPJüSLV÷ ñLAST STOP:ü÷ ô SLVüSLV÷ ô2 JPJþû&#x27; ñUTS EMERGENCYõDISPATCH CENTERüú ÷ UVA TRANSIT EMEüú ÷ óÿü  ERGENCY DISPATCHüú ÷ óÿû  H CENTERü÷ ô EDCü÷ ô2 UVA TRANSITôEMERGENCY DISPATCH CENTERü÷ ô UVAôTRANSITþýýÿýÿýÿýÿýÿýÿýÿýÿ</td><td>16</td><td>3</td><td>4</td></tr>
+</tbody></table>
+</section>
+</body></html>


### PR DESCRIPTION
## Summary
- add a pre-generated ips.html that breaks down the luminator.ips Access database into human-readable tables
- load the new HTML asset in FastAPI and expose it at /ips for easy viewing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e07b766918833388a68d23e9afde0e