### PR TITLE
Remove route legend header text from kiosk views

### DIFF
--- a/cattestmap.html
+++ b/cattestmap.html
@@ -6222,11 +6222,6 @@
         legendElement.style.display = "block";
         legendElement.innerHTML = "";
 
-        const title = document.createElement("div");
-        title.className = "legend-title";
-        title.textContent = "Routes";
-        legendElement.appendChild(title);
-
         routes.forEach(route => {
           const item = document.createElement("div");
           item.className = "legend-item";

--- a/map.html
+++ b/map.html
@@ -6222,11 +6222,6 @@
         legendElement.style.display = "block";
         legendElement.innerHTML = "";
 
-        const title = document.createElement("div");
-        title.className = "legend-title";
-        title.textContent = "Routes";
-        legendElement.appendChild(title);
-
         routes.forEach(route => {
           const item = document.createElement("div");
           item.className = "legend-item";

--- a/testmap.js
+++ b/testmap.js
@@ -5884,11 +5884,6 @@ ${trainPlaneMarkup}
           : null;
         const target = fragment || legendElement;
 
-        const title = document.createElement("div");
-        title.className = "legend-title";
-        title.textContent = "Routes";
-        target.appendChild(title);
-
         routes.forEach(route => {
           const item = document.createElement("div");
           item.className = "legend-item";


### PR DESCRIPTION
## Summary
- stop injecting the "Routes" heading when rendering the route legend so kiosks only list routes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2cad4d4cc8333914659a830fd7cc8