### PR TITLE
Fix dynamic font sizing override for downed view pills

### DIFF
--- a/downed.html
+++ b/downed.html
@@ -293,7 +293,7 @@
     word-break:break-word;
   }
   @media (max-width:1100px){
-    body{font-size:calc(var(--base-font-size) * 0.92);}
+    body{font-size:calc(var(--dynamic-base-font-size, var(--base-font-size)) * 0.92);}
     main{padding:0 1.25rem 1.5rem;}
   }
   @media (max-width:960px){


### PR DESCRIPTION
## Summary
- ensure the ≤1100px media query uses the dynamic base font size so runtime adjustments work on smaller layouts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e489a6d9d483339ede01c8f5f5657c