### PR TITLE
Prevent pulse halo from triggering table scrollbar flicker

### DIFF
--- a/downed.html
+++ b/downed.html
@@ -143,18 +143,19 @@
   .pill.pulse-alert::after{
     content:'';
     position:absolute;
-    inset:-4px;
+    inset:0;
     border-radius:inherit;
-    background:currentColor;
+    background:none;
     opacity:0.35;
-    transform:scale(0.85);
+    box-shadow:0 0 0 0 currentColor;
     z-index:-1;
     animation:statusPulse 1.8s ease-out infinite;
+    pointer-events:none;
   }
   @keyframes statusPulse{
-    0%{transform:scale(0.85); opacity:0.35;}
-    70%{transform:scale(1.35); opacity:0;}
-    100%{transform:scale(1.35); opacity:0;}
+    0%{opacity:0.35; box-shadow:0 0 0 0 currentColor;}
+    70%{opacity:0; box-shadow:0 0 0 18px currentColor;}
+    100%{opacity:0; box-shadow:0 0 0 18px currentColor;}
   }
   .pill.down,
   .pill.downed{


### PR DESCRIPTION
## Summary
- replace the pulsating halo on downed vehicle pills with a box-shadow animation so the pulse effect no longer expands the table width
- keep the alert styling intact while preventing the table from gaining and losing a horizontal scrollbar

## Testing
- No tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e4711c21d4833386025665685e5d80