### PR TITLE
Adjust downed page typography

### DIFF
--- a/downed.html
+++ b/downed.html
@@ -103,7 +103,7 @@
     word-break:break-word;
   }
   tbody td.vehicle-column{
-    font-size:32px;
+    font-size:36px;
     font-weight:700;
     letter-spacing:0.08em;
     text-transform:uppercase;
@@ -122,14 +122,14 @@
     gap:6px;
     padding:6px 14px;
     border-radius:999px;
-    font-size:16px;
+    font-size:18px;
     text-transform:uppercase;
     letter-spacing:0.05em;
     background:rgba(255,255,255,0.08);
   }
   .pill .dot{
-    width:8px;
-    height:8px;
+    width:10px;
+    height:10px;
     border-radius:50%;
     background:currentColor;
   }
@@ -202,7 +202,7 @@
     outline-offset:2px;
   }
   .card-summary .vehicle{
-    font-size:22px;
+    font-size:26px;
     font-weight:600;
     letter-spacing:0.05em;
     text-transform:uppercase;


### PR DESCRIPTION
## Summary
- enlarge the vehicle column typography on the downed vehicles screen
- increase the size of status pills for improved visibility
- update the mobile card vehicle label to match the larger desktop styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e45cf0034c83338ab6598c2325ee1a