### PR TITLE
Prevent table header wrapping on downed view

### DIFF
--- a/downed.html
+++ b/downed.html
@@ -94,7 +94,8 @@
     padding:12px 16px 8px;
     border-bottom:1px solid var(--line);
     text-align:center;
-    word-break:break-word;
+    word-break:normal;
+    white-space:nowrap;
   }
   tbody td{
     padding:9px 16px;
@@ -103,6 +104,11 @@
     font-size:clamp(1rem,0.95rem + 0.22vw,1.2rem);
     line-height:1.35;
     text-align:center;
+    word-break:normal;
+    white-space:nowrap;
+  }
+  tbody td.wrap-allowed{
+    white-space:normal;
     word-break:break-word;
   }
   tbody td.vehicle-column{
@@ -452,6 +458,15 @@ function abbreviateHeaderLabel(text){
     .replace(/ACTUAL DELIVERY DATE/gi,'DEL DATE');
 }
 
+function allowsWrappingForHeader(text){
+  const normalized=normalizeHeader(text);
+  if(!normalized) return false;
+  if(normalized.includes('note')) return true;
+  if(normalized.includes('description')) return true;
+  if(normalized.includes('notes/description')) return true;
+  return false;
+}
+
 function normalizeHeader(text){
   return String(text || '')
     .replace(/\s+/g,' ')
@@ -685,11 +700,7 @@ function renderSection(section){
     const isVehicleColumn=originalNormalized==='bus' || originalNormalized==='p&t support vehicle' || originalNormalized==='vehicle' || originalNormalized.includes('vehicle');
     if(isVehicleColumn) th.classList.add('vehicle-column');
     if(text && normalized!=='bus' && normalized!=='p&t support vehicle'){
-      const parts=String(text).split('\n');
-      parts.forEach((part,idx)=>{
-        if(idx>0) th.appendChild(document.createElement('br'));
-        th.appendChild(document.createTextNode(part));
-      });
+      th.textContent=String(text).replace(/[\n\r]+/g,' ').replace(/\s{2,}/g,' ').trim();
     }else{
       th.textContent='';
     }
@@ -722,7 +733,9 @@ function renderSection(section){
       const text=cell;
       const normalizedHeader=normalizeHeader(headerText);
       const isVehicleColumn=normalizedHeader==='bus' || normalizedHeader==='p&t support vehicle' || normalizedHeader==='vehicle' || normalizedHeader.includes('vehicle');
+      const allowsWrapping=allowsWrappingForHeader(headerText);
       if(isVehicleColumn) td.classList.add('vehicle-column');
+      if(allowsWrapping) td.classList.add('wrap-allowed');
       if(isStatusHeader(headerText)){
         const cls=getStatusClass(text);
         td.className='status';


### PR DESCRIPTION
## Summary
- force table headers to stay on a single line so column labels are never hidden
- allow only the notes/description column to wrap by tagging those cells dynamically
- remove manual line breaks when rendering headers to keep labels intact

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68e48b3d4e088333aeae1fde88715b6f