### PR TITLE
Increase base font size on downed page

### DIFF
--- a/downed.html
+++ b/downed.html
@@ -25,7 +25,7 @@
     --pill-hold:#FFFFFF;
     --pill-up:#00ff00;
     --pill-usable:#0000ff;
-    --base-font-size:clamp(17px,calc(0.9vw + 0.6vh),24px);
+    --base-font-size:clamp(19px,calc(1.05vw + 0.7vh),28px);
   }
   *{box-sizing:border-box;}
   body{


### PR DESCRIPTION
## Summary
- increase the base font size clamp on the downed vehicles page to improve readability on 1080p displays

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4911954608333b240f9c2a9742ed7