### PR TITLE
Fix ridership CSV export encoding

### DIFF
--- a/ridership.html
+++ b/ridership.html
@@ -735,7 +735,7 @@ function exportCsv(){
     lines.push(`Notes,${escapeCsv(notes)}`);
   }
   const csv=lines.join('\n');
-  const blob=new Blob([csv],{type:'text/csv'});
+  const blob=new Blob(['\ufeff'+csv],{type:'text/csv'});
   const a=document.createElement('a');
   a.href=URL.createObjectURL(blob);
   a.download=`ridership_${dateValue}.csv`;


### PR DESCRIPTION
## Summary
- add a UTF-8 byte order mark to the ridership CSV export so en dash characters render correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5c90d7e7c833398dc1e48be99450a