### PR TITLE
Align grid view to top-left

### DIFF
--- a/eink-block.html
+++ b/eink-block.html
@@ -32,7 +32,9 @@
     width:auto;
     min-width:280px;
     height:auto;
-    padding:12px;
+    padding:0;
+    align-items:flex-start;
+    justify-content:flex-start;
   }
   main{
     width:100%;
@@ -45,6 +47,7 @@
   body.grid-mode main{
     height:auto;
     justify-content:flex-start;
+    align-items:flex-start;
     padding:0;
   }
   [hidden]{
@@ -82,7 +85,7 @@
     font-weight:600;
     font-size:18px;
     background:#fff;
-    margin:0 auto;
+    margin:0;
   }
   body.grid-mode #grid-view{
     height:auto;


### PR DESCRIPTION
## Summary
- remove padding around the grid layout in grid mode so the grid sits flush to the viewport edges
- adjust flex alignment so the grid starts from the top-left corner
- eliminate automatic centering margins on the grid container

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e183d237348333bb326548ede40c7e