### PR TITLE
Fix mobile nav spacer height to prevent content overlap

### DIFF
--- a/mobile-nav.js
+++ b/mobile-nav.js
@@ -174,7 +174,7 @@
     .hg-mobile-nav-spacer{display:none;}
     @media (max-width: 768px){
       #${NAV_ID}{display:block;}
-      .hg-mobile-nav-spacer{display:block;height:96px;}
+      .hg-mobile-nav-spacer{display:block;}
     }
   `;
   document.head.appendChild(style);
@@ -211,4 +211,20 @@
   const spacer = document.createElement('div');
   spacer.className = 'hg-mobile-nav-spacer';
   document.body.appendChild(spacer);
+
+  const updateSpacerHeight = () => {
+    if (window.getComputedStyle(nav).display === 'none') {
+      spacer.style.height = '0px';
+      return;
+    }
+    const navHeight = nav.offsetHeight;
+    spacer.style.height = `${navHeight}px`;
+  };
+
+  updateSpacerHeight();
+  window.addEventListener('resize', updateSpacerHeight, { passive: true });
+  if (window.ResizeObserver) {
+    const observer = new ResizeObserver(updateSpacerHeight);
+    observer.observe(nav);
+  }
 })();


### PR DESCRIPTION
## Summary
- update the mobile navigation spacer to size itself based on the rendered nav height
- adjust the spacer on resize and via a ResizeObserver so page content is no longer hidden

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e432b40efc83339ec244cd194560c6