### PR TITLE
Adjust mobile nav spacing for content

### DIFF
--- a/mobile-nav.js
+++ b/mobile-nav.js
@@ -112,9 +112,15 @@
   const style = document.createElement('style');
   style.textContent = `
     :root{--hg-mobile-nav-offset:0px;}
+    body.hg-mobile-nav-active{
+      padding-bottom:var(--hg-mobile-nav-offset);
+    }
     body.hg-mobile-nav-active .hg-mobile-nav-scroll{
       padding-bottom:var(--hg-mobile-nav-offset);
       box-sizing:border-box;
+    }
+    body.hg-mobile-nav-active .leaflet-bottom{
+      bottom:calc(var(--hg-mobile-nav-offset) + 4px);
     }
     #${NAV_ID}{
       position:fixed;


### PR DESCRIPTION
## Summary
- add body padding when the mobile navigation is active so page content clears the bar
- shift Leaflet bottom controls upward by the navigation height to keep map credits visible

## Testing
- no automated tests were run

------
https://chatgpt.com/codex/tasks/task_e_68e437df78308333b5f0fcaf17e14dd5