### PR TITLE
Increase base font size for downed vehicles page

### DIFF
--- a/downed.html
+++ b/downed.html
@@ -25,7 +25,7 @@
     --pill-hold:#FFFFFF;
     --pill-up:#00ff00;
     --pill-usable:#0000ff;
-    --base-font-size:clamp(15px,calc(0.7vw + 0.52vh),19px);
+    --base-font-size:clamp(17px,calc(0.9vw + 0.6vh),24px);
   }
   *{box-sizing:border-box;}
   body{


### PR DESCRIPTION
## Summary
- increase the base font size clamp for the downed vehicles page so text reads larger on 1080p displays

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e48fe829208333a1d5d5c50a843481