### PR TITLE
Add ridership template loader for Red and Blue lines

### DIFF
--- a/ridership.html
+++ b/ridership.html
@@ -33,6 +33,7 @@
   #tablesContainer.is-loading{opacity:0.4;filter:grayscale(0.6);pointer-events:none;transition:opacity 0.2s ease;}
   .route-block{background:var(--panel);padding:16px;border-radius:12px;border:1px solid var(--line);box-shadow:0 4px 12px rgba(0,0,0,0.2);}
   .route-header{display:flex;flex-wrap:wrap;gap:12px;align-items:center;justify-content:space-between;}
+  .alternate-input{min-width:220px;}
   .route-header label{display:flex;align-items:center;gap:8px;}
   .time-input{width:100%;min-width:160px;}
   .result-cell{width:120px;text-align:right;font-variant-numeric:tabular-nums;}
@@ -51,6 +52,7 @@
   <button id="loadBtn">Load</button>
   <span id="spinner" class="spinner" style="display:none"></span>
   <button id="exportBtn">Export CSV</button>
+  <button id="templateBtn" type="button">Load Red/Blue Template</button>
 </div>
 <div id="newestDisplay">Newest Data: <span id="newestTimestamp"></span></div>
 <div id="overallTotalRow">Overall Displayed Total: <span id="overallTotal">0</span></div>
@@ -65,6 +67,7 @@ const newestTimestamp=document.getElementById('newestTimestamp');
 const tablesContainer=document.getElementById('tablesContainer');
 const overallTotalDisplay=document.getElementById('overallTotal');
 const addTableBtn=document.getElementById('addTableBtn');
+const templateBtn=document.getElementById('templateBtn');
 const notesInput=document.getElementById('notes');
 const loadingMessage=document.getElementById('loadingMessage');
 
@@ -83,6 +86,7 @@ addTableBtn.addEventListener('click',()=>{
   const input=block.querySelector('.time-input');
   if(input){input.focus();}
 });
+templateBtn.addEventListener('click',loadTemplate);
 
 if(!tablesContainer.children.length){
   addRouteTable();
@@ -170,11 +174,20 @@ function addRouteTable(){
   select.className='route-select';
   label.appendChild(select);
 
+  const altLabel=document.createElement('label');
+  altLabel.textContent='Alternate Name:';
+  const altInput=document.createElement('input');
+  altInput.type='text';
+  altInput.placeholder='Optional description';
+  altInput.className='alternate-input';
+  altLabel.appendChild(altInput);
+
   const addRowBtn=document.createElement('button');
   addRowBtn.type='button';
   addRowBtn.textContent='Add Time Range';
 
   header.appendChild(label);
+  header.appendChild(altLabel);
   header.appendChild(addRowBtn);
   block.appendChild(header);
 
@@ -394,8 +407,12 @@ function exportCsv(){
   lines.push(`Date,${escapeCsv(dateValue)}`);
   tablesContainer.querySelectorAll('.route-block').forEach((block,index)=>{
     const route=block.querySelector('.route-select').value||'';
+    const alternate=block.querySelector('.alternate-input')?.value||'';
     if(index>0){lines.push('');}
     lines.push(`Route,${escapeCsv(route)}`);
+    if(alternate){
+      lines.push(`Alternate,${escapeCsv(alternate)}`);
+    }
     lines.push('Time Range,Passengers');
     block.querySelectorAll('tbody tr').forEach(row=>{
       const timeValue=row.querySelector('.time-input').value.trim();
@@ -419,6 +436,48 @@ function exportCsv(){
   a.click();
   document.body.removeChild(a);
   URL.revokeObjectURL(a.href);
+}
+
+function ensureRouteOption(select,route){
+  if(!route){return;}
+  const exists=[...select.options].some(opt=>opt.value===route);
+  if(!exists){
+    const opt=document.createElement('option');
+    opt.value=route;
+    opt.textContent=route;
+    select.appendChild(opt);
+  }
+}
+
+function loadTemplate(){
+  const template=[
+    {route:'Red Line AM',alternate:'Scott Stadium West Parking Lots (Red Line)',times:['0430 - 0600','0600 - 0730']},
+    {route:'Red Line PM',alternate:'Scott Stadium West Parking Lots (Red Line)',times:['1400 - 1500','1500 - 1600','1600 - 1700','1700 - 1800','1800 - 1900','1900 - 2030']},
+    {route:'Blue Line',alternate:'Emmet-Ivy Garage (Blue Line AM)',times:['0630 - 0730','0730 - 0800','0800 - 0900','0900 - 1000']},
+    {route:'Blue Line',alternate:'Emmet-Ivy Garage (Blue Line PM)',times:['1000 - 1430','1430 - 1500','1500 - 1600','1600 - 1700','1700 - 1800','1800 - 1900','1900 - 2030']}
+  ];
+  tablesContainer.innerHTML='';
+  template.forEach(item=>{
+    const block=addRouteTable();
+    const select=block.querySelector('.route-select');
+    ensureRouteOption(select,item.route);
+    select.value=item.route;
+    const altInput=block.querySelector('.alternate-input');
+    if(altInput){altInput.value=item.alternate;}
+    const rows=[...block.querySelectorAll('.time-row')];
+    if(rows[0]){
+      rows[0].querySelector('.time-input').value=item.times[0]||'';
+    }
+    for(let i=1;i<item.times.length;i++){
+      const row=addTimeRow(block);
+      row.querySelector('.time-input').value=item.times[i];
+    }
+    // Remove extra empty rows if template has fewer than default rows
+    if(item.times.length===0){
+      rows.forEach(row=>row.remove());
+    }
+    updateBlock(block);
+  });
 }
 
 function escapeCsv(text){


### PR DESCRIPTION
## Summary
- add a Load Red/Blue Template shortcut button to the ridership page
- support entering an alternate name for each route block and include it in CSV exports
- pre-fill the template with Red Line AM/PM and Blue Line AM/PM ranges as requested

## Testing
- Manual template load in browser

------
https://chatgpt.com/codex/tasks/task_e_68e585c48adc8333852f3650bed8fdd1