### PR TITLE
Add Headway Guard favicon to all HTML pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
 <head>
+<link rel="icon" type="image/png" href="headwayguardicon.png" />
 <meta charset="utf-8" />
 <title>Page Not Found</title>
 <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/admin.html
+++ b/admin.html
@@ -1,4 +1,5 @@
 <!doctype html>
+<link rel="icon" type="image/png" href="headwayguardicon.png" />
 <meta charset="utf-8">
 <title>Headway Guard Admin</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/apicalls.html
+++ b/apicalls.html
@@ -1,4 +1,5 @@
 <!doctype html>
+<link rel="icon" type="image/png" href="headwayguardicon.png" />
 <meta charset="utf-8">
 <title>External API Calls - Headway Guard</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/arrivalsdisplay.html
+++ b/arrivalsdisplay.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<link rel="icon" type="image/png" href="headwayguardicon.png" />
 <meta charset="UTF-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <title>Bus Arrival Predictions</title>

--- a/buses.html
+++ b/buses.html
@@ -1,4 +1,5 @@
 <!doctype html>
+<link rel="icon" type="image/png" href="headwayguardicon.png" />
 <meta charset="utf-8">
 <title>Bus Overview</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/cattestmap.html
+++ b/cattestmap.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+<link rel="icon" type="image/png" href="headwayguardicon.png" />
     <title>Live Map - Headway Guard</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />

--- a/debug.html
+++ b/debug.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
 <head>
+<link rel="icon" type="image/png" href="headwayguardicon.png" />
 <meta charset="utf-8" />
 <title>Debug - Headway Guard</title>
 <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/dispatcher.html
+++ b/dispatcher.html
@@ -1,4 +1,5 @@
 <!doctype html>
+<link rel="icon" type="image/png" href="headwayguardicon.png" />
 <meta charset="utf-8">
 <title>Dispatch - Headway Guard</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/downed.html
+++ b/downed.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
 <head>
+<link rel="icon" type="image/png" href="headwayguardicon.png" />
 <meta charset="utf-8" />
 <title>Downed Vehicles - Headway Guard</title>
 <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/driver.html
+++ b/driver.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
 <head>
+<link rel="icon" type="image/png" href="headwayguardicon.png" />
 <meta charset="utf-8" />
 <title>Driver - Headway Guard</title>
 <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/eink-block.html
+++ b/eink-block.html
@@ -1,4 +1,5 @@
 <!doctype html>
+<link rel="icon" type="image/png" href="headwayguardicon.png" />
 <meta charset="utf-8">
 <title>E-ink Block Display</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/incidents.html
+++ b/incidents.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
 <head>
+  <link rel="icon" type="image/png" href="headwayguardicon.png" />
   <meta charset="utf-8" />
   <title>PulsePoint Incidents — Decrypted Viewer</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
 <head>
+<link rel="icon" type="image/png" href="headwayguardicon.png" />
 <meta charset="utf-8" />
 <title>Headway Guard</title>
 <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/ips.html
+++ b/ips.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang='en'>
 <head>
+<link rel="icon" type="image/png" href="headwayguardicon.png" />
 <meta charset='utf-8'>
 <title>Luminator IPS Database Overview</title>
 <style>body{font-family:Arial, sans-serif; margin:2rem; background:#f6f8fb;} h1,h2{color:#123;} table{border-collapse:collapse; width:100%; margin-bottom:1rem; background:#fff;} th,td{border:1px solid #ccc; padding:0.25rem 0.5rem; font-size:0.85rem;} th{background:#003366; color:#fff;} tbody tr:nth-child(even){background:#f2f2f2;} .summary{margin-bottom:1.5rem; background:#fff; padding:1rem; border:1px solid #ccd;} .note{font-style:italic; color:#555;} .toc ul{columns:2; margin:0; padding-left:1.2rem;} .toc a{text-decoration:none; color:#0066aa;} .toc a:hover{text-decoration:underline;} section{margin-bottom:2.5rem;} code{background:#eef;padding:0 0.3rem;border-radius:3px;} .error{color:#b00;font-weight:bold;}</style>

--- a/kioskmap.html
+++ b/kioskmap.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+<link rel="icon" type="image/png" href="headwayguardicon.png" />
     <meta charset="utf-8" />
     <title>Headway Guard – UVA Kiosk Map</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/madmap.html
+++ b/madmap.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+<link rel="icon" type="image/png" href="headwayguardicon.png" />
     <title>Live Map - Headway Guard</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />

--- a/map.html
+++ b/map.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+<link rel="icon" type="image/png" href="headwayguardicon.png" />
     <title>Live Map - Headway Guard</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />

--- a/metromap.html
+++ b/metromap.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<link rel="icon" type="image/png" href="headwayguardicon.png" />
   <title>Metro Map - Headway Guard</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <script src="https://unpkg.com/@mapbox/polyline@1.1.1"></script>

--- a/radar.html
+++ b/radar.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+<link rel="icon" type="image/png" href="headwayguardicon.png" />
     <meta charset="utf-8" />
     <title>Headway Guard — Radar Sweep</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/replay.html
+++ b/replay.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<link rel="icon" type="image/png" href="headwayguardicon.png" />
   <title>Replay Map - Headway Guard</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />

--- a/ridership.html
+++ b/ridership.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
 <head>
+<link rel="icon" type="image/png" href="headwayguardicon.png" />
 <meta charset="utf-8" />
 <title>Red and Blue Daily Counts - Headway Guard</title>
 <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/servicecrew.html
+++ b/servicecrew.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
 <head>
+<link rel="icon" type="image/png" href="headwayguardicon.png" />
 <meta charset="utf-8" />
 <title>Service Crew - Headway Guard</title>
 <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/testmap-minimal.html
+++ b/testmap-minimal.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+<link rel="icon" type="image/png" href="headwayguardicon.png" />
     <meta charset="utf-8" />
     <title>Headway Guard Minimal Route Viewer</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/testmap.html
+++ b/testmap.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+<link rel="icon" type="image/png" href="headwayguardicon.png" />
     <title>Live Map - Headway Guard</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />

--- a/transloc_ticker.html
+++ b/transloc_ticker.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-visible="false">
 <head>
+  <link rel="icon" type="image/png" href="headwayguardicon.png" />
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>UTS Ticker</title>


### PR DESCRIPTION
## Summary
- add the Headway Guard icon as the favicon for each HTML page so that every surface shows consistent branding

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e30cc2f22483339312e15f71aacf3d