### PR TITLE
Make downed tables span the full viewport width

### DIFF
--- a/downed.html
+++ b/downed.html
@@ -44,7 +44,7 @@
   }
   main{
     width:100%;
-    padding:0 32px 36px;
+    padding:0 0 36px;
     display:flex;
     flex-direction:column;
     gap:20px;
@@ -300,7 +300,7 @@
   }
   @media (max-width:1100px){
     body{font-size:calc(var(--dynamic-base-font-size, var(--base-font-size)) * 0.92);}
-    main{padding:0 1.25rem 1.5rem;}
+    main{padding:0 0 1.5rem;}
   }
   @media (max-width:960px){
     #sections{gap:10px;}


### PR DESCRIPTION
## Summary
- remove the horizontal padding from the main container on the downed view so its tables reach the screen edges
- ensure the reduced padding also applies to the responsive breakpoint for consistent full-width layouts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e48dd97eec8333be9650265723558e