### PR TITLE
Restore low performance guard for testmap smoothing

### DIFF
--- a/testmap.js
+++ b/testmap.js
@@ -13551,7 +13551,7 @@ ${trainPlaneMarkup}
           return;
         }
 
-        if (typeof requestAnimationFrame !== 'function') {
+        if (lowPerformanceMode || typeof requestAnimationFrame !== 'function') {
           marker.setLatLng(endPos);
           return;
         }


### PR DESCRIPTION
## Summary
- restore the low performance mode guard around requestAnimationFrame checks in testmap.js

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2ef86e5608333a4090b05145f32e4