### PR TITLE
Adjust replay mobile controls spacing

### DIFF
--- a/replay.html
+++ b/replay.html
@@ -162,7 +162,7 @@
     #controls.playback-controls {
       position: fixed;
       left: 50%;
-      bottom: 16px;
+      bottom: calc(var(--hg-mobile-nav-offset, 0px) + 16px);
       transform: translateX(-50%);
       width: min(1120px, calc(100% - 32px));
       background: var(--panel-surface);
@@ -722,7 +722,7 @@
       #controlsToggle {
         position: fixed;
         left: 50%;
-        bottom: calc(var(--controls-height) + 24px);
+        bottom: calc(var(--controls-height) + var(--hg-mobile-nav-offset, 0px) + 24px);
         transform: translateX(-50%);
         display: inline-flex;
         align-items: center;
@@ -749,7 +749,7 @@
         box-shadow: 0 0 0 3px var(--accent-soft), 0 16px 30px rgba(15, 23, 42, 0.3);
       }
       body.controls-collapsed #controlsToggle {
-        bottom: calc(var(--controls-height) + 16px);
+        bottom: calc(var(--controls-height) + var(--hg-mobile-nav-offset, 0px) + 16px);
         color: #1f1300;
         background: linear-gradient(135deg, var(--accent), var(--accent-bright));
         box-shadow: 0 12px 24px rgba(229, 114, 0, 0.35);


### PR DESCRIPTION
## Summary
- offset the replay playback controls and toggle by the mobile navigation height so they no longer overlap on small screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e45f18cf688333bd8605dd0996bc8f