### PR TITLE
Remove top padding above downed table

### DIFF
--- a/downed.html
+++ b/downed.html
@@ -41,7 +41,7 @@
   }
   main{
     width:100%;
-    padding:32px 32px 36px;
+    padding:0 32px 36px;
     display:flex;
     flex-direction:column;
     gap:20px;
@@ -259,7 +259,7 @@
   @media (max-width:1100px){
     body{font-size:18px;}
     tbody td{font-size:20px;}
-    main{padding:24px 20px;}
+    main{padding:0 20px 24px;}
     section h2{font-size:28px;}
     thead th{font-size:18px;}
   }


### PR DESCRIPTION
## Summary
- remove the extra top padding from the Downed Vehicles layout so the table sits flush with the top of the panel
- update responsive padding to match the new spacing

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e460ce695c83338560848b1e5e034c