### PR TITLE
Increase typography scale on downed vehicles dashboard

### DIFF
--- a/downed.html
+++ b/downed.html
@@ -25,7 +25,7 @@
     --pill-hold:#FFFFFF;
     --pill-up:#00ff00;
     --pill-usable:#0000ff;
-    --base-font-size:clamp(19px,calc(1.05vw + 0.7vh),28px);
+    --base-font-size:clamp(21px,calc(1.2vw + 0.8vh),32px);
   }
   *{box-sizing:border-box;}
   body{
@@ -71,7 +71,7 @@
   }
   section h2{
     margin:0;
-    font-size:clamp(1.4rem,1.2rem + 0.3vw,1.7rem);
+    font-size:clamp(1.55rem,1.35rem + 0.35vw,1.9rem);
     text-transform:uppercase;
     letter-spacing:0.08em;
   }
@@ -87,7 +87,7 @@
     overflow-x:auto;
   }
   thead th{
-    font-size:clamp(0.85rem,0.75rem + 0.18vw,1rem);
+    font-size:clamp(0.95rem,0.85rem + 0.22vw,1.15rem);
     color:var(--muted);
     text-transform:uppercase;
     letter-spacing:0.05em;
@@ -101,7 +101,7 @@
     padding:9px 6px;
     border-top:1px solid rgba(159,176,201,0.08);
     vertical-align:middle;
-    font-size:clamp(1rem,0.95rem + 0.22vw,1.2rem);
+    font-size:clamp(1.1rem,1.05rem + 0.26vw,1.35rem);
     line-height:1.35;
     text-align:center;
     word-break:normal;
@@ -112,7 +112,7 @@
     word-break:break-word;
   }
   tbody td.vehicle-column{
-    font-size:clamp(1.4rem,1.1rem + 0.45vw,1.8rem);
+    font-size:clamp(1.55rem,1.25rem + 0.5vw,2rem);
     font-weight:700;
     letter-spacing:0.08em;
     text-transform:uppercase;
@@ -140,7 +140,7 @@
     align-items:center;
     padding:5px 14px;
     border-radius:999px;
-    font-size:0.9rem;
+    font-size:1rem;
     text-transform:uppercase;
     letter-spacing:0.05em;
     --pill-bg:rgba(255,255,255,0.08);
@@ -217,7 +217,7 @@
   .empty-indicator{
     padding:36px 24px;
     text-align:center;
-    font-size:0.9rem;
+    font-size:1.05rem;
     color:var(--muted);
   }
   .mobile-list{
@@ -252,7 +252,7 @@
     outline-offset:2px;
   }
   .card-summary .vehicle{
-    font-size:1.3rem;
+    font-size:1.45rem;
     font-weight:600;
     letter-spacing:0.05em;
     text-transform:uppercase;
@@ -264,7 +264,7 @@
     gap:8px;
   }
   .card-summary .summary-date{
-    font-size:0.8rem;
+    font-size:0.9rem;
     color:var(--muted);
   }
   .card-summary .chevron{
@@ -287,14 +287,14 @@
   }
   .card-details dt{
     margin:0 0 4px;
-    font-size:0.7rem;
+    font-size:0.8rem;
     text-transform:uppercase;
     letter-spacing:0.08em;
     color:var(--muted);
   }
   .card-details dd{
     margin:0;
-    font-size:0.9rem;
+    font-size:1.05rem;
     line-height:1.4;
     word-break:break-word;
   }


### PR DESCRIPTION
## Summary
- enlarge the base font clamp to provide larger typography on the downed vehicles page
- increase supporting table, pill, and mobile card font sizes for improved readability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e49da82d9c8333af2f6e4e789f4726