### PR TITLE
Adjust index color palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 <link rel="preload" href="FGDC.ttf" as="font" type="font/ttf" crossorigin />
 <style>
   @font-face{font-family:'FGDC';src:url('FGDC.ttf') format('truetype');font-weight:normal;font-style:normal;}
-  :root{ --bg:#0b0e11; --panel:#0f141a; --ink:#e8eef5; --line:#1f2630; }
+  :root{ --bg:#232D4B; --panel:#232D4B; --ink:#E57200; --line:#232D4B; }
   body{margin:0;background:var(--bg);color:var(--ink);font:16px/1.45 'FGDC',sans-serif;display:flex;flex-direction:column;align-items:center;justify-content:center;height:100vh;}
   .title{text-align:center;font-size:24px;margin-bottom:24px;}
   .container{display:flex;flex-wrap:wrap;gap:20px;justify-content:center;max-width:700px;}


### PR DESCRIPTION
## Summary
- update root CSS variables on the landing page to use #232D4B for the dark surfaces
- switch the primary text/icon color to #E57200

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e42125ac5c833385b40a1342f39ffd