### PR TITLE
Add padding between downed columns

### DIFF
--- a/downed.html
+++ b/downed.html
@@ -91,14 +91,14 @@
     color:var(--muted);
     text-transform:uppercase;
     letter-spacing:0.05em;
-    padding:12px 0 8px;
+    padding:12px 6px 8px;
     border-bottom:1px solid var(--line);
     text-align:center;
     word-break:normal;
     white-space:nowrap;
   }
   tbody td{
-    padding:9px 0;
+    padding:9px 6px;
     border-top:1px solid rgba(159,176,201,0.08);
     vertical-align:middle;
     font-size:clamp(1rem,0.95rem + 0.22vw,1.2rem);
@@ -118,12 +118,12 @@
     text-transform:uppercase;
     white-space:nowrap;
     word-break:normal;
-    padding:9px 0;
+    padding:9px 6px;
   }
   thead th.vehicle-column{
     white-space:nowrap;
     word-break:normal;
-    padding:12px 0 8px;
+    padding:12px 6px 8px;
   }
   tbody tr:hover{
     background:var(--panel-soft);


### PR DESCRIPTION
## Summary
- add a small horizontal padding to table headers and cells on the downed vehicles page to create space between columns

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e49606d07883339328a2e9eff3b377