### PR TITLE
Adjust downed page typography for mid-size screens

### DIFF
--- a/downed.html
+++ b/downed.html
@@ -25,7 +25,7 @@
     --pill-hold:#FFFFFF;
     --pill-up:#00ff00;
     --pill-usable:#0000ff;
-    --base-font-size:clamp(16px,calc(0.8vw + 0.6vh),20px);
+    --base-font-size:clamp(15px,calc(0.7vw + 0.52vh),19px);
   }
   *{box-sizing:border-box;}
   body{
@@ -71,7 +71,7 @@
   }
   section h2{
     margin:0;
-    font-size:1.7rem;
+    font-size:clamp(1.4rem,1.2rem + 0.3vw,1.7rem);
     text-transform:uppercase;
     letter-spacing:0.08em;
   }
@@ -87,7 +87,7 @@
     overflow-x:auto;
   }
   thead th{
-    font-size:1rem;
+    font-size:clamp(0.85rem,0.75rem + 0.18vw,1rem);
     color:var(--muted);
     text-transform:uppercase;
     letter-spacing:0.05em;
@@ -100,13 +100,13 @@
     padding:9px 16px;
     border-top:1px solid rgba(159,176,201,0.08);
     vertical-align:middle;
-    font-size:1.2rem;
+    font-size:clamp(1rem,0.95rem + 0.22vw,1.2rem);
     line-height:1.35;
     text-align:center;
     word-break:break-word;
   }
   tbody td.vehicle-column{
-    font-size:1.8rem;
+    font-size:clamp(1.4rem,1.1rem + 0.45vw,1.8rem);
     font-weight:700;
     letter-spacing:0.08em;
     text-transform:uppercase;


### PR DESCRIPTION
## Summary
- retune the base font clamp on the downed vehicles page to better balance large and mid-size displays
- add responsive clamp values to table headers, cells, and section titles to reduce text wrapping at 1360×768 while keeping larger screen legibility

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e4859020b883339ddc99a16546ef4b