### PR TITLE
Enhance incident alerts with on-scene timing updates

### DIFF
--- a/testmap.css
+++ b/testmap.css
@@ -769,6 +769,10 @@
       .selector-panel .incident-alert__received {
         font-weight: 600;
       }
+      .selector-panel .incident-alert__on-scene {
+        font-weight: 600;
+        color: rgba(21, 128, 61, 0.95);
+      }
       .selector-panel .incident-alert__routes-line {
         display: flex;
         flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- track and persist first-on-scene timestamps for active incidents so alerts and popups can reuse them
- render the new on-scene time within the incident alert card and popup when units are on scene, and refresh metadata when details change
- extend incident alert change detection to cover status/unit updates and style the new on-scene badge in the control panel

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2fca035048333925ee3874da23c34