### PR TITLE
Adjust ridership CSV overall total placement

### DIFF
--- a/ridership.html
+++ b/ridership.html
@@ -464,7 +464,12 @@ function sumForRange(route,start,end){
 function exportCsv(){
   const lines=[];
   const dateValue=dateInput.value||new Date().toISOString().split('T')[0];
+  const overallTotal=overallTotalDisplay.textContent.trim();
   lines.push(`Date,${escapeCsv(dateValue)}`);
+  if(overallTotal){
+    lines.push(`Overall Total,${escapeCsv(overallTotal)}`);
+    lines.push('');
+  }
   const blocks=[...tablesContainer.querySelectorAll('.route-block')];
   const routeMeta=new Map();
   blocks.forEach(block=>{
@@ -504,11 +509,6 @@ function exportCsv(){
       }
     }
   });
-  const overallTotal=overallTotalDisplay.textContent.trim();
-  if(overallTotal){
-    lines.push('');
-    lines.push(`Overall Total,${escapeCsv(overallTotal)}`);
-  }
   const notes=notesInput.value.trim();
   if(notes){
     lines.push('');


### PR DESCRIPTION
## Summary
- place the overall total directly beneath the selected date in the ridership CSV export
- insert a blank row after the overall total to separate it from per-route sections

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e592590bc88333acccb3152d5e56aa