### PR TITLE
Prevent vehicle column wrapping on downed page

### DIFF
--- a/downed.html
+++ b/downed.html
@@ -107,6 +107,14 @@
     font-weight:700;
     letter-spacing:0.08em;
     text-transform:uppercase;
+    white-space:nowrap;
+    word-break:normal;
+    min-width:220px;
+  }
+  thead th.vehicle-column{
+    white-space:nowrap;
+    word-break:normal;
+    min-width:220px;
   }
   tbody tr:hover{
     background:var(--panel-soft);


### PR DESCRIPTION
## Summary
- prevent the vehicle column on the downed vehicles table from wrapping to multiple lines
- ensure the vehicle column header matches the row styling so the column can expand instead of wrapping

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e45e726e10833388c3cc86315c02f4