### PR TITLE
Use alternate route name in CSV export

### DIFF
--- a/ridership.html
+++ b/ridership.html
@@ -408,11 +408,9 @@ function exportCsv(){
   tablesContainer.querySelectorAll('.route-block').forEach((block,index)=>{
     const route=block.querySelector('.route-select').value||'';
     const alternate=block.querySelector('.alternate-input')?.value||'';
+    const routeLabel=alternate||route;
     if(index>0){lines.push('');}
-    lines.push(`Route,${escapeCsv(route)}`);
-    if(alternate){
-      lines.push(`Alternate,${escapeCsv(alternate)}`);
-    }
+    lines.push(`Route,${escapeCsv(routeLabel)}`);
     lines.push('Time Range,Passengers');
     block.querySelectorAll('tbody tr').forEach(row=>{
       const timeValue=row.querySelector('.time-input').value.trim();


### PR DESCRIPTION
## Summary
- use the alternate name as the route label when exporting ridership CSV data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e589a48adc8333a0c30e51f84287b2