### PR TITLE
Reduce downed table row padding

### DIFF
--- a/downed.html
+++ b/downed.html
@@ -88,13 +88,13 @@
     color:var(--muted);
     text-transform:uppercase;
     letter-spacing:0.05em;
-    padding:16px 16px 12px;
+    padding:12px 16px 8px;
     border-bottom:1px solid var(--line);
     text-align:center;
     word-break:break-word;
   }
   tbody td{
-    padding:18px 16px;
+    padding:12px 16px;
     border-top:1px solid rgba(159,176,201,0.08);
     vertical-align:middle;
     font-size:24px;
@@ -109,12 +109,12 @@
     text-transform:uppercase;
     white-space:nowrap;
     word-break:normal;
-    padding:18px 10px;
+    padding:12px 10px;
   }
   thead th.vehicle-column{
     white-space:nowrap;
     word-break:normal;
-    padding:16px 10px 12px;
+    padding:12px 10px 8px;
   }
   tbody tr:hover{
     background:var(--panel-soft);
@@ -195,7 +195,7 @@
     align-items:flex-start;
     justify-content:space-between;
     gap:14px;
-    padding:16px 20px;
+    padding:12px 20px;
     background:none;
     border:none;
     color:inherit;
@@ -234,7 +234,7 @@
   }
   .card-details{
     display:none;
-    padding:0 20px 18px;
+    padding:0 20px 12px;
     margin:0;
     column-gap:12px;
   }


### PR DESCRIPTION
## Summary
- tighten table header and cell padding on the downed vehicles view to shorten each row
- trim padding on mobile summaries and details to match the reduced row height

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4633a3adc83339987d5fb5a590f01