### PR TITLE
Make downed display typography responsive

### DIFF
--- a/downed.html
+++ b/downed.html
@@ -25,7 +25,7 @@
     --pill-hold:#FFFFFF;
     --pill-up:#00ff00;
     --pill-usable:#0000ff;
-    --base-font-size:clamp(16px,calc(0.8vw + 0.6vh),22px);
+    --base-font-size:clamp(16px,calc(0.8vw + 0.6vh),20px);
   }
   *{box-sizing:border-box;}
   body{
@@ -71,7 +71,7 @@
   }
   section h2{
     margin:0;
-    font-size:2.125rem;
+    font-size:1.7rem;
     text-transform:uppercase;
     letter-spacing:0.08em;
   }
@@ -87,7 +87,7 @@
     overflow-x:auto;
   }
   thead th{
-    font-size:1.25rem;
+    font-size:1rem;
     color:var(--muted);
     text-transform:uppercase;
     letter-spacing:0.05em;
@@ -100,13 +100,13 @@
     padding:9px 16px;
     border-top:1px solid rgba(159,176,201,0.08);
     vertical-align:middle;
-    font-size:1.5rem;
+    font-size:1.2rem;
     line-height:1.35;
     text-align:center;
     word-break:break-word;
   }
   tbody td.vehicle-column{
-    font-size:2.25rem;
+    font-size:1.8rem;
     font-weight:700;
     letter-spacing:0.08em;
     text-transform:uppercase;
@@ -134,7 +134,7 @@
     align-items:center;
     padding:5px 14px;
     border-radius:999px;
-    font-size:1.125rem;
+    font-size:0.9rem;
     text-transform:uppercase;
     letter-spacing:0.05em;
     --pill-bg:rgba(255,255,255,0.08);
@@ -211,7 +211,7 @@
   .empty-indicator{
     padding:36px 24px;
     text-align:center;
-    font-size:1.125rem;
+    font-size:0.9rem;
     color:var(--muted);
   }
   .mobile-list{
@@ -246,7 +246,7 @@
     outline-offset:2px;
   }
   .card-summary .vehicle{
-    font-size:1.625rem;
+    font-size:1.3rem;
     font-weight:600;
     letter-spacing:0.05em;
     text-transform:uppercase;
@@ -258,7 +258,7 @@
     gap:8px;
   }
   .card-summary .summary-date{
-    font-size:1rem;
+    font-size:0.8rem;
     color:var(--muted);
   }
   .card-summary .chevron{
@@ -281,14 +281,14 @@
   }
   .card-details dt{
     margin:0 0 4px;
-    font-size:0.875rem;
+    font-size:0.7rem;
     text-transform:uppercase;
     letter-spacing:0.08em;
     color:var(--muted);
   }
   .card-details dd{
     margin:0;
-    font-size:1.125rem;
+    font-size:0.9rem;
     line-height:1.4;
     word-break:break-word;
   }


### PR DESCRIPTION
## Summary
- reduce the responsive base font size clamp to maintain the original 20px maximum
- recalculate converted rem sizes for headings, table cells, and pills around the 20px baseline
- keep mobile card typography aligned with the updated base scale

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e48355b45883338ba0d1f083b20cbb