### PR TITLE
Increase alert pulse visibility

### DIFF
--- a/downed.html
+++ b/downed.html
@@ -148,15 +148,15 @@
     border-radius:inherit;
     background:none;
     color:var(--pill-bg);
-    opacity:0.35;
+    opacity:0.6;
     box-shadow:0 0 0 0 currentColor;
     z-index:-1;
     animation:statusPulse 1.8s ease-out infinite;
     pointer-events:none;
   }
   @keyframes statusPulse{
-    0%{opacity:0.35; box-shadow:0 0 0 0 currentColor;}
-    70%{opacity:0; box-shadow:0 0 0 18px currentColor;}
+    0%{opacity:0.6; box-shadow:0 0 0 0 currentColor;}
+    70%{opacity:0.15; box-shadow:0 0 0 18px currentColor;}
     100%{opacity:0; box-shadow:0 0 0 18px currentColor;}
   }
   .pill.down,


### PR DESCRIPTION
## Summary
- increase the initial opacity of the pulse effect on status pills so red alerts remain visible against the blue backdrop
- adjust the pulse animation to fade out more gradually for better contrast

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e474bb6a0c833391719b275ad05acb