### PR TITLE
Lazy-load aircraft assets and gate train polling

### DIFF
--- a/testmap.html
+++ b/testmap.html
@@ -10,10 +10,6 @@
     <script defer src="https://unpkg.com/rbush@3.0.1/rbush.min.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/crypto-js@4.2.0/crypto-js.min.js"></script>
     <script defer src="testmap.js"></script>
-    <script defer src="plane_globals.js"></script>
-    <script defer src="markers.js"></script>
-    <script defer src="planeObject.js"></script>
-    <script defer src="planes_integration.js"></script>
   </head>
   <body>
     <div id="map"></div>


### PR DESCRIPTION
## Summary
- stop including the plane integration scripts on every testmap page load and pull them in on demand when the aircraft feature is toggled
- add a plane dependency loader that reapplies styling overrides after the assets arrive
- ensure train polling only runs while the trains layer is visible, cleaning up the interval when the user hides it or the mode disallows trains

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2a87e3ea0833392b17c43ecb1eb5c