### PR TITLE
Rewrite overlap renderer from scratch

### DIFF
--- a/html/overlap-demo.html
+++ b/html/overlap-demo.html
@@ -6,7 +6,6 @@
   <title>Overlap Route Renderer Demo</title>
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/rbush@2.0.2/rbush.js"></script>
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body { font-family: system-ui, sans-serif; background: #1a1a2e; color: #e0e0e0; height: 100vh; display: flex; flex-direction: column; }
@@ -41,390 +40,266 @@
   <div id="map"></div>
   <div id="legend"><h3>Routes</h3><div id="legend-items"></div></div>
 </div>
-<div id="info-bar">Zoom in for narrower lines &nbsp;|&nbsp; Click routes in legend to toggle visibility &nbsp;|&nbsp; <span id="route-count">0 routes</span></div>
+<div id="info-bar"><span id="route-count">0 routes</span></div>
 
 <script>
 // ─── Google Polyline Decoder ──────────────────────────────────────────────────
 function decodePolyline(encoded) {
-  const result = [];
-  let index = 0, lat = 0, lng = 0;
-  while (index < encoded.length) {
+  const out = [];
+  let i = 0, lat = 0, lng = 0;
+  while (i < encoded.length) {
     let b, shift = 0, val = 0;
-    do { b = encoded.charCodeAt(index++) - 63; val |= (b & 0x1f) << shift; shift += 5; } while (b >= 0x20);
+    do { b = encoded.charCodeAt(i++) - 63; val |= (b & 0x1f) << shift; shift += 5; } while (b >= 0x20);
     lat += (val & 1) ? ~(val >> 1) : (val >> 1);
     shift = 0; val = 0;
-    do { b = encoded.charCodeAt(index++) - 63; val |= (b & 0x1f) << shift; shift += 5; } while (b >= 0x20);
+    do { b = encoded.charCodeAt(i++) - 63; val |= (b & 0x1f) << shift; shift += 5; } while (b >= 0x20);
     lng += (val & 1) ? ~(val >> 1) : (val >> 1);
-    result.push(L.latLng(lat / 1e5, lng / 1e5));
+    out.push(L.latLng(lat / 1e5, lng / 1e5));
   }
-  return result;
+  return out;
 }
 
-// ─── Spatial Index (wraps rbush) ──────────────────────────────────────────────
-function createSpatialIndex(options = {}) {
-  if (typeof rbush === 'function') { try { return rbush(options.maxEntries); } catch(e) {} }
-  if (typeof RBush === 'function') { try { return new RBush(options.maxEntries); } catch(e) {} }
-  // Brute-force fallback — slower but always works
-  console.warn('RBush unavailable, using brute-force spatial index');
-  return {
-    _items: [],
-    load(items) { this._items = this._items.concat(items); },
-    search(bbox) {
-      return this._items.filter(i =>
-        i.minX <= bbox.maxX && i.maxX >= bbox.minX &&
-        i.minY <= bbox.maxY && i.maxY >= bbox.minY
-      );
-    },
-    clear() { this._items = []; }
-  };
+// ─── Geographic utilities ─────────────────────────────────────────────────────
+// Distance in meters between two L.LatLng points (Haversine).
+function haversineM(a, b) {
+  const R = 6371000;
+  const f1 = a.lat * Math.PI / 180, f2 = b.lat * Math.PI / 180;
+  const df = (b.lat - a.lat) * Math.PI / 180;
+  const dl = (b.lng - a.lng) * Math.PI / 180;
+  const x = Math.sin(df / 2) ** 2 + Math.cos(f1) * Math.cos(f2) * Math.sin(dl / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(x), Math.sqrt(1 - x));
+}
+
+// Bearing in radians from a to b.
+function bearingRad(a, b) {
+  const f1 = a.lat * Math.PI / 180, f2 = b.lat * Math.PI / 180;
+  const dl = (b.lng - a.lng) * Math.PI / 180;
+  return Math.atan2(Math.sin(dl) * Math.cos(f2), Math.cos(f1) * Math.sin(f2) - Math.sin(f1) * Math.cos(f2) * Math.cos(dl));
+}
+
+// Smallest angle between two bearings, folded into [0, π/2].
+// Treats opposite directions (180° apart) as equivalent (same road, different direction).
+function smallestAngleDiff(a, b) {
+  let d = Math.abs(a - b) % Math.PI;
+  return d > Math.PI / 2 ? Math.PI - d : d;
+}
+
+// Distance in meters from point p to segment (a → b).
+// Uses a flat-earth approximation centred on a — accurate to <0.1% for segments <1 km.
+function distPointToSegM(p, a, b) {
+  const cosLat = Math.cos(a.lat * Math.PI / 180);
+  const mPerDeg = 111319;
+  const px = (p.lng - a.lng) * cosLat * mPerDeg;
+  const py = (p.lat - a.lat) * mPerDeg;
+  const bx = (b.lng - a.lng) * cosLat * mPerDeg;
+  const by = (b.lat - a.lat) * mPerDeg;
+  const lenSq = bx * bx + by * by;
+  if (lenSq < 1e-6) return Math.sqrt(px * px + py * py);
+  const t = Math.max(0, Math.min(1, (px * bx + py * by) / lenSq));
+  const dx = px - t * bx, dy = py - t * by;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+// Total length of a polyline in meters.
+function polylineLengthM(pts) {
+  let len = 0;
+  for (let i = 1; i < pts.length; i++) len += haversineM(pts[i - 1], pts[i]);
+  return len;
+}
+
+// ─── OverlapRenderer ──────────────────────────────────────────────────────────
+//
+// Algorithm overview:
+//   1. setRoutes() — runs once per route change, in geographic space:
+//      a. For every pair of routes, compare segments pairwise.
+//         For each segment of route A, project its midpoint onto each segment of
+//         route B. If the distance is within toleranceM AND the bearings are
+//         within bearingTolDeg, both segments are marked as shared.
+//      b. Group consecutive segments of each route with the same sharing set.
+//         Only the lowest-ID route in a shared group "owns" it (renders it),
+//         so shared segments are drawn exactly once.
+//      c. Short shared groups (< minSharedM) are dropped to avoid tiny artifacts
+//         at divergence points.
+//
+//   2. render() — cheap, runs on zoom/pan/route visibility change:
+//      Draws each group as either a solid polyline (solo) or N overlapping dashed
+//      polylines with fixed phase offsets (shared). Dash length is fixed so
+//      stripes are visually uniform everywhere.
+//
+class OverlapRenderer {
+  constructor(map, opts = {}) {
+    this.map        = map;
+    this.toleranceM = opts.toleranceM  ?? 25;  // match if midpoint is within this many metres
+    this.bearingTol = opts.bearingTol  ?? 25;  // max heading difference in degrees
+    this.minSharedM = opts.minSharedM  ?? 30;  // drop shared groups shorter than this
+    this.dashPx     = opts.dashPx      ?? 14;  // stripe dash length in pixels
+    this.getColor   = opts.getColor    ?? (() => '#888888');
+    this.layers     = [];
+    this._groups    = []; // [{pts: L.LatLng[], routeIds: number[]}]
+  }
+
+  // Call when the set of routes changes. Rebuilds groups then redraws.
+  setRoutes(routeMap) {
+    // routeMap: Map<number, L.LatLng[]>
+    const routes = Array.from(routeMap.entries())
+      .map(([id, pts]) => ({ id: Number(id), pts }))
+      .filter(r => r.pts.length >= 2)
+      .sort((a, b) => a.id - b.id);
+
+    this._groups = this._buildGroups(routes);
+    this.render();
+  }
+
+  // Call on zoom/pan/visibility change. Does not recompute groups.
+  render() {
+    this.clearLayers();
+    const w = this._weight();
+
+    for (const g of this._groups) {
+      const coords = g.pts.map(ll => [ll.lat, ll.lng]);
+      const ids = g.routeIds;
+
+      if (ids.length === 1) {
+        this.layers.push(L.polyline(coords, {
+          color: this.getColor(ids[0]),
+          weight: w, opacity: 1, lineCap: 'round', lineJoin: 'round', interactive: false
+        }).addTo(this.map));
+      } else {
+        const gap = this.dashPx * (ids.length - 1);
+        ids.forEach((id, i) => {
+          this.layers.push(L.polyline(coords, {
+            color: this.getColor(id),
+            weight: w, opacity: 1,
+            dashArray: `${this.dashPx} ${gap}`,
+            dashOffset: `${this.dashPx * i}`,
+            lineCap: 'butt', lineJoin: 'round', interactive: false
+          }).addTo(this.map));
+        });
+      }
+    }
+  }
+
+  reset()       { this.clearLayers(); this._groups = []; }
+  handleZoomEnd() { this.render(); }
+  handleMoveEnd() { this.render(); }
+
+  clearLayers() {
+    this.layers.forEach(l => { if (this.map.hasLayer(l)) this.map.removeLayer(l); });
+    this.layers = [];
+  }
+
+  _weight() {
+    const z = this.map.getZoom();
+    return Math.max(3, Math.min(12, 6 + Math.round(z - 15)));
+  }
+
+  // ── Core matching ──────────────────────────────────────────────────────────
+
+  _buildGroups(routes) {
+    if (!routes.length) return [];
+
+    // segSharing[routeId][segIdx] = Set of routeIds that share this segment.
+    // Starts with just {self}.
+    const segSharing = new Map();
+    routes.forEach(r => {
+      segSharing.set(r.id, Array.from({ length: r.pts.length - 1 }, () => new Set([r.id])));
+    });
+
+    // Pairwise segment matching (geographic space, computed once).
+    for (let i = 0; i < routes.length - 1; i++) {
+      for (let j = i + 1; j < routes.length; j++) {
+        this._matchPair(routes[i], routes[j], segSharing);
+      }
+    }
+
+    // Build groups: runs of consecutive segments with identical sharing sets,
+    // rendered only by the lowest-ID route in the set (the "owner").
+    const groups = [];
+    routes.forEach(route => {
+      const segs = segSharing.get(route.id);
+      let runStart = 0;
+
+      for (let k = 1; k <= segs.length; k++) {
+        const atEnd   = k === segs.length;
+        const prevSet = segs[k - 1];
+        const currSet = atEnd ? null : segs[k];
+
+        if (atEnd || !this._setsEq(prevSet, currSet)) {
+          const routeIds = Array.from(prevSet).sort((a, b) => a - b);
+          const isOwner  = routeIds[0] === route.id;
+
+          if (isOwner) {
+            const pts      = route.pts.slice(runStart, k + 1); // +1 includes endpoint
+            const isShared = routeIds.length > 1;
+
+            if (!isShared || polylineLengthM(pts) >= this.minSharedM) {
+              groups.push({ pts, routeIds });
+            }
+          }
+
+          runStart = k; // next run starts at end of this one (shared endpoint = no gap)
+        }
+      }
+    });
+
+    return groups;
+  }
+
+  _matchPair(rA, rB, segSharing) {
+    const tolM       = this.toleranceM;
+    const bufDeg     = tolM / 85000; // rough degree buffer for bbox pre-filter
+    const bearTolRad = this.bearingTol * Math.PI / 180;
+    const aSegs      = segSharing.get(rA.id);
+    const bSegs      = segSharing.get(rB.id);
+
+    for (let ai = 0; ai < rA.pts.length - 1; ai++) {
+      const a1 = rA.pts[ai], a2 = rA.pts[ai + 1];
+      const mid = { lat: (a1.lat + a2.lat) / 2, lng: (a1.lng + a2.lng) / 2 };
+      const aBrg = bearingRad(a1, a2);
+
+      // Expanded bbox of this A-segment for quick rejection of B-segments.
+      const minLat = Math.min(a1.lat, a2.lat) - bufDeg;
+      const maxLat = Math.max(a1.lat, a2.lat) + bufDeg;
+      const minLng = Math.min(a1.lng, a2.lng) - bufDeg;
+      const maxLng = Math.max(a1.lng, a2.lng) + bufDeg;
+
+      for (let bi = 0; bi < rB.pts.length - 1; bi++) {
+        const b1 = rB.pts[bi], b2 = rB.pts[bi + 1];
+
+        // Bbox rejection: skip if both B-endpoints are clearly outside.
+        if (b1.lat > maxLat && b2.lat > maxLat) continue;
+        if (b1.lat < minLat && b2.lat < minLat) continue;
+        if (b1.lng > maxLng && b2.lng > maxLng) continue;
+        if (b1.lng < minLng && b2.lng < minLng) continue;
+
+        // Distance: how far is A's midpoint from segment B?
+        if (distPointToSegM(mid, b1, b2) > tolM) continue;
+
+        // Bearing: are they heading roughly the same way (or opposite)?
+        if (smallestAngleDiff(aBrg, bearingRad(b1, b2)) > bearTolRad) continue;
+
+        // Match — both segments are shared.
+        aSegs[ai].add(rB.id);
+        bSegs[bi].add(rA.id);
+      }
+    }
+  }
+
+  _setsEq(a, b) {
+    if (a.size !== b.size) return false;
+    for (const v of a) if (!b.has(v)) return false;
+    return true;
+  }
 }
 
 // ─── Route color registry ─────────────────────────────────────────────────────
 const routeColorMap = new Map();
-function getRouteColor(routeId) {
-  return routeColorMap.get(Number(routeId)) || '#888888';
-}
-
-// ─── Stroke weight by zoom ────────────────────────────────────────────────────
-const DEFAULT_ROUTE_STROKE_WEIGHT = 6;
-const MIN_ROUTE_STROKE_WEIGHT = 3;
-const MAX_ROUTE_STROKE_WEIGHT = 12;
-const ROUTE_WEIGHT_BASE_ZOOM = 15;
-const ROUTE_WEIGHT_STEP_PER_ZOOM = 1;
-const ROUTE_WEIGHT_ZOOM_DELTA_LIMIT = 3;
-
-function computeRouteStrokeWeight(zoom) {
-  if (!Number.isFinite(zoom)) return DEFAULT_ROUTE_STROKE_WEIGHT;
-  const delta = Math.max(-ROUTE_WEIGHT_ZOOM_DELTA_LIMIT, Math.min(ROUTE_WEIGHT_ZOOM_DELTA_LIMIT, zoom - ROUTE_WEIGHT_BASE_ZOOM));
-  return Math.max(MIN_ROUTE_STROKE_WEIGHT, Math.min(MAX_ROUTE_STROKE_WEIGHT, DEFAULT_ROUTE_STROKE_WEIGHT + ROUTE_WEIGHT_STEP_PER_ZOOM * delta));
-}
-
-// ─── Polyline options helper ──────────────────────────────────────────────────
-function mergeRouteLayerOptions(overrides = {}) {
-  return Object.assign({ updateWhenZooming: true, updateWhenIdle: true, interactive: false }, overrides);
-}
-
-// ─── OverlapRouteRenderer ─────────────────────────────────────────────────────
-// Extracted from scripts/testmap.js. Detects road segments shared by multiple
-// routes and renders them as interleaved dash patterns so all route colors show.
-class OverlapRouteRenderer {
-  constructor(map, options = {}) {
-    this.map = map;
-    this.options = Object.assign({
-      sampleStepPx: 8,
-      dashLengthPx: 16,
-      minDashLengthPx: 0.5,
-      matchTolerancePx: 12,
-      minGroupLengthPx: 40,
-      headingToleranceDeg: 20,
-      simplifyTolerancePx: 0.75,
-      latLngEqualityMargin: 1e-9,
-      strokeWeight: DEFAULT_ROUTE_STROKE_WEIGHT,
-      minStrokeWeight: MIN_ROUTE_STROKE_WEIGHT,
-      maxStrokeWeight: MAX_ROUTE_STROKE_WEIGHT
-    }, options);
-    this.layers = [];
-    this.routeGeometries = new Map();
-    this.selectedRoutes = [];
-    this.currentZoom = map.getZoom();
-    this.routeGeometrySignatures = new Map();
-    this.lastRenderState = null;
-  }
-
-  reset() {
-    this.clearLayers();
-    this.routeGeometries.clear();
-    this.selectedRoutes = [];
-    this.routeGeometrySignatures.clear();
-    this.lastRenderState = null;
-  }
-
-  clearLayers() {
-    this.layers.forEach(layer => { if (this.map.hasLayer(layer)) this.map.removeLayer(layer); });
-    this.layers = [];
-  }
-
-  updateRoutes(routeGeometryMap, selectedRouteIds) {
-    if (!Array.isArray(selectedRouteIds) || selectedRouteIds.length === 0) {
-      this.reset(); return this.getLayers();
-    }
-    const entries = routeGeometryMap instanceof Map ? Array.from(routeGeometryMap.entries()) : Object.entries(routeGeometryMap || {});
-    const desired = new Set(selectedRouteIds.map(Number).filter(Number.isFinite));
-    const next = new Map();
-    entries.forEach(([k, v]) => { const n = Number(k); if (!isNaN(n) && desired.has(n) && Array.isArray(v)) next.set(n, v); });
-    this.routeGeometries = next;
-    this.selectedRoutes = Array.from(next.keys()).sort((a, b) => a - b);
-    const sigs = new Map();
-    this.routeGeometries.forEach((pts, id) => sigs.set(id, this._signature(pts)));
-    this.routeGeometrySignatures = sigs;
-    this.currentZoom = this.map.getZoom();
-    this.render();
-    return this.getLayers();
-  }
-
-  handleZoomEnd() {
-    this.currentZoom = this.map.getZoom();
-    this.render();
-    return this.getLayers();
-  }
-
-  handleMoveEnd() {
-    this.render();
-    return this.getLayers();
-  }
-
-  getLayers() { return this.layers.slice(); }
-
-  _signature(latlngs) {
-    if (!latlngs || latlngs.length === 0) return 'empty';
-    const n = latlngs.length, step = Math.max(1, Math.floor(n / Math.min(n, 10)));
-    const parts = [n];
-    const lat = p => (p && typeof p.lat === 'number') ? p.lat : (Array.isArray(p) ? p[0] : NaN);
-    const lng = p => (p && typeof p.lng === 'number') ? p.lng : (Array.isArray(p) ? p[1] : NaN);
-    for (let i = 0; i < n; i += step) parts.push(`${lat(latlngs[i]).toFixed(6)},${lng(latlngs[i]).toFixed(6)}`);
-    return parts.join('|');
-  }
-
-  computeStrokeWeight(zoom = this.currentZoom) {
-    return Math.max(this.options.minStrokeWeight, Math.min(this.options.maxStrokeWeight, computeRouteStrokeWeight(zoom)));
-  }
-
-  render() {
-    if (!this.map || this.routeGeometries.size === 0) { this.clearLayers(); return; }
-    const zoom = this.currentZoom;
-    if (!Number.isFinite(zoom)) { this.clearLayers(); return; }
-
-    // Skip re-render if nothing changed
-    const center = this.map.getCenter();
-    const stateKey = this.selectedRoutes.join(',') + '|' + zoom.toFixed(4) + '|' +
-      center.lat.toFixed(5) + ',' + center.lng.toFixed(5) + '|' +
-      this.selectedRoutes.map(id => `${id}:${this.routeGeometrySignatures.get(id)}:${getRouteColor(id)}`).join('|');
-    if (this.lastRenderState === stateKey) return;
-    this.clearLayers();
-
-    const step = this.options.sampleStepPx;
-    const tolerance = this.options.matchTolerancePx;
-    const headingTolRad = this.options.headingToleranceDeg * Math.PI / 180;
-    const segsByRoute = new Map();
-    const spatialItems = [];
-
-    this.routeGeometries.forEach((latlngs, routeId) => {
-      if (!latlngs || latlngs.length < 2) return;
-      const segs = this._resampleRoute(routeId, latlngs, zoom, step);
-      if (!segs.length) return;
-      segsByRoute.set(routeId, segs);
-      segs.forEach(seg => spatialItems.push({
-        minX: seg.bounds.minX - tolerance, minY: seg.bounds.minY - tolerance,
-        maxX: seg.bounds.maxX + tolerance, maxY: seg.bounds.maxY + tolerance, segment: seg
-      }));
-    });
-
-    if (!spatialItems.length) { this.lastRenderState = stateKey; return; }
-
-    const tree = createSpatialIndex();
-    if (!tree) { this.lastRenderState = stateKey; return; }
-    tree.load(spatialItems);
-    this._populateSharedRoutes(spatialItems, tree, tolerance, headingTolRad);
-
-    const groups = this._buildGroups(segsByRoute, zoom);
-    this._drawGroups(groups);
-    this.lastRenderState = stateKey;
-  }
-
-  _populateSharedRoutes(items, tree, tolerance, headingTolRad) {
-    const seen = new Set();
-    items.forEach(item => {
-      const seg = item.segment;
-      tree.search(item).forEach(cand => {
-        const other = cand.segment;
-        if (!other || other === seg || other.routeId === seg.routeId) return;
-        const key = seg.routeId < other.routeId
-          ? `${seg.routeId}:${seg.index}|${other.routeId}:${other.index}`
-          : `${other.routeId}:${other.index}|${seg.routeId}:${seg.index}`;
-        if (seen.has(key)) return;
-        seen.add(key);
-        if (!this._segmentsOverlap(seg, other, tolerance, headingTolRad)) return;
-        seg.sharedRoutes.add(other.routeId);
-        other.sharedRoutes.add(seg.routeId);
-        this._applyOffset(seg, other);
-        this._applyOffset(other, seg);
-      });
-    });
-  }
-
-  _applyOffset(target, source) {
-    if (!target.routeOffsets) target.routeOffsets = {};
-    const v = source.start?.cumulativeLength;
-    if (!Number.isFinite(Number(v))) return;
-    const existing = target.routeOffsets[source.routeId];
-    target.routeOffsets[source.routeId] = { min: Number.isFinite(existing?.min) ? Math.min(existing.min, v) : v };
-  }
-
-  _buildGroups(segsByRoute, zoom) {
-    const groups = [];
-    segsByRoute.forEach((segs, routeId) => {
-      const ordered = segs.slice().sort((a, b) => (a.start?.cumulativeLength || 0) - (b.start?.cumulativeLength || 0));
-      let cur = null;
-      ordered.forEach(seg => {
-        const shared = Array.from(seg.sharedRoutes).sort((a, b) => a - b);
-        if (!shared.length || shared[0] !== routeId) return;
-        const newGroup = !cur || !this._sameSet(cur.routes, shared) || !this._close(cur.lastLatLng, seg.start.latlng);
-        if (newGroup) {
-          if (cur) { const f = this._finalizeGroup(cur); if (f) groups.push(f); }
-          cur = { routes: shared, segments: [], points: [], offsets: new Map(), lastLatLng: null };
-        }
-        cur.segments.push(seg);
-        if (!cur.points.length) cur.points.push(seg.start.latlng);
-        else if (!this._close(cur.points[cur.points.length - 1], seg.start.latlng)) cur.points.push(seg.start.latlng);
-        cur.points.push(seg.end.latlng);
-        cur.lastLatLng = seg.end.latlng;
-        const ro = seg.routeOffsets || {};
-        cur.routes.forEach(rk => {
-          const v = Number(ro[rk]?.min ?? ro[rk]);
-          if (Number.isFinite(v)) { const ex = cur.offsets.get(rk); if (!Number.isFinite(ex) || v < ex) cur.offsets.set(rk, v); }
-        });
-      });
-      if (cur) { const f = this._finalizeGroup(cur); if (f) groups.push(f); }
-    });
-    return groups;
-  }
-
-  _finalizeGroup(g) {
-    const pts = this._collapse(g.points || []);
-    if (pts.length < 2) return null;
-    const lenPx = g.segments.reduce((s, seg) => s + (Number.isFinite(seg.lengthPx) ? seg.lengthPx : 0), 0);
-    const minLen = this.options.minGroupLengthPx || 0;
-    if (lenPx < minLen) return null;
-    return { routes: g.routes.slice(), points: pts, lengthPx: lenPx };
-  }
-
-  _collapse(pts) {
-    const out = [];
-    pts.forEach(p => { if (!out.length || !this._close(out[out.length - 1], p)) out.push(p); });
-    return out;
-  }
-
-  _sameSet(a, b) {
-    if (!a || !b || a.length !== b.length) return false;
-    for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
-    return true;
-  }
-
-  _close(a, b) {
-    if (!a || !b) return false;
-    const t = this.options.latLngEqualityMargin;
-    const latA = a.lat ?? a?.latlng?.lat ?? 0, lngA = a.lng ?? a?.latlng?.lng ?? 0;
-    const latB = b.lat ?? b?.latlng?.lat ?? 0, lngB = b.lng ?? b?.latlng?.lng ?? 0;
-    return Math.abs(latA - latB) <= t && Math.abs(lngA - lngB) <= t;
-  }
-
-  _drawGroups(groups) {
-    const newLayers = [];
-    const dashBase = this.options.dashLengthPx, minDash = this.options.minDashLengthPx;
-    const weight = this.computeStrokeWeight();
-
-    groups.forEach(group => {
-      if (!group?.routes?.length || !group.points?.length || group.points.length < 2) return;
-      const coords = group.points.map(ll => [ll.lat, ll.lng]);
-      const routes = group.routes.slice().sort((a, b) => a - b);
-
-      if (routes.length === 1) {
-        const layer = L.polyline(coords, mergeRouteLayerOptions({ color: getRouteColor(routes[0]), weight, opacity: 1, lineCap: 'round', lineJoin: 'round' })).addTo(this.map);
-        newLayers.push(layer);
-        return;
-      }
-
-      const dashLen = dashBase > 0 ? dashBase : minDash;
-      const gapLen = dashLen * (routes.length - 1);
-
-      // Simple per-route phase offset — anchored to path start, not absolute pixel
-      // coords, so stripes stay stable across pans.
-      routes.forEach((id, i) => {
-        const off = dashLen * i;
-        const layer = L.polyline(coords, mergeRouteLayerOptions({ color: getRouteColor(id), weight, opacity: 1, dashArray: `${dashLen} ${gapLen}`, dashOffset: `${off}`, lineCap: 'butt', lineJoin: 'round' })).addTo(this.map);
-        newLayers.push(layer);
-      });
-    });
-
-    this.layers = newLayers;
-  }
-
-  _simplify(latlngs, zoom) {
-    const projected = latlngs.map(ll => this.map.project(ll, zoom));
-    let simplified = projected;
-    if (projected.length > 2 && this.options.simplifyTolerancePx > 0 && L.LineUtil?.simplify) {
-      simplified = L.LineUtil.simplify(projected, this.options.simplifyTolerancePx);
-    }
-    return simplified.map(pt => ({ point: L.point(pt.x, pt.y), latlng: this.map.unproject(pt, zoom) }));
-  }
-
-  _resampleRoute(routeId, latlngs, zoom, step) {
-    const simp = this._simplify(latlngs, zoom);
-    if (simp.length < 2) return [];
-    const samples = [{ latlng: simp[0].latlng, point: simp[0].point, cumulativeLength: 0 }];
-    let traversed = 0, distSinceLast = 0;
-    for (let i = 1; i < simp.length; i++) {
-      const prev = simp[i - 1], curr = simp[i];
-      const segLen = this._dist(prev.point, curr.point);
-      if (segLen === 0) continue;
-      let consumed = 0;
-      while (distSinceLast + (segLen - consumed) >= step) {
-        const rem = step - distSinceLast; consumed += rem;
-        const t = consumed / segLen;
-        const pt = L.point(prev.point.x + (curr.point.x - prev.point.x) * t, prev.point.y + (curr.point.y - prev.point.y) * t);
-        traversed += rem;
-        samples.push({ latlng: this.map.unproject(pt, zoom), point: pt, cumulativeLength: traversed });
-        distSinceLast = 0;
-      }
-      traversed += segLen - consumed;
-      distSinceLast += segLen - consumed;
-    }
-    const last = simp[simp.length - 1];
-    if (!this._close(samples[samples.length - 1].latlng, last.latlng)) {
-      samples.push({ latlng: last.latlng, point: last.point, cumulativeLength: traversed });
-    } else {
-      samples[samples.length - 1].cumulativeLength = traversed;
-    }
-
-    const segs = [];
-    for (let i = 0; i < samples.length - 1; i++) {
-      const s = samples[i], e = samples[i + 1];
-      const lenPx = this._dist(s.point, e.point);
-      if (!(lenPx > 0)) continue;
-      segs.push({
-        routeId, index: segs.length, start: s, end: e, lengthPx: lenPx,
-        bounds: { minX: Math.min(s.point.x, e.point.x), minY: Math.min(s.point.y, e.point.y), maxX: Math.max(s.point.x, e.point.x), maxY: Math.max(s.point.y, e.point.y) },
-        midpoint: L.point((s.point.x + e.point.x) / 2, (s.point.y + e.point.y) / 2),
-        heading: Math.atan2(e.point.y - s.point.y, e.point.x - s.point.x),
-        routeOffsets: { [routeId]: { min: Math.min(s.cumulativeLength, e.cumulativeLength) } },
-        sharedRoutes: new Set([routeId])
-      });
-    }
-    return segs;
-  }
-
-  _dist(a, b) {
-    const dx = (b?.x ?? 0) - (a?.x ?? 0), dy = (b?.y ?? 0) - (a?.y ?? 0);
-    return Math.sqrt(dx * dx + dy * dy);
-  }
-
-  _segmentsOverlap(a, b, tolerance, headingTolRad) {
-    if (this._dist(a.midpoint, b.midpoint) > tolerance) return false;
-    const hd = this._headingDiff(a.heading, b.heading);
-    if (hd > headingTolRad && Math.abs(Math.PI - hd) > headingTolRad) return false;
-    return Math.min(this._dist(a.start.point, b.start.point), this._dist(a.end.point, b.end.point), this._dist(a.start.point, b.end.point), this._dist(a.end.point, b.start.point)) <= tolerance * 2;
-  }
-
-  _headingDiff(a, b) {
-    let d = Math.abs(a - b) % (Math.PI * 2);
-    return d > Math.PI ? Math.PI * 2 - d : d;
-  }
-}
+function getRouteColor(id) { return routeColorMap.get(Number(id)) || '#888888'; }
 
 // ─── App state ────────────────────────────────────────────────────────────────
 let map, renderer;
 let overlapEnabled = true;
-let allRoutes = new Map(); // routeId -> { latLngs, color, name }
+let allRoutes  = new Map(); // id -> {latLngs, color, name}
 let hiddenRoutes = new Set();
 let simpleLayers = [];
 
@@ -434,37 +309,45 @@ L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
   attribution: '&copy; OpenStreetMap contributors &copy; CARTO', maxZoom: 19
 }).addTo(map);
 
-renderer = new OverlapRouteRenderer(map);
+renderer = new OverlapRenderer(map, { getColor: getRouteColor });
 map.on('zoomend', () => renderer.handleZoomEnd());
 map.on('moveend', () => renderer.handleMoveEnd());
 
+// ─── Helpers ──────────────────────────────────────────────────────────────────
 function setStatus(msg) { document.getElementById('status').textContent = msg; }
 
-// ─── Render all routes (overlap or simple) ────────────────────────────────────
+function getVisibleGeomMap() {
+  const m = new Map();
+  allRoutes.forEach((r, id) => { if (!hiddenRoutes.has(id)) m.set(id, r.latLngs); });
+  return m;
+}
+
+// ─── Render ───────────────────────────────────────────────────────────────────
 function redraw() {
-  // Clear simple layers
   simpleLayers.forEach(l => { if (map.hasLayer(l)) map.removeLayer(l); });
   simpleLayers = [];
   renderer.reset();
 
-  const visibleIds = Array.from(allRoutes.keys()).filter(id => !hiddenRoutes.has(id));
-  if (!visibleIds.length) return;
+  const geomMap = getVisibleGeomMap();
+  if (!geomMap.size) {
+    document.getElementById('route-count').textContent = '0 routes visible';
+    return;
+  }
 
   if (overlapEnabled) {
-    const geomMap = new Map();
-    visibleIds.forEach(id => geomMap.set(id, allRoutes.get(id).latLngs));
-    renderer.updateRoutes(geomMap, visibleIds);
+    renderer.setRoutes(geomMap);
   } else {
-    visibleIds.forEach(id => {
-      const route = allRoutes.get(id);
-      const layer = L.polyline(route.latLngs.map(ll => [ll.lat, ll.lng]), {
-        color: route.color, weight: computeRouteStrokeWeight(map.getZoom()), opacity: 0.9, lineCap: 'round', lineJoin: 'round'
-      }).addTo(map);
-      simpleLayers.push(layer);
+    const w = Math.max(3, Math.min(12, 6 + Math.round(map.getZoom() - 15)));
+    geomMap.forEach((pts, id) => {
+      simpleLayers.push(L.polyline(pts.map(ll => [ll.lat, ll.lng]), {
+        color: getRouteColor(id), weight: w, opacity: 0.9,
+        lineCap: 'round', lineJoin: 'round', interactive: false
+      }).addTo(map));
     });
   }
 
-  document.getElementById('route-count').textContent = `${visibleIds.length} of ${allRoutes.size} routes visible`;
+  document.getElementById('route-count').textContent =
+    `${geomMap.size} of ${allRoutes.size} routes visible`;
 }
 
 // ─── Legend ───────────────────────────────────────────────────────────────────
@@ -474,9 +357,10 @@ function buildLegend() {
   allRoutes.forEach((route, id) => {
     const item = document.createElement('div');
     item.className = 'legend-item' + (hiddenRoutes.has(id) ? ' hidden' : '');
-    item.innerHTML = `<div class="legend-swatch" style="background:${route.color}"></div><span class="legend-name">${route.name}</span>`;
+    item.innerHTML = `<div class="legend-swatch" style="background:${route.color}"></div>
+                      <span class="legend-name">${route.name}</span>`;
     item.onclick = () => {
-      if (hiddenRoutes.has(id)) hiddenRoutes.delete(id); else hiddenRoutes.add(id);
+      hiddenRoutes.has(id) ? hiddenRoutes.delete(id) : hiddenRoutes.add(id);
       item.classList.toggle('hidden');
       redraw();
     };
@@ -493,46 +377,44 @@ function toggleOverlap() {
   redraw();
 }
 
-// ─── Load live routes from utsopsdashboard.com ───────────────────────────────
+// ─── Load live routes ─────────────────────────────────────────────────────────
 async function loadLive() {
   setStatus('Fetching live routes…');
   document.getElementById('btn-live').disabled = true;
   try {
-    // Try same-origin first (when served from the app), then absolute URL
-    const urls = ['/v1/testmap/transloc/metadata', 'https://utsopsdashboard.com/v1/testmap/transloc/metadata'];
+    const urls = [
+      '/v1/testmap/transloc/metadata',
+      'https://utsopsdashboard.com/v1/testmap/transloc/metadata'
+    ];
     let data = null;
     for (const url of urls) {
-      try {
-        const res = await fetch(url, { cache: 'no-store' });
-        if (res.ok) { data = await res.json(); break; }
-      } catch (_) {}
+      try { const r = await fetch(url, { cache: 'no-store' }); if (r.ok) { data = await r.json(); break; } } catch (_) {}
     }
     if (!data) throw new Error('Could not reach metadata endpoint');
 
     const routes = Array.isArray(data.routes) ? data.routes : [];
     const loaded = routes.filter(r => r.EncodedPolyline && r.MapLineColor);
-    if (!loaded.length) throw new Error('No routes with polylines returned');
+    if (!loaded.length) throw new Error('No routes with polylines in response');
 
     allRoutes.clear(); routeColorMap.clear(); hiddenRoutes.clear();
     loaded.forEach(r => {
-      const id = Number(r.RouteID);
-      const raw = String(r.MapLineColor || '888888');
-    const color = raw.startsWith('#') ? raw : `#${raw}`;
+      const id     = Number(r.RouteID);
+      const raw    = String(r.MapLineColor || '888888');
+      const color  = raw.startsWith('#') ? raw : `#${raw}`;
       const latLngs = decodePolyline(r.EncodedPolyline);
       if (latLngs.length < 2) return;
-      const name = r.Description || r.Name || r.RouteName || `Route ${id}`;
+      const name = (r.Description || r.Name || r.RouteName || `Route ${id}`).trim();
       allRoutes.set(id, { latLngs, color, name });
       routeColorMap.set(id, color);
     });
 
     buildLegend();
+    setStatus('Computing overlaps…');
     redraw();
 
-    // Fit to bounds
     const allPts = [];
     allRoutes.forEach(r => allPts.push(...r.latLngs));
     if (allPts.length) map.fitBounds(L.latLngBounds(allPts), { padding: [20, 20] });
-
     setStatus(`Loaded ${allRoutes.size} live routes`);
   } catch (err) {
     setStatus(`Error: ${err.message}`);
@@ -542,40 +424,27 @@ async function loadLive() {
   }
 }
 
-// ─── Hardcoded demo routes (UVA-area, designed to show overlap) ───────────────
+// ─── Hardcoded demo routes ────────────────────────────────────────────────────
+// Three routes share a central corridor; one is independent.
 function loadDemo() {
   allRoutes.clear(); routeColorMap.clear(); hiddenRoutes.clear();
 
-  // Three routes sharing a central corridor (roughly University Ave area)
-  // Route 1: Blue – travels east along the corridor, then turns north
-  const r1 = [
-    [38.0395, -78.5210], [38.0390, -78.5150], [38.0385, -78.5085],
-    [38.0380, -78.5020], [38.0375, -78.4960], [38.0370, -78.4900],
-    [38.0400, -78.4870], [38.0430, -78.4850], [38.0460, -78.4840]
-  ];
-  // Route 2: Red – same corridor eastbound, diverges at the end going south
-  const r2 = [
-    [38.0330, -78.5230], [38.0350, -78.5160], [38.0360, -78.5085],
-    [38.0375, -78.5020], [38.0375, -78.4960], [38.0370, -78.4900],
-    [38.0350, -78.4870], [38.0320, -78.4860], [38.0290, -78.4855]
-  ];
-  // Route 3: Orange – joins the shared corridor for its full length, no deviation
-  const r3 = [
-    [38.0510, -78.5180], [38.0460, -78.5140], [38.0420, -78.5085],
-    [38.0380, -78.5020], [38.0375, -78.4960], [38.0370, -78.4900],
-    [38.0360, -78.4840], [38.0345, -78.4770], [38.0330, -78.4700]
-  ];
-  // Route 4: Green – independent route, no overlap
-  const r4 = [
-    [38.0280, -78.5300], [38.0260, -78.5200], [38.0250, -78.5100],
-    [38.0240, -78.5000], [38.0230, -78.4900]
-  ];
-
   const demos = [
-    { id: 1, color: '#3b82f6', name: 'Blue – North Loop', pts: r1 },
-    { id: 2, color: '#ef4444', name: 'Red – South Loop',  pts: r2 },
-    { id: 3, color: '#f97316', name: 'Orange – Express',  pts: r3 },
-    { id: 4, color: '#22c55e', name: 'Green – Connector', pts: r4 }
+    { id: 1, color: '#3b82f6', name: 'Blue – North Loop', pts: [
+      [38.0395,-78.5210],[38.0390,-78.5150],[38.0385,-78.5085],
+      [38.0380,-78.5020],[38.0375,-78.4960],[38.0370,-78.4900],
+      [38.0400,-78.4870],[38.0430,-78.4850],[38.0460,-78.4840] ] },
+    { id: 2, color: '#ef4444', name: 'Red – South Loop', pts: [
+      [38.0330,-78.5230],[38.0350,-78.5160],[38.0360,-78.5085],
+      [38.0375,-78.5020],[38.0375,-78.4960],[38.0370,-78.4900],
+      [38.0350,-78.4870],[38.0320,-78.4860],[38.0290,-78.4855] ] },
+    { id: 3, color: '#f97316', name: 'Orange – Express', pts: [
+      [38.0510,-78.5180],[38.0460,-78.5140],[38.0420,-78.5085],
+      [38.0380,-78.5020],[38.0375,-78.4960],[38.0370,-78.4900],
+      [38.0360,-78.4840],[38.0345,-78.4770],[38.0330,-78.4700] ] },
+    { id: 4, color: '#22c55e', name: 'Green – Connector', pts: [
+      [38.0280,-78.5300],[38.0260,-78.5200],[38.0250,-78.5100],
+      [38.0240,-78.5000],[38.0230,-78.4900] ] }
   ];
 
   demos.forEach(({ id, color, name, pts }) => {
@@ -587,7 +456,7 @@ function loadDemo() {
   buildLegend();
   redraw();
   map.fitBounds(L.latLngBounds(demos.flatMap(d => d.pts)), { padding: [30, 30] });
-  setStatus('Demo routes loaded (3 routes share a central corridor)');
+  setStatus('Demo loaded — 3 routes share a central corridor');
 }
 
 // ─── Boot ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Complete rewrite replacing the Codex pixel-space approach. Geographic matching in metres (not pixels), computed once per route change rather than every zoom/pan. Fixed stripe width everywhere. No rbush dependency. See inline comments for algorithm details.