### PR TITLE
Rename ridership navigation label

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
       <rect x="28" y="24" width="8" height="28" stroke="none" fill="currentColor" />
       <rect x="44" y="16" width="8" height="36" stroke="none" fill="currentColor" />
     </svg>
-    <div>Red/Blue Daily Counts</div>
+    <div>Ridership</div>
   </a>
   <a class="card" href="/replay">
     <svg viewBox="0 0 64 64" stroke="currentColor" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round">

--- a/mobile-nav.js
+++ b/mobile-nav.js
@@ -65,7 +65,7 @@
     },
     {
       href: '/ridership',
-      label: 'Red/Blue Daily Counts',
+      label: 'Ridership',
       icon: `
         <svg viewBox="0 0 64 64" stroke="currentColor" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round">
           <line x1="8" y1="52" x2="56" y2="52" />


### PR DESCRIPTION
## Summary
- rename the ridership link label in the index page
- rename the ridership entry label in the mobile navigation menu

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4b3e673e88333b81eb22b4a9430d7