### PR TITLE
Improve downed signage readability

### DIFF
--- a/downed.html
+++ b/downed.html
@@ -31,15 +31,18 @@
     margin:0;
     background:var(--bg);
     color:var(--ink);
-    font:16px/1.4 'FGDC',sans-serif;
+    font:20px/1.45 'FGDC',sans-serif;
     min-height:100vh;
     display:flex;
     justify-content:center;
+    -webkit-font-smoothing:antialiased;
+    -moz-osx-font-smoothing:grayscale;
+    text-rendering:geometricPrecision;
   }
   main{
     width:100%;
-    max-width:1600px;
-    padding:24px 24px 32px;
+    max-width:1920px;
+    padding:32px 32px 36px;
     display:flex;
     flex-direction:column;
     gap:20px;
@@ -66,32 +69,34 @@
   }
   section h2{
     margin:0;
-    font-size:28px;
+    font-size:34px;
     text-transform:uppercase;
     letter-spacing:0.08em;
   }
   table{
     width:100%;
     border-collapse:collapse;
-    table-layout:auto;
+    table-layout:fixed;
     background:var(--panel);
   }
   thead th{
-    font-size:16px;
+    font-size:20px;
     color:var(--muted);
     text-transform:uppercase;
     letter-spacing:0.05em;
-    padding:12px 12px 10px;
+    padding:16px 16px 12px;
     border-bottom:1px solid var(--line);
     text-align:center;
+    word-break:break-word;
   }
   tbody td{
-    padding:14px 12px;
+    padding:18px 16px;
     border-top:1px solid rgba(159,176,201,0.08);
     vertical-align:middle;
-    font-size:18px;
-    line-height:1.3;
+    font-size:24px;
+    line-height:1.35;
     text-align:center;
+    word-break:break-word;
   }
   tbody tr:hover{
     background:var(--panel-soft);
@@ -105,9 +110,9 @@
     display:inline-flex;
     align-items:center;
     gap:6px;
-    padding:4px 12px;
+    padding:6px 14px;
     border-radius:999px;
-    font-size:14px;
+    font-size:16px;
     text-transform:uppercase;
     letter-spacing:0.05em;
     background:rgba(255,255,255,0.08);
@@ -187,7 +192,7 @@
     outline-offset:2px;
   }
   .card-summary .vehicle{
-    font-size:18px;
+    font-size:22px;
     font-weight:600;
     letter-spacing:0.05em;
     text-transform:uppercase;
@@ -199,7 +204,7 @@
     gap:8px;
   }
   .card-summary .summary-date{
-    font-size:14px;
+    font-size:16px;
     color:var(--muted);
   }
   .card-summary .chevron{
@@ -222,22 +227,23 @@
   }
   .card-details dt{
     margin:0 0 4px;
-    font-size:12px;
+    font-size:14px;
     text-transform:uppercase;
     letter-spacing:0.08em;
     color:var(--muted);
   }
   .card-details dd{
     margin:0;
-    font-size:16px;
-    line-height:1.35;
+    font-size:18px;
+    line-height:1.4;
     word-break:break-word;
   }
   @media (max-width:1100px){
-    table{font-size:14px;}
-    tbody td{font-size:16px;}
-    main{padding:20px 16px;}
-    section h2{font-size:22px;}
+    body{font-size:18px;}
+    tbody td{font-size:20px;}
+    main{padding:24px 20px;}
+    section h2{font-size:28px;}
+    thead th{font-size:18px;}
   }
   @media (max-width:960px){
     #sections{gap:10px;}


### PR DESCRIPTION
## Summary
- increase the default typography sizes for the downed vehicles display and adjust pill styling for better legibility
- expand the main layout width and use fixed table layout so the table occupies more horizontal space on signage
- enable font smoothing hints to produce a cleaner rasterized rendering of the custom font

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e443ea9d2c8333b4e12b6cd30cb6b1