### PR TITLE
Add landing page cards for downed and test map

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,22 @@
     </svg>
     <div>Replay</div>
   </a>
+  <a class="card" href="/downed">
+    <svg viewBox="0 0 64 64" stroke="currentColor" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M32 12 L12 52h40L32 12z" />
+      <line x1="32" y1="26" x2="32" y2="38" />
+      <circle cx="32" cy="46" r="2.5" fill="currentColor" stroke="none" />
+    </svg>
+    <div>Downed Vehicles</div>
+  </a>
+  <a class="card" href="/testmap">
+    <svg viewBox="0 0 64 64" stroke="currentColor" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M12 18l16-6 16 6 16-6v34l-16 6-16-6-16 6V18z" />
+      <line x1="28" y1="12" x2="28" y2="46" />
+      <line x1="44" y1="18" x2="44" y2="52" />
+    </svg>
+    <div>Test Map</div>
+  </a>
 </div>
 <div class="credit">proof of concept created by pat cox • phc6j@virginia.edu</div>
 </body>


### PR DESCRIPTION
## Summary
- add Downed Vehicles and Test Map cards to the landing page
- include matching inline SVG icons for the new links

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e41dc69a00833390d0327240d4e2aa