### PR TITLE
Align column widths between downed vehicle tables

### DIFF
--- a/downed.html
+++ b/downed.html
@@ -336,6 +336,27 @@ function getStatusClass(text){
   return '';
 }
 
+function getVisibleColumns(section){
+  if(!section || !Array.isArray(section.headers)) return [];
+  return section.headers
+    .map((text,index)=>({ text, index }))
+    .filter(col=>!isHiddenHeader(col.text));
+}
+
+function computeSharedColumnWidths(sections){
+  const lookup=new Map();
+  sections.forEach(section=>{
+    const visible=getVisibleColumns(section);
+    const count=visible.length;
+    if(!count || lookup.has(count)) return;
+    const width=100/count;
+    lookup.set(count, Array.from({length:count},()=>width));
+  });
+  return lookup;
+}
+
+let sharedColumnWidthsByCount=new Map();
+
 function renderSection(section){
   const wrapper=document.createElement('section');
   const title=section.title ? String(section.title).trim() : '';
@@ -358,9 +379,18 @@ function renderSection(section){
   const table=document.createElement('table');
   const thead=document.createElement('thead');
   const headRow=document.createElement('tr');
-  const visibleColumns=section.headers
-    .map((text,index)=>({ text, index }))
-    .filter(col=>!isHiddenHeader(col.text));
+  const visibleColumns=getVisibleColumns(section);
+  const widthConfig=sharedColumnWidthsByCount.get(visibleColumns.length);
+
+  if(widthConfig && widthConfig.length===visibleColumns.length){
+    const colgroup=document.createElement('colgroup');
+    widthConfig.forEach(value=>{
+      const col=document.createElement('col');
+      col.style.width=`${value}%`;
+      colgroup.appendChild(col);
+    });
+    table.appendChild(colgroup);
+  }
 
   visibleColumns.forEach(col => {
     const text=abbreviateHeaderLabel(col.text);
@@ -454,6 +484,8 @@ function renderSheet(data){
       return a.index-b.index;
     })
     .map(item=>item.section);
+
+  sharedColumnWidthsByCount=computeSharedColumnWidths(orderedSections);
   orderedSections.forEach(section => {
     sectionsContainer.appendChild(renderSection(section));
   });


### PR DESCRIPTION
## Summary
- derive visible column metadata for each section of the downed vehicles sheet
- compute shared column width templates and apply them through colgroup elements
- ensure bus and support vehicle tables keep consistent column widths

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0836ae034833394c603ecd73635ea