### PR TITLE
Improve home page layout responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,13 +11,16 @@
   :root{ --bg:#0b0e11; --panel:#0f141a; --ink:#e8eef5; --line:#1f2630; }
   body{margin:0;background:var(--bg);color:var(--ink);font:16px/1.45 'FGDC',sans-serif;display:flex;flex-direction:column;align-items:center;justify-content:center;height:100vh;}
   .title{text-align:center;font-size:24px;margin-bottom:24px;}
-  .container{display:flex;gap:20px;}
+  .container{display:flex;flex-wrap:wrap;gap:20px;justify-content:center;max-width:700px;}
   .card{width:160px;height:160px;border-radius:16px;background:var(--panel);border:1px solid var(--line);display:flex;flex-direction:column;align-items:center;justify-content:center;text-decoration:none;color:var(--ink);}
   .card svg{width:64px;height:64px;margin-bottom:12px;}
   .admin-link{position:fixed;top:12px;right:16px;color:var(--ink);text-decoration:none;font-size:14px;}
   .github-link{position:fixed;top:12px;left:16px;color:var(--ink);text-decoration:none;font-size:14px;}
   .credit{position:fixed;bottom:8px;right:8px;font-size:12px;color:var(--muted,#9fb0c9);}
-  @media(max-width:600px){.container{flex-direction:column;}}
+  @media(max-width:600px){
+    body{justify-content:flex-start;padding:32px 16px;height:auto;min-height:100vh;}
+    .container{flex-direction:column;flex-wrap:nowrap;width:100%;max-width:360px;max-height:calc(100vh - 160px);overflow-y:auto;align-items:center;padding-right:8px;}
+  }
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- allow the home page card container to wrap into two rows on larger screens
- tweak mobile styles so the cards display in a scrollable single column

## Testing
- Viewed index.html in the browser

------
https://chatgpt.com/codex/tasks/task_e_68e4200024748333bfb86e295f02e8b9