### PR TITLE
Remove horizontal padding from downed tables

### DIFF
--- a/downed.html
+++ b/downed.html
@@ -91,14 +91,14 @@
     color:var(--muted);
     text-transform:uppercase;
     letter-spacing:0.05em;
-    padding:12px 16px 8px;
+    padding:12px 0 8px;
     border-bottom:1px solid var(--line);
     text-align:center;
     word-break:normal;
     white-space:nowrap;
   }
   tbody td{
-    padding:9px 16px;
+    padding:9px 0;
     border-top:1px solid rgba(159,176,201,0.08);
     vertical-align:middle;
     font-size:clamp(1rem,0.95rem + 0.22vw,1.2rem);
@@ -118,12 +118,12 @@
     text-transform:uppercase;
     white-space:nowrap;
     word-break:normal;
-    padding:9px 10px;
+    padding:9px 0;
   }
   thead th.vehicle-column{
     white-space:nowrap;
     word-break:normal;
-    padding:12px 10px 8px;
+    padding:12px 0 8px;
   }
   tbody tr:hover{
     background:var(--panel-soft);


### PR DESCRIPTION
## Summary
- remove horizontal padding from downed vehicle table headers and cells
- keep tables flush with section borders while retaining existing vertical spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e48c71abf88333a1baef7fe3dcc233