### PR TITLE
Include overall total in ridership export

### DIFF
--- a/ridership.html
+++ b/ridership.html
@@ -420,6 +420,11 @@ function exportCsv(){
     const total=block.querySelector('.route-total').textContent.trim();
     lines.push(`Total,${escapeCsv(total)}`);
   });
+  const overallTotal=overallTotalDisplay.textContent.trim();
+  if(overallTotal){
+    lines.push('');
+    lines.push(`Overall Total,${escapeCsv(overallTotal)}`);
+  }
   const notes=notesInput.value.trim();
   if(notes){
     lines.push('');


### PR DESCRIPTION
## Summary
- append the overall displayed total to the ridership CSV export so it matches the on-screen total

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e58c1197fc83339aaf280845542174