### PR TITLE
Make downed display typography responsive

### DIFF
--- a/downed.html
+++ b/downed.html
@@ -25,13 +25,16 @@
     --pill-hold:#FFFFFF;
     --pill-up:#00ff00;
     --pill-usable:#0000ff;
+    --base-font-size:clamp(16px,calc(0.8vw + 0.6vh),22px);
   }
   *{box-sizing:border-box;}
   body{
     margin:0;
     background:var(--bg);
     color:var(--ink);
-    font:20px/1.45 'FGDC',sans-serif;
+    font-family:'FGDC',sans-serif;
+    font-size:var(--base-font-size);
+    line-height:1.45;
     min-height:100vh;
     display:flex;
     justify-content:center;
@@ -68,7 +71,7 @@
   }
   section h2{
     margin:0;
-    font-size:34px;
+    font-size:2.125rem;
     text-transform:uppercase;
     letter-spacing:0.08em;
   }
@@ -84,7 +87,7 @@
     overflow-x:auto;
   }
   thead th{
-    font-size:20px;
+    font-size:1.25rem;
     color:var(--muted);
     text-transform:uppercase;
     letter-spacing:0.05em;
@@ -97,13 +100,13 @@
     padding:9px 16px;
     border-top:1px solid rgba(159,176,201,0.08);
     vertical-align:middle;
-    font-size:24px;
+    font-size:1.5rem;
     line-height:1.35;
     text-align:center;
     word-break:break-word;
   }
   tbody td.vehicle-column{
-    font-size:36px;
+    font-size:2.25rem;
     font-weight:700;
     letter-spacing:0.08em;
     text-transform:uppercase;
@@ -131,7 +134,7 @@
     align-items:center;
     padding:5px 14px;
     border-radius:999px;
-    font-size:18px;
+    font-size:1.125rem;
     text-transform:uppercase;
     letter-spacing:0.05em;
     --pill-bg:rgba(255,255,255,0.08);
@@ -208,7 +211,7 @@
   .empty-indicator{
     padding:36px 24px;
     text-align:center;
-    font-size:18px;
+    font-size:1.125rem;
     color:var(--muted);
   }
   .mobile-list{
@@ -243,7 +246,7 @@
     outline-offset:2px;
   }
   .card-summary .vehicle{
-    font-size:26px;
+    font-size:1.625rem;
     font-weight:600;
     letter-spacing:0.05em;
     text-transform:uppercase;
@@ -255,7 +258,7 @@
     gap:8px;
   }
   .card-summary .summary-date{
-    font-size:16px;
+    font-size:1rem;
     color:var(--muted);
   }
   .card-summary .chevron{
@@ -278,23 +281,20 @@
   }
   .card-details dt{
     margin:0 0 4px;
-    font-size:14px;
+    font-size:0.875rem;
     text-transform:uppercase;
     letter-spacing:0.08em;
     color:var(--muted);
   }
   .card-details dd{
     margin:0;
-    font-size:18px;
+    font-size:1.125rem;
     line-height:1.4;
     word-break:break-word;
   }
   @media (max-width:1100px){
-    body{font-size:18px;}
-    tbody td{font-size:20px;}
-    main{padding:0 20px 24px;}
-    section h2{font-size:28px;}
-    thead th{font-size:18px;}
+    body{font-size:calc(var(--base-font-size) * 0.92);}
+    main{padding:0 1.25rem 1.5rem;}
   }
   @media (max-width:960px){
     #sections{gap:10px;}


### PR DESCRIPTION
## Summary
- add a viewport-aware base font size so typography scales with screen dimensions
- convert headings, tables, and pill labels to rem units so they adjust with the base size
- keep medium screen padding adjustments while relying on the new scaling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e481da53108333a4a3b4133f3f2c23